### PR TITLE
undo temp flushall

### DIFF
--- a/tecken/apps.py
+++ b/tecken/apps.py
@@ -27,13 +27,9 @@ class TeckenAppConfig(AppConfig):
         # "Error 9 while writing to socket. Bad file descriptor."
         # This is only occuring in running unit tests.
         connection = get_redis_connection('default')
-        # XXX TEMPORARY FIX
-        connection.flushall()
-        # connection.info()
+        connection.info()
 
         connection = get_redis_connection('store')
-        # XXX TEMPORARY FIX
-        connection.flushall()
         maxmemory_policy = connection.info()['maxmemory_policy']
         if maxmemory_policy != 'allkeys-lru':  # pragma: no cover
             if settings.DEBUG:


### PR DESCRIPTION
To be merged, by miles, after this has worked once:

```
curl -d '{"stacks":[[[0,11723767],[1, 65802]]],"memoryMap":[["xul.pdb","44E4EC8C2F41492B9369D6B9A059577C2"],["wntdll.pdb","D74F79EB1F8D4A45ABCD2F476CCABACC2"]],"version":4}' https://symbols.dev.mozaws.net
```