### PR TITLE
Doc typos

### DIFF
--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -251,7 +251,7 @@ Manual Integration Testing for symbolication
 To do integration testing pasting lots of ``curl`` commands gets
 tedious. Instead use `tecken-loader`_. It's a simple script that
 sends symbolication requests to your local server. Run this in a separate
-termal when you have started the development server:
+terminal when you have started the development server:
 
 .. code-block:: shell
 

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -259,7 +259,7 @@ terminal when you have started the development server:
    $ cd tecken-loader
    $ python3.5 main.py stacks http://localhost:8000/
 
-It will keep going to ages. If you kill it with ``Ctrl-C`` it will
+It will keep going for ages. If you kill it with ``Ctrl-C`` it will
 print out a summary of what it has done.
 
 This is useful for sending somewhat realistic symbolication requests

--- a/docs/download.rst
+++ b/docs/download.rst
@@ -68,9 +68,9 @@ processing. See https://bugzilla.mozilla.org/show_bug.cgi?id=1361809
 Ignore Patterns
 ===============
 
-Certain files are repeatedly queried for by we know with confidence that
-not only is it never in our symbol stores, it's also not worth logging
-that it couldn't be found.
+We know with confidence users repeatedly query certain files that are
+never in our symbol stores. We can ignore them to suppress logging
+that they couldn't be found.
 
 Right now, this is maintained as a configurable blacklist but is hard
 coded inside the ``_ignore_symbol`` code in ``tecken.download.views``.

--- a/docs/redis.rst
+++ b/docs/redis.rst
@@ -5,8 +5,8 @@ Redis Documentation
 Usage
 =====
 
-Redis is used for two distinct purposes any shouldn't mixed as the
-configuration is expected to be different.
+Redis is used for two distinct purposes and the different
+configurations shouldn't be mixed.
 
 One is used as an LRU cache for the Symbolication service. It's basically
 an alternative to a disk cache where eviction is automatically taken care

--- a/docs/upload.rst
+++ b/docs/upload.rst
@@ -119,7 +119,10 @@ To override this amend the ``DJANGO_DISALLOWED_SYMBOLS_SNIPPETS`` environment
 variable as a comma separated list. But be aware to include the existing
 defaults which can be seen in ``settings.py``.
 
-.. note:: More advanced validations is going to be introduced. See https://bugzilla.mozilla.org/show_bug.cgi?id=1367456
+The final check is that each file path in the zip file matches the
+pattern ``<module>/<hex>/<file>`` or ``<name>-symbols.txt``. All other
+file paths are rejected.
+
 
 Gzip
 ====

--- a/docs/upload.rst
+++ b/docs/upload.rst
@@ -71,7 +71,7 @@ message queue task. What that task does is that it then downloads the ``.zip``
 from the inbox, unpacks it into memory, then iterates over the files within
 and uploads each and every one to S3. It might seen counter productive to first
 upload, then download it again but the message queue tasks run as completely
-separate processes so they can't share memory. And S2 is preferred instead of
+separate processes so they can't share memory. And S3 is preferred instead of
 relying on disk.
 
 The path of the files uploaded is

--- a/docs/upload.rst
+++ b/docs/upload.rst
@@ -63,7 +63,7 @@ such as date, who and size.
 
 When the ``.zip`` is uploaded into the "inbox" folder, the key name
 is determined by today's date, a md5 hash of the ``.zip`` file's content as a
-string listing and the orignal file as it was called when uploaded.
+string listing and the original file as it was called when uploaded.
 So an example key name to the inbox is ``inbox/2017-05-06/51dc30ddc473/myfile.zip``.
 
 That ``Upload`` instance's ID is then sent to a

--- a/docs/upload.rst
+++ b/docs/upload.rst
@@ -74,10 +74,10 @@ upload, then download it again but the message queue tasks run as completely
 separate processes so they can't share memory. And S3 is preferred instead of
 relying on disk.
 
-The path of the files uploaded is
-exactly as the path in the ``.zip`` file. E.g. If you upload a zip file with
-a file within called ``symbol.pdb/B33F4A641F154EC4A87E31CCF30F95441/symbol.sym``
-it will be put into S3 as
+The path of the uploaded files exactly match their path in the
+``.zip`` file. E.g. If you upload a zip file with a file within called
+``symbol.pdb/B33F4A641F154EC4A87E31CCF30F95441/symbol.sym`` it will be
+put into S3 as
 ``{settings.UPLOAD_FILE_PREFIX}/symbol.pdb/B33F4A641F154EC4A87E31CCF30F95441/symbol.sym``.
 
 Once every file has been successfully uploaded, the message queue task

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -179,7 +179,8 @@ class Core(CSP, AWS, Configuration, Celery):
     SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
     SESSION_CACHE_ALIAS = 'default'
 
-    # XXX what IS this?
+    # System Checks
+    # https://docs.djangoproject.com/en/1.11/ref/checks/#security
     SILENCED_SYSTEM_CHECKS = [
         'security.W003',  # We're using django-session-csrf
         # We can't set SECURE_HSTS_INCLUDE_SUBDOMAINS since this runs under a


### PR DESCRIPTION
refs: https://github.com/mozilla-services/foxsec/issues/317 since I usually read the docs to understand the code.

Changes:

* typo fixes
* rewording some things to possibly be clearer
* document the new file validation changes 

These commits are independent and can be cherry-picked or dropped as desired.

r? @peterbe 