### PR TITLE
bug 1364937 - log all metrics keys used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ yarn-error.log*
 .docker-build
 .python_history
 hack.py
+all-metrics-keys.json

--- a/bin/list-all-metrics-keys.py
+++ b/bin/list-all-metrics-keys.py
@@ -3,6 +3,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""
+Script to print out the contents of the 'all-metrics-key.json' file.
+Useful to get an insight into what metrics keys are being used.
+"""
+
 import json
 import time
 
@@ -10,7 +15,7 @@ import time
 def run():
     with open('all-metrics-keys.json') as f:
         all_keys = json.load(f)
-    for key in all_keys:
+    for key in sorted(all_keys):
         if key.startswith('_documentation'):
             continue
         age = time.time() - all_keys[key]['timestamp']

--- a/bin/list-all-metrics-keys.py
+++ b/bin/list-all-metrics-keys.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import time
+
+
+def run():
+    with open('all-metrics-keys.json') as f:
+        all_keys = json.load(f)
+    for key in all_keys:
+        if key.startswith('_documentation'):
+            continue
+        age = time.time() - all_keys[key]['timestamp']
+        print(
+            key.ljust(55),
+            all_keys[key]['type'].ljust(10),
+            '{} times'.format(all_keys[key]['count']).ljust(10),
+            '' if age < 1000 else 'longtimeago'
+        )
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(run())

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -52,9 +52,11 @@ case $1 in
     coverage erase
     coverage run -m py.test --flake8 "${@:2}"
     coverage report -m
-    if [[ -z ${CI+check} ]]; then
+    if [[ -z ${CI+check} ]]; then  # when doing local `make test`
       # generate code coverage to disk
       coverage html --skip-covered
+      echo "All metrics keys used..."
+      python bin/list-all-metrics-keys.py
     fi
     # Temporarily disabled. The team is small and codecov's report inside
     # pull requests (as comments) is more noise than help.
@@ -66,6 +68,7 @@ case $1 in
     #   env
     #   bash <(curl -s https://codecov.io/bash) -s /tmp
     # fi
+
     ;;
   bash)
     # The likelyhood of needing pytest-watch when in shell is

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -55,8 +55,6 @@ case $1 in
     if [[ -z ${CI+check} ]]; then  # when doing local `make test`
       # generate code coverage to disk
       coverage html --skip-covered
-      echo "All metrics keys used..."
-      python bin/list-all-metrics-keys.py
     fi
     # Temporarily disabled. The team is small and codecov's report inside
     # pull requests (as comments) is more noise than help.

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -383,3 +383,25 @@ how:
 
 Alternatively, just do step 1, from the list above, and then run:
 ``docker-compose up motocker web worker frontend``.
+
+
+All metrics keys
+================
+
+To get insight into all metrics keys that are used, a special Markus backend
+is enabled called ``tecken.markus_extra.LogAllMetricsKeys``. It's enabled
+by default in local development. And to inspect its content you can either
+open ``all-metrics-keys.json`` directly (it's git ignored) or you can run:
+
+.. code-block:: shell
+
+    $ make shell
+    $ ./bin/list-all-metrics-keys.py
+
+Now you can see a list of all keys that are used. Take this and, for example,
+make sure you make a graph in Datadog of each and everyone. If there's a key
+in there that you know you don't need or care about in Datadog, then delete
+it from the code.
+
+The file ``all-metrics-keys.json`` can be deleted any time and it will be
+recreated again.

--- a/tecken/markus_extra.py
+++ b/tecken/markus_extra.py
@@ -1,0 +1,48 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import time
+from functools import partialmethod
+
+from markus import INCR, GAUGE, HISTOGRAM, TIMING
+from markus.backends import BackendBase
+
+
+class LogAllMetricsKeys(BackendBase):  # pragma: no cover
+    """A markus backend that uses the filesystem to jot down ALL keys
+    that ever get used.
+    This then becomes handy when you want to make sure that you're using
+    all metrics in places like Datadog.
+    If you're not, it's maybe time to delete the metrics key.
+
+    Don't enable this in production. Use it during local development
+    and/or local test running.
+    """
+
+    def notice_use(self, state, type, *args, **kwargs):
+        filename = 'all-metrics-keys.json'
+        try:
+            with open(filename) as f:
+                all_keys = json.load(f)
+        except FileNotFoundError:
+            all_keys = {
+                '_documentation': (
+                    'This file was created so you can see all metrics '
+                    "keys that get used. It won't delete keys that are no "
+                    "longer used. Feel free to delete this file and run again."
+                )
+            }
+        all_keys[state] = {
+            'type': type,
+            'timestamp': time.time(),
+            'count': all_keys.get(state, {}).get('count', 0) + 1,
+        }
+        with open(filename, 'w') as f:
+            json.dump(all_keys, f, sort_keys=True, indent=3)
+
+    incr = partialmethod(notice_use, type=INCR)
+    gauge = partialmethod(notice_use, type=GAUGE)
+    histogram = partialmethod(notice_use, type=HISTOGRAM)
+    timing = partialmethod(notice_use, type=TIMING)

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -503,6 +503,9 @@ class Localdev(Base):
                 'statsd_namespace': ''
             }
         },
+        {
+            'class': 'tecken.markus_extra.LogAllMetricsKeys',
+        },
         # {
         #     'class': 'markus.backends.logging.LoggingRollupMetrics',
         #     'options': {

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -583,6 +583,17 @@ class Test(Localdev):
         }
         return parent
 
+    MARKUS_BACKENDS = [
+        {
+            'class': 'markus.backends.datadog.DatadogMetrics',
+            'options': {
+                'statsd_host': 'statsd',
+                'statsd_port': 8125,
+                'statsd_namespace': ''
+            }
+        },
+    ]
+
 
 class Dev(Base):
     """Configuration to be used in dev server environment"""


### PR DESCRIPTION
This'll make it easier to get an insight into what ALL keys are being used. Using its output you can make sure they're all used in Datadog in some form. 