### PR TITLE
only volume mount explicitly

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -10,7 +10,7 @@ export DJANGO_CONFIGURATION=Test
 
 # run docker compose with the given environment variables
 
-if [[ ! -z "${CI}" ]]; then
+if [[ -n "${CI}" ]]; then
     # pass CI env vars into docker containers for codecov submission
     echo "Getting Codecov environment variables"
     export CI_ENV=`bash <(curl -s https://codecov.io/env)`

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -8,18 +8,14 @@ set -eo pipefail
 export DEVELOPMENT=1
 export DJANGO_CONFIGURATION=Test
 
-
 # run docker compose with the given environment variables
 
 if [[ ! -z "${CI}" ]]; then
-    echo "IN CI!!!!!"
     # pass CI env vars into docker containers for codecov submission
     echo "Getting Codecov environment variables"
     export CI_ENV=`bash <(curl -s https://codecov.io/env)`
 
     docker-compose run -e DEVELOPMENT -e DJANGO_CONFIGURATION $CI_ENV test-ci test $@
 else
-    echo "NOT IN CI"
     docker-compose run -e DEVELOPMENT -e DJANGO_CONFIGURATION test test $@
 fi
-#

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -8,10 +8,18 @@ set -eo pipefail
 export DEVELOPMENT=1
 export DJANGO_CONFIGURATION=Test
 
-# pass CI env vars into docker containers for codecov submission
-[ ! -z ${CI+check} ] && \
-    echo "Getting Codecov environment variables" && \
-    export CI_ENV=`bash <(curl -s https://codecov.io/env)`
 
 # run docker compose with the given environment variables
-docker-compose run -e DEVELOPMENT -e DJANGO_CONFIGURATION $CI_ENV test test $@
+
+if [[ ! -z "${CI}" ]]; then
+    echo "IN CI!!!!!"
+    # pass CI env vars into docker containers for codecov submission
+    echo "Getting Codecov environment variables"
+    export CI_ENV=`bash <(curl -s https://codecov.io/env)`
+
+    docker-compose run -e DEVELOPMENT -e DJANGO_CONFIGURATION $CI_ENV test-ci test $@
+else
+    echo "NOT IN CI"
+    docker-compose run -e DEVELOPMENT -e DJANGO_CONFIGURATION test test $@
+fi
+#

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,12 +38,6 @@ services:
       - redis-cache
     ports:
       - "8000:8000"
-    links:
-      - db
-      - redis-store
-      - redis-cache
-      - minio
-      - statsd
     volumes:
       - $PWD:/app
     command: web-dev
@@ -52,10 +46,6 @@ services:
   test:
     extends:
       service: base
-    links:
-      - db
-      - redis-store
-      - redis-cache
     volumes:
       - $PWD:/app
     command: test
@@ -63,10 +53,6 @@ services:
   test-ci:
     extends:
       service: base
-    links:
-      - db
-      - redis-store
-      - redis-cache
 
   # Container specifically for running system tests against a remote.
   # Python based but distinct from the 'web' container.
@@ -88,10 +74,6 @@ services:
       service: base
     ports:
       - "8000:8000"
-    links:
-      - db
-      - redis-store
-      - redis-cache
     command: web
 
   statsd:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,17 @@ services:
       - db
       - redis-store
       - redis-cache
+    volumes:
+      - $PWD:/app
     command: test
+
+  test-ci:
+    extends:
+      service: base
+    links:
+      - db
+      - redis-store
+      - redis-cache
 
   # Container specifically for running system tests against a remote.
   # Python based but distinct from the 'web' container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,12 @@ services:
       - redis-cache
     ports:
       - "8000:8000"
+    links:
+      - db
+      - redis-store
+      - redis-cache
+      - minio
+      - statsd
     volumes:
       - $PWD:/app
     command: web-dev
@@ -46,6 +52,10 @@ services:
   test:
     extends:
       service: base
+    links:
+      - db
+      - redis-store
+      - redis-cache
     volumes:
       - $PWD:/app
     command: test
@@ -53,6 +63,10 @@ services:
   test-ci:
     extends:
       service: base
+    links:
+      - db
+      - redis-store
+      - redis-cache
 
   # Container specifically for running system tests against a remote.
   # Python based but distinct from the 'web' container.
@@ -74,6 +88,10 @@ services:
       service: base
     ports:
       - "8000:8000"
+    links:
+      - db
+      - redis-store
+      - redis-cache
     command: web
 
   statsd:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
-norecursedirs = .git .* static frontend docs htmlcov .cache systemtest frontend
+norecursedirs = .git .* frontend docs htmlcov .cache systemtest
+testpaths = tests
 addopts = -rsxX --showlocals --tb=native --no-migrations
 
 DJANGO_SETTINGS_MODULE = tecken.settings
@@ -14,4 +15,4 @@ DJANGO_CONFIGURATION = Test
 
 
 [pytest-watch]
-ignore = frontend .git docs test-with-nginx
+ignore = frontend .git docs test-with-nginx .cache htmlcov


### PR DESCRIPTION
@milescrabill I think I figured it out. At least it all makes sense locally. 
If you run `docker-compose run test-ci test` it runs the `test-ci` directive from `docker-compose.yml`. So, that'll run with the files "as of the latest `make build`". 

To test this, I do:
```
$ export CI=true
$ make test
```
The tests pass. So I mess with, for example, `tests/test_api.py` and put in a `raise Exception("hi")` and run: `make test` again and the tests pass again. 

However, when I do this WITHOUT setting `export CI=true` the tests will re-read the host's file and the second time the tests fail because of the temporary `raise Exception("hi")` I put in. 
