### PR TITLE
circle config: add tag specifiers for all workflow jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,15 @@ jobs:
 
 workflows:
   version: 2
+
+  # workflow jobs are _not_ run in tag builds by default
+  # we use filters to whitelist jobs that should be run for tags
+
+  # workflow jobs are run in _all_ branch builds by default
+  # we use filters to blacklist jobs that shouldn't be run for a branch
+
+  # see: https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
+
   build-test-deploy:
     jobs:
       - checkout_code:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,10 +123,16 @@ workflows:
   version: 2
   build-test-deploy:
     jobs:
-      - checkout_code
+      - checkout_code:
+          filters:
+            tags:
+              only: /.*/
       - build_test_and_deploy:
           requires:
             - checkout_code
+          filters:
+            tags:
+              only: /.*/
       - run_lintcheck:
           requires:
             - checkout_code


### PR DESCRIPTION
per https://circleci.com/docs/2.0/configuration-reference/#tags and https://circleci.com/docs/2.0/workflows/#git-tag-job-execution we need to whitelist which jobs run in our workflow in the case of pushing a tag.

this is why we weren't seeing builds for tag jobs earlier.

i've tested this using the following repo that seeks to mirror tecken (and other mozilla projects') structure:
https://github.com/mozilla-services/ci-testground

see release here: https://github.com/mozilla-services/ci-testground/releases/tag/v0.1.1
corresponding workflow build here: https://circleci.com/workflow-run/53225b01-935b-4167-856a-f6cdd5676cad
corresponding tagged docker image: https://hub.docker.com/r/mozilla/testground/tags/