### PR TITLE
optional 'm' after FUNC or PUBLIC, fixes #924

### DIFF
--- a/tecken/symbolicate/views.py
+++ b/tecken/symbolicate/views.py
@@ -719,7 +719,7 @@ class SymbolicateJSON:
         # We are only interested in lines that match this regex.
         # The 'm' is special. It's an extra *optional* prefix which,
         # we currently omit.
-        # Origin: https://bugzilla.mozilla.org/show_bug.cgi?id=1470092
+        # Origin: https://bugs.chromium.org/p/google-breakpad/issues/detail?id=751
         # Note, as pointed out in
         # https://github.com/mozilla-services/tecken/issues/924#issuecomment-399130860
         # some day we might actually extract and use the presence of this 'm'


### PR DESCRIPTION
@luser The code kinda speaks for itself. I just made it so that the symbolication works with *and without* the 'm' after 'FUNC' and 'PUBLIC'. 
Left a code comment in there to note that some day we might actually use the 'm' in the symbolication. 