### PR TITLE
enable python in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,8 @@
   },
   "dockerfile": {
     "pinDigests": true
+  },
+  "python": {
+    "enabled": true
   }
 }


### PR DESCRIPTION
@rarkins As a piece of feedback on [the documentation](https://renovatebot.com/docs/python/) I think it's not clear why Python support is not enabled by default. This project as a `requirements.txt` and the config was basically just extending `config:base`. The documentation talks about how to *disable* but not how to enable it. 