### PR TITLE
Incorrect module returned after a frame with module ID -1

### DIFF
--- a/tecken/symbolicate/views.py
+++ b/tecken/symbolicate/views.py
@@ -36,6 +36,9 @@ downloader = SymbolDownloader(
     file_prefix=settings.SYMBOL_FILE_PREFIX,
 )
 
+# What to put for the module if a stack points to a negative module index.
+UNKNOWN_MODULE = "(unknown)"
+
 # This lists all the possible exceptions that the SymbolDownloader
 # might raise that we swallow in runtime.
 # Any failure to download a symbol from S3, that is considered operational,
@@ -297,7 +300,7 @@ class SymbolicateJSON:
                     response_stack.append(
                         {
                             "module_offset": module_offset,
-                            "module": symbol_filename,
+                            "module": UNKNOWN_MODULE,
                             "frame": j,
                         }
                     )


### PR DESCRIPTION
Fixes #1475

@CarlCorcoran r? (Not expecting you to manually end-to-end test this like I did. What I want your review for is the wording. In particular it's a rather odd thing to use a string `(unknown)`. Why can't that be a more structured thing like `null` instead? 


Here's how I test it locally (beyond unit tests)

First I created a .zip like this:

```bash
./bin/make-a-zip.py mozglue.pdb/E160ACAB977F93F52AF4015ADD8B844E1 kernelbase.pdb/D396875654E9416CBA16E51F8B0A8B1E2 ws2_32.pdb/5D9C92DA00D24235AD321A8810C80B022
```
And then I uploaded that on http://localhost:3000/uploads/upload

```
▶ curl -XPOST -d '{"jobs":[{"memoryMap":[["mozglue.pdb","E160ACAB977F93F52AF4015ADD8B844E1"],["kernelbase.pdb","D396875654E9416CBA16E51F8B0A8B1E2"],["ws2_32.pdb","5D9C92DA00D24235AD321A8810C80B022"]],"stacks":[[[0,21180],[1,131446], [-1, 0]]]}]}' http://localhost:8000/symbolicate/v5 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   817  100   590  100   227  29826  11475 --:--:-- --:--:-- --:--:-- 31052
{
  "results": [
    {
      "stacks": [
        [
          {
            "module_offset": "0x52bc",
            "module": "mozglue.pdb",
            "frame": 0,
            "function": "static long patched_LdrLoadDll(wchar_t *, unsigned long *, struct _UNICODE_STRING *, void * *)",
            "function_offset": "0x1ec"
          },
          {
            "module_offset": "0x20176",
            "module": "kernelbase.pdb",
            "frame": 1,
            "function": "NlsConvertStringToIntegerW",
            "function_offset": "0x2eb6"
          },
          {
            "module_offset": "0x0",
            "module": "(unknown)",
            "frame": 2
          }
        ]
      ],
      "found_modules": {
        "mozglue.pdb/E160ACAB977F93F52AF4015ADD8B844E1": true,
        "kernelbase.pdb/D396875654E9416CBA16E51F8B0A8B1E2": true,
        "ws2_32.pdb/5D9C92DA00D24235AD321A8810C80B022": null
      }
    }
  ]
}
```