### PR TITLE
bug 1552901: Use oidcprovider in local dev

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -17,7 +17,12 @@ AWS_SECRET_ACCESS_KEY=miniostorage
 #SENTRY_PUBLIC_DSN=....
 
 # Get these settings from Auth0 or some provider you use.
-DJANGO_OIDC_RP_CLIENT_ID=mustbesomething
-DJANGO_OIDC_RP_CLIENT_SECRET=mustbesomething
+#DJANGO_OIDC_RP_CLIENT_ID=mustbesomething
+#DJANGO_OIDC_RP_CLIENT_SECRET=mustbesomething
+#DJANGO_OIDC_OP_AUTHORIZATION_ENDPOINT=https://auth.mozilla.auth0.com/authorize
+#DJANGO_OIDC_OP_TOKEN_ENDPOINT=https://auth.mozilla.auth0.com/oauth/token
+#DJANGO_OIDC_OP_USER_ENDPOINT=https://auth.mozilla.auth0.com/userinfo
+#DJANGO_OIDC_VERIFY_SSL=True
+#DJANGO_ENABLE_AUTH0_BLOCKED_CHECK=True
 
 #GOOGLE_APPLICATION_CREDENTIALS=google_service_account.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - redis-store
       - redis-cache
       - minio
+      - oidcprovider
       - statsd
     volumes:
       - $PWD:/app
@@ -144,3 +145,11 @@ services:
     volumes:
       - $PWD/miniodata:/export
     command: server /export
+
+  # OpenID Connect provider
+  oidcprovider:
+    build:
+      context: docker/images/oidcprovider
+    image: local/tecken_oidcprovider
+    ports:
+      - "8081:8080"

--- a/docker/images/oidcprovider/Dockerfile
+++ b/docker/images/oidcprovider/Dockerfile
@@ -1,0 +1,8 @@
+# Derived from the "testprovider" container from
+# https://github.com/mozilla-parsys/docker-test-mozilla-django-oidc.
+# Only the redirect_urls specified in "fixtures.json" are being
+# modified to fit the needs of the docker setup.
+
+FROM mozillaparsys/oidc_testprovider
+
+COPY fixtures.json /code/fixtures.json

--- a/docker/images/oidcprovider/fixtures.json
+++ b/docker/images/oidcprovider/fixtures.json
@@ -1,0 +1,105 @@
+[
+    {
+        "model": "oidc_provider.responsetype",
+        "pk": 1,
+        "fields": {
+            "value": "code",
+            "description": "code (Authorization Code Flow)"
+        }
+    },
+    {
+        "model": "oidc_provider.responsetype",
+        "pk": 2,
+        "fields": {
+            "value": "id_token",
+            "description": "id_token (Implicit Flow)"
+        }
+    },
+    {
+        "model": "oidc_provider.responsetype",
+        "pk": 3,
+        "fields": {
+            "value": "id_token token",
+            "description": "id_token token (Implicit Flow)"
+        }
+    },
+    {
+        "model": "oidc_provider.responsetype",
+        "pk": 4,
+        "fields": {
+            "value": "code token",
+            "description": "code token (Hybrid Flow)"
+        }
+    },
+    {
+        "model": "oidc_provider.responsetype",
+        "pk": 5,
+        "fields": {
+            "value": "code id_token",
+            "description": "code id_token (Hybrid Flow)"
+        }
+    },
+    {
+        "model": "oidc_provider.responsetype",
+        "pk": 6,
+        "fields": {
+            "value": "code id_token token",
+            "description": "code id_token token (Hybrid Flow)"
+        }
+    },
+    {
+        "model": "oidc_provider.client",
+        "pk": 1,
+        "fields": {
+            "name": "testrpHS256",
+            "owner": null,
+            "client_type": "confidential",
+            "client_id": "1",
+            "client_secret": "bd01adf93cfb",
+            "jwt_alg": "HS256",
+            "date_created": "2017-11-10",
+            "website_url": "",
+            "terms_url": "",
+            "contact_email": "",
+            "logo": "",
+            "reuse_consent": true,
+            "require_consent": true,
+            "_redirect_uris": "http://localhost:8000/oidc/callback/",
+            "_post_logout_redirect_uris": "",
+            "response_types": [
+                1
+            ]
+        }
+    },
+    {
+        "model": "oidc_provider.client",
+        "pk": 2,
+        "fields": {
+            "name": "testrpRS256",
+            "owner": null,
+            "client_type": "confidential",
+            "client_id": "2",
+            "client_secret": "a6b4dad2f215",
+            "jwt_alg": "RS256",
+            "date_created": "2017-11-10",
+            "website_url": "",
+            "terms_url": "",
+            "contact_email": "",
+            "logo": "",
+            "reuse_consent": true,
+            "require_consent": true,
+            "_redirect_uris": "http://localhost:8000/oidc/callback/",
+            "_post_logout_redirect_uris": "",
+            "response_types": [
+                1
+            ]
+        }
+    },
+    {
+        "model": "oidc_provider.rsakey",
+        "pk": 3,
+        "fields": {
+            "key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQDAAgiIdiJG7GSMKTRbnGjWpHp1ulJ43/iQjDywWh5MP3in2PK8\nPVI6ItxIFLV81nWZMymA7hjfP7adOlxKY6rI+fExn8cTimI3W/oX6mHrPXm52uj/\nwe839pxxkeD7cmWgaif9Sujuy5AHUuUM1BTlO55POHkmhWyYMKC2P29qgQIDAQAB\nAoGAUHdJri6b1M8yoA6Qk6frw7AwZfAMqf1qxOEQefN6aQfcf7MKntqwAA8l88tB\n96xEokxvo0mlAMJJvIB9tusn4dIHKpmQGacQWVd/KONxPkvyuGgQXX5KCusZTbg7\ni6YQM52RGbExVFWLdGYJRBvzyfRkWX0b4LiderPZUiD6J/UCQQDZIgnLqYyGw3Ro\nnNboWYyOtLhKMF59f/0aSMXLlWdsnFG8kVm/7tw6jcDBalELci/+ExL2JACGwDea\n8DpvWiEDAkEA4mCovWmMDiS8tQCeY5NDic1wMp51+Ya8RX47bvb5F+X7SSE9L87y\n6eU9zVBSY8F+9npkvrxoU9PlKbS3Lzz1KwJAZ5/8BsuS+lnbe3Wmhtr93rlW3mk5\nHzHu7BVg+GkEI+xygcjoiVYImpU+MdB4fzrutpYJzZie+7BOmU4exTfBWwJBAKj+\nN3mO/Xrhee41VAhJuzV4I7XmDXQFXS8TmRKxVCq/COQC6EZ0W2q4M3a964OEw18E\n54hr5gYOPRjxS378JpkCQDjKw2Vyw0S0M8O2hOGuNsUtlGApYKt2iA41jGUf7bvO\nWz/tQuEIXQMd4e9zxNxOzPJOtjR1gyPZyi/FvsgDJDU=\n-----END RSA PRIVATE KEY-----"
+        }
+    }
+]

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -2,7 +2,12 @@
 Authentication
 ==============
 
-We use Auth0 to handle all authentication. See :ref:`Auth0 configuration <auth0-configuration>`.
+In the production, stage, and development deployments, Tecken uses Mozilla SSO,
+a self-hosted Auth0 instance that integrates with Mozilla's LDAP system.
+
+For local development, Tecken uses a test OpenID Connect (OIDC) provider.
+This can be overridden to use an Auth0 or other OIDC account.
+See :ref:`Authentication configuration <auth-configuration>`.
 
 Authentication **will let anybody** become a signed in user. But note, the
 user will **not have any useful permissions** to do anything more than

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -338,46 +338,75 @@ The three environment variables to control the statsd are as follows
 3. ``DJANGO_STATSD_NAMESPACE`` (*''* (empty string))
 
 
-.. _auth0-configuration:
+.. _auth-configuration:
 
-Auth0
-=====
+Authentication
+==============
+In the production, stage, and development deployments, Tecken uses Mozilla SSO,
+a self-hosted Auth0 instance that integrates with Mozilla's LDAP system.
 
-For authentication to work, you need to have an Auth0 account and its
-credentials. You also need a domain so you can figure out certain
-URLs. You need the client ID and the client secret. Put these into
-the environment variables like this:
+For local development, Tecken uses a test OpenID Connect (OIDC) provider.
+This can be overridden to use an Auth0 account or other OIDC provider.
+
+oidcprovider
+------------
+Local developement is configured to use ``oidcprovider``, a containerized
+OpenID Connect provider that allows self-created accounts. The default
+configuration is:
+
+.. code-block:: shell
+
+    DJANGO_OIDC_RP_CLIENT_ID=1
+    DJANGO_OIDC_RP_CLIENT_SECRET=bd01adf93cfb
+    DJANGO_OIDC_OP_AUTHORIZATION_ENDPOINT=http://oidc.127.0.0.1.nip.io:8081/openid/authorize
+    DJANGO_OIDC_OP_TOKEN_ENDPOINT=http://oidcprovider:8080/openid/token
+    DJANGO_OIDC_OP_USER_ENDPOINT=http://oidcprovider:8080/openid/userinfo
+    DJANGO_OIDC_VERIFY_SSL=False
+    DJANGO_ENABLE_AUTH0_BLOCKED_CHECK=False
+
+To use the provider:
+
+1. Load http://localhost:3000
+2. Click "Sign In" to start an OpenID Connect session on ``oidcprovider``
+3. Click "Sign up" to create an ``oidcprovider`` account:
+    * Username: A non-email username, like ``username``
+    * Email: Your email address
+    * Password: Any password, like ``password``
+4. Click "Authorize" to authorize Tecken to use your ``oidcprovider`` account
+5. You are returned to http://localhost:3000. If needed, a parallel Tecken User
+   will be created, with default permissions and identified by email address.
+
+You'll remain logged in to ``oidcprovider``, and the account will persist until
+the ``oidcprovider`` container is stopped.
+You can visit http://oidc.127.0.0.1.nip.io:8081/account/logout to manually log
+out.
+
+Auth0 and other OIDC providers
+------------------------------
+Mozilla SSO, a self-hosted instance of Auth0_, is used in the production, stage,
+and development deployments, and Tecken has additional functionality that uses
+SSO / Auth0 features. See :doc:`authentication` for details.
+
+To use Auth0 in local development, customize your environment:
 
 .. code-block:: shell
 
     DJANGO_OIDC_RP_CLIENT_ID=clientidhereclientidhere
     DJANGO_OIDC_RP_CLIENT_SECRET=clientsecrethereclientsecrethere
-
-The default domain is ``auth.mozilla.auth0.com``. That has consequently
-been used to set up the following defaults:
-
-.. code-block:: shell
-
     DJANGO_OIDC_OP_AUTHORIZATION_ENDPOINT=https://auth.mozilla.auth0.com/authorize
     DJANGO_OIDC_OP_TOKEN_ENDPOINT=https://auth.mozilla.auth0.com/oauth/token
     DJANGO_OIDC_OP_USER_ENDPOINT=https://auth.mozilla.auth0.com/userinfo
+    DJANGO_OIDC_VERIFY_SSL=True
+    DJANGO_ENABLE_AUTH0_BLOCKED_CHECK=True
 
-If your domain is different, override these above three environment
-variables with your domain.
-
-Note! Tecken uses `Auth0`_ which follows the OpenID Connect protocol.
-The configuration actually requires the above mentioned URLs and when
-you use Auth0, the URLs are quite constant. But if you use another OpenID
-Connect provider, use the domain (e.g. ``myoidc.example.com``) and go to
-``https://myoidc.example.com/.well-known/openid-configuration`` and from
-there it should publish the authorization, token and user endpoints.
+Any OpenID Connect (OIDC) provider can be used. Many OIDC providers publish
+their endpoints, for example
+https://auth.mozilla.auth0.com/.well-known/openid-configuration.
 
 .. _`Auth0`: https://auth0.com/
 
-
 First Superuser
-===============
-
+---------------
 Users need to create their own API tokens but before they can do that they
 need to be promoted to have that permission at all. The only person/people
 who can give other users permissions is the superuser. To bootstrap

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -16,7 +16,7 @@ Git clone and then run::
    $ make run
 
 Now a development server should be available at
-``http://localhost:8000``.
+``http://localhost:3000``.
 
 To test the symbolication run::
 

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -665,6 +665,26 @@ class Localdev(Base):
     API_UPLOADS_BATCH_SIZE = 10
     API_FILES_BATCH_SIZE = 20
 
+    #
+    # Default to the test oidcprovider container for Open ID Connect
+    #
+    # Client ID and secret must match oidcprovider database
+    OIDC_RP_CLIENT_ID = values.IntegerValue(1)
+    OIDC_RP_CLIENT_SECRET = values.Value("bd01adf93cfb")
+    # Load oidcprovider on public port 8081, without /etc/hosts changes
+    OIDC_OP_AUTHORIZATION_ENDPOINT = values.URLValue(
+        "http://oidc.127.0.0.1.nip.io:8081/openid/authorize"
+    )
+    # The backend connects to oidcprovider on docker port 8080
+    # Django's URL validator, used in URLValue, doesn't like docker hostnames
+    OIDC_OP_TOKEN_ENDPOINT = values.Value("http://oidcprovider:8080/openid/token")
+    # Same as token switch from URLValue to Value
+    OIDC_OP_USER_ENDPOINT = values.Value("http://oidcprovider:8080/openid/userinfo")
+    # Allow non-SSL connection to oidcprovider
+    OIDC_VERIFY_SSL = values.BooleanValue(False)
+    # Disable NotBlockedInAuth0Middleware
+    ENABLE_AUTH0_BLOCKED_CHECK = values.BooleanValue(False)
+
 
 class Test(Localdev):
     """Configuration to be used during testing"""


### PR DESCRIPTION
Use testprovider from [mozilla-parsys/docker-test-mozilla-django-oidc](https://github.com/mozilla-parsys/docker-test-mozilla-django-oidc) for authentication in the local development environment.

You may need to comment out ``DJANGO_OIDC_RP_CLIENT_ID`` and other parameters in your ``.env``, to get the new defaults.  Restart with ``make build run``, go to ``http://localhost:3000``, and authenticate. The setup is very similar to Socorro.

The docs are updated to reflect the new default, and that extra steps are required beyond the client ID and secret to get Auth0 working now.