### PR TITLE
bug 1552950: Add GCS Emulator

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -27,4 +27,11 @@ AWS_SECRET_ACCESS_KEY=miniostorage
 #DJANGO_OIDC_VERIFY_SSL=True
 #DJANGO_ENABLE_AUTH0_BLOCKED_CHECK=True
 
+# URLs for Google Cloud Storage
 #GOOGLE_APPLICATION_CREDENTIALS=google_service_account.json
+#DJANGO_SYMBOL_URLS=https://storage.googleapis.com/<my-gcs-bucket>
+#DJANGO_UPLOAD_DEFAULT_URL=https://storage.googleapis.com/<my-gcs-bucket>
+
+# URLs for emulated Google Cloud Storage
+#DJANGO_SYMBOL_URLS=https://gcs-emulator.127.0.0.1.nip.io:4443/tecken
+#DJANGO_UPLOAD_DEFAULT_URL=https://gcs-emulator.127.0.0.1.nip.io:4443/tecken

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ default:
 	@echo "  clean            Stops and removes all docker containers"
 	@echo "  redis-cache-cli  Opens a Redis CLI to the cache Redis server"
 	@echo "  redis-store-cli  Opens a Redis CLI to the store Redis server"
+	@echo "  clear-caches     Clear Redis caches"
 	@echo "  shell            Opens a Bash shell"
 	@echo "  currentshell     Opens a Bash shell into existing running 'web' container"
 	@echo "  test             Runs the Python test suite"
@@ -44,6 +45,11 @@ clean: .env stop
 	docker-compose rm -f
 	rm -rf coverage/ .coverage
 	rm -fr .docker-build
+
+.PHONY: clear-caches
+clear-caches:
+	docker-compose run --rm redis-cache redis-cli -h redis-cache FLUSHDB
+	docker-compose run --rm redis-store redis-cli -h redis-store FLUSHDB
 
 .PHONY: setup
 setup: .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - minio
       - oidcprovider
       - statsd
+      - "gcs-emulator:gcs-emulator.127.0.0.1.nip.io"
     volumes:
       - $PWD:/app
     command: web-dev
@@ -112,6 +113,7 @@ services:
     links:
       - db
       - redis-cache
+      - "gcs-emulator:gcs-emulator.127.0.0.1.nip.io"
     volumes:
       - $PWD:/app
     command: worker-purge
@@ -153,3 +155,15 @@ services:
     image: local/tecken_oidcprovider
     ports:
       - "8081:8080"
+
+  # Fake Google Cloud Storage
+  gcs-emulator:
+    # TODO: Switch to official image, when it is ready (bug 1563036)
+    image: jwhitlock/gc-fake-storage:test
+    environment:
+      - GCS_FAKE_EXTERNAL_URL=https://gcs-emulator.127.0.0.1.nip.io:4443
+      - GCS_FAKE_PUBLIC_HOST=storage.gcs-emulator.127.0.0.1.nip.io:4443
+    ports:
+      - "4443:4443"
+    volumes:
+      - /storage

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -163,6 +163,46 @@ public by default with:
 
     $ gsutil defacl set public-read gs://my-gcs-bucket
 
+Emulated Google Cloud Storage
+=============================
+
+The ``gcs-emulator`` container provides an emulated Google Cloud Storage service
+as well as a public host for downloads. It supports the operations needed by
+Tecken, such as creating and listing buckets, uploading and reading files, and
+serving files via the public host. Further GCS features may not be supported,
+but can be added to `fsouza/fake-gcs-server`_.
+
+To use the emulator, set the URLs in your ``.env`` file:
+
+.. code-block:: shell
+
+    DJANGO_SYMBOL_URLS=https://gcs-emulator.127.0.0.1.nip.io:4443/tecken
+    DJANGO_UPLOAD_DEFAULT_URL=https://gcs-emulator.127.0.0.1.nip.io:4443/tecken
+
+The bucket (``tecken`` in this example) will be created when the web server
+starts.
+
+Tecken changes the Google Cloud Storage client libraries to use the
+``gcs-emulator`` URLs rather than the official URLs. It is not possible to mix
+real and emulated GCS usage in the same Tecken instance, so ensure that all
+the URL settings (``DJANGO_SYMBOL_URLS``, ``DJANGO_UPLOAD_DEFAULT_URL``,
+``DJANGO_UPLOAD_TRY_SYMBOLS_URL``, and ``DJANGO_UPLOAD_URL_EXCEPTIONS``)
+are consistantly set to real or emulated GCS URLs.
+
+The public host at https://storage.gcs-emulator.127.0.0.1.nip.io:4443 uses a
+self-signed certificate.  You will need to add an SSL exception when downloading
+a symbol file for the first time.
+
+Files are persisted in a volume created by ``docker-compose``. To clear old
+uploads, delete the ``gcs-emulator`` container and volumes:
+
+.. code-block:: shell
+
+    $ docker-compose rm --force --stop -v gcs-emulator
+
+A fresh volume with no files will be created on the next startup of ``gcs-emulator``.
+
+.. _`fsouza/fake-gcs-server`: https://github.com/fsouza/fake-gcs-server
 
 Documentation
 =============

--- a/tecken/apps.py
+++ b/tecken/apps.py
@@ -116,16 +116,16 @@ class TeckenAppConfig(AppConfig):
             if not url:
                 continue
             netloc = urlparse(url).netloc
-            is_minio = "minio" in netloc
-            is_emulated_gcs = "gcs-emulator" in netloc
-            if is_minio:
+            is_emulated_s3 = StorageBucket.URL_FINGERPRINT["emulated-s3"] in netloc
+            is_emulated_gcs = StorageBucket.URL_FINGERPRINT["emulated-gcs"] in netloc
+            if is_emulated_s3:
                 bucket = StorageBucket(url)
                 try:
                     bucket.client.head_bucket(Bucket=bucket.name)
                 except ClientError as exception:
                     if exception.response["Error"]["Code"] == "404":
                         bucket.client.create_bucket(Bucket=bucket.name)
-                        logger.info(f"Created minio bucket {bucket.name!r}")
+                        logger.info(f"Created emulated S3 bucket {bucket.name!r}")
                     else:
                         # The most common problem is that the S3 doesn't match
                         # the AWS credentials configured.

--- a/tecken/download/views.py
+++ b/tecken/download/views.py
@@ -28,6 +28,7 @@ from tecken.download.models import MissingSymbol
 from tecken.download.utils import store_missing_symbol
 from tecken.download.tasks import download_microsoft_symbol, store_missing_symbol_task
 from tecken.download.forms import DownloadForm
+from tecken.storage import StorageBucket
 
 logger = logging.getLogger("tecken")
 metrics = markus.get_metrics("tecken")
@@ -150,6 +151,7 @@ def download_symbol(request, symbol, debugid, filename, try_symbols=False):
             # from the host.
             if (
                 settings.DEBUG
+                and StorageBucket.URL_FINGERPRINT["emulated-s3"] in url
                 and "http://minio:9000" in url
                 and request.get_host() == "localhost:8000"
             ):  # pragma: no cover

--- a/tecken/storage.py
+++ b/tecken/storage.py
@@ -5,9 +5,12 @@
 import re
 from urllib.parse import urlparse, urlunparse
 
+from google.auth.credentials import AnonymousCredentials
 from google.cloud import storage
 import boto3
 from botocore.config import Config
+import requests
+import urllib3
 
 from django.conf import settings
 
@@ -79,7 +82,12 @@ class StorageBucket:
 
     @property
     def is_google_cloud_storage(self):
-        return "googleapis" in self.netloc
+        return "googleapis" in self.netloc or self.is_emulated_gcs
+
+    @property
+    def is_emulated_gcs(self):
+        """Is the URL for the emulated Google Cloud Storage?"""
+        return "gcs-emulator" in self.netloc
 
     @property
     def base_url(self):
@@ -90,7 +98,8 @@ class StorageBucket:
         return (
             f"<{self.__class__.__name__} name={self.name!r} "
             f"endpoint_url={self.endpoint_url!r} region={self.region!r} "
-            f"is_google_cloud_storage={self.is_google_cloud_storage}>"
+            f"is_google_cloud_storage={self.is_google_cloud_storage} "
+            f"is_emulated_gcs={self.is_emulated_gcs}> "
         )
 
     @property
@@ -101,6 +110,7 @@ class StorageBucket:
                 endpoint_url=self.endpoint_url,
                 region_name=self.region,
                 is_google_cloud_storage=self.is_google_cloud_storage,
+                is_emulated_gcs=self.is_emulated_gcs,
             )
         return self._client
 
@@ -110,6 +120,7 @@ class StorageBucket:
             endpoint_url=self.endpoint_url,
             region_name=self.region,
             is_google_cloud_storage=self.is_google_cloud_storage,
+            is_emulated_gcs=self.is_emulated_gcs,
             **config_params,
         )
 
@@ -121,9 +132,18 @@ class StorageBucket:
 
 
 def get_storage_client(
-    endpoint_url=None, region_name=None, is_google_cloud_storage=False, **config_params
+    endpoint_url=None,
+    region_name=None,
+    is_google_cloud_storage=False,
+    is_emulated_gcs=False,
+    **config_params,
 ):
-    if is_google_cloud_storage:
+    if is_emulated_gcs:
+        endpoint_host = urlparse(endpoint_url).netloc
+        public_host = "storage." + endpoint_host
+        client = FakeGCSClient(server_url=endpoint_url, public_host=public_host)
+        return client
+    elif is_google_cloud_storage:
         client = storage.Client.from_service_account_json(
             settings.GOOGLE_APPLICATION_CREDENTIALS
         )
@@ -141,3 +161,101 @@ def get_storage_client(
             options["region_name"] = region_name
         session = boto3.session.Session()
         return session.client("s3", **options)
+
+
+class FakeGCSClient(storage.Client):
+    """Client to bundle configuration needed for API requests to faked GCS."""
+
+    def __init__(self, server_url, public_host, project="fake"):
+        """Initialize a FakeGCSClient."""
+
+        self.server_url = server_url
+        self.public_host = public_host
+        self.init_fake_urls(server_url, public_host)
+
+        # Create a session that is OK talking over insecure HTTPS
+        weak_http = requests.Session()
+        weak_http.verify = False
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+        # Initialize the base class
+        super().__init__(
+            project=project, credentials=AnonymousCredentials(), _http=weak_http
+        )
+
+    _FAKED_URLS = None
+
+    @classmethod
+    def init_fake_urls(cls, server_url, public_host):
+        """
+        Update URL variables in classes and modules.
+
+        This is ugly, but the Google Cloud Storage Python library doesn't
+        support setting these as instance variables.
+        """
+        if cls._FAKED_URLS:
+            # Check that we're not changing the value, which would affect other
+            # instances of FakeGKSClient
+            if cls._FAKED_URLS["server_url"] != server_url:
+                raise ValueError(
+                    'server_url already "%s", can\'t change to "%s"'
+                    % (cls._FAKED_URLS["server_url"], server_url)
+                )
+            if cls._FAKED_URLS["public_host"] != public_host:
+                raise ValueError(
+                    'public_host already "%s", can\'t change to "%s"'
+                    % (cls._FAKED_URLS["public_host"], public_host)
+                )
+            cls._FAKED_URLS["depth"] += 1
+        else:
+            cls._FAKED_URLS = {
+                "server_url": server_url,
+                "public_host": public_host,
+                "depth": 1,
+                "old_api_base_url": storage._http.Connection.API_BASE_URL,
+                "old_api_access_endpoint": storage.blob._API_ACCESS_ENDPOINT,
+                "old_download_tmpl": storage.blob._DOWNLOAD_URL_TEMPLATE,
+                "old_multipart_tmpl": storage.blob._MULTIPART_URL_TEMPLATE,
+                "old_resumable_tmpl": storage.blob._RESUMABLE_URL_TEMPLATE,
+            }
+
+            storage._http.Connection.API_BASE_URL = server_url
+            storage.blob._API_ACCESS_ENDPOINT = "https://" + public_host
+            storage.blob._DOWNLOAD_URL_TEMPLATE = (
+                "%s/download/storage/v1{path}?alt=media" % server_url
+            )
+            base_tmpl = "%s/upload/storage/v1{bucket_path}/o?uploadType=" % server_url
+            storage.blob._MULTIPART_URL_TEMPLATE = base_tmpl + "multipart"
+            storage.blob._RESUMABLE_URL_TEMPLATE = base_tmpl + "resumable"
+
+    @classmethod
+    def undo_fake_urls(cls):
+        """
+        Reset the faked URL variables in classes and modules.
+
+        Returns True if we've returned to original,
+        False if still on faked URLs due to nested clients.
+        """
+        if cls._FAKED_URLS is None:
+            return True
+        cls._FAKED_URLS["depth"] -= 1
+        if cls._FAKED_URLS["depth"] <= 0:
+            storage._http.Connection.API_BASE_URL = cls._FAKED_URLS["old_api_base_url"]
+            storage.blob._API_ACCESS_ENDPOINT = cls._FAKED_URLS[
+                "old_api_access_endpoint"
+            ]
+            storage.blob._DOWNLOAD_URL_TEMPLATE = cls._FAKED_URLS["old_download_tmpl"]
+            storage.blob._MULTIPART_URL_TEMPLATE = cls._FAKED_URLS["old_multipart_tmpl"]
+            storage.blob._RESUMABLE_URL_TEMPLATE = cls._FAKED_URLS["old_resumable_tmpl"]
+            cls._FAKED_URLS = None
+            return True
+        else:
+            return False
+
+    def __enter__(self):
+        """Allow FakeGCSClient to be used as a context manager."""
+        return self
+
+    def __exit__(self, *args):
+        """Undo setting fake URLs when exiting context."""
+        self.undo_fake_urls()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,9 +4,10 @@
 
 import mock
 import pytest
+from google.cloud.storage import _http, blob
 from google.cloud.storage.client import Client as google_Client
 
-from tecken.storage import StorageBucket, scrub_credentials
+from tecken.storage import StorageBucket, scrub_credentials, FakeGCSClient
 
 
 def test_use_StorageBucket():
@@ -101,6 +102,96 @@ def test_google_cloud_storage_client_with_prefix():
     bucket = StorageBucket("https://storage.googleapis.com/foo-bar-bucket/myprefix")
     assert bucket.name == "foo-bar-bucket"
     assert bucket.prefix == "myprefix"
+
+
+def test_emulated_gcs_client():
+    bucket = StorageBucket("https://gcs-emulator.127.0.0.1.nip.io:4443/emulated-bucket")
+    assert bucket.name == "emulated-bucket"
+    assert bucket.is_google_cloud_storage
+    assert bucket.is_emulated_gcs
+
+    # Google Cloud Storage constants before creating a client
+    orig = {
+        "api_base_url": "https://www.googleapis.com",
+        "api_access_endpoint": "https://storage.googleapis.com",
+        "download_url_template": (
+            "https://www.googleapis.com/download/storage/v1{path}?alt=media"
+        ),
+        "multipart_url_template": (
+            "https://www.googleapis.com"
+            "/upload/storage/v1{bucket_path}/o?uploadType=multipart"
+        ),
+        "resumable_url_template": (
+            "https://www.googleapis.com"
+            "/upload/storage/v1{bucket_path}/o?uploadType=resumable"
+        ),
+    }
+    assert _http.Connection.API_BASE_URL == orig["api_base_url"]
+    assert blob._API_ACCESS_ENDPOINT == orig["api_access_endpoint"]
+    assert blob._DOWNLOAD_URL_TEMPLATE == orig["download_url_template"]
+    assert blob._MULTIPART_URL_TEMPLATE == orig["multipart_url_template"]
+    assert blob._RESUMABLE_URL_TEMPLATE == orig["resumable_url_template"]
+
+    # Constants after creating a client
+    fake = {
+        "api_base_url": "https://gcs-emulator.127.0.0.1.nip.io:4443",
+        "api_access_endpoint": "https://storage.gcs-emulator.127.0.0.1.nip.io:4443",
+        "download_url_template": (
+            "https://gcs-emulator.127.0.0.1.nip.io:4443"
+            "/download/storage/v1{path}?alt=media"
+        ),
+        "multipart_url_template": (
+            "https://gcs-emulator.127.0.0.1.nip.io:4443"
+            "/upload/storage/v1{bucket_path}/o?uploadType=multipart"
+        ),
+        "resumable_url_template": (
+            "https://gcs-emulator.127.0.0.1.nip.io:4443"
+            "/upload/storage/v1{bucket_path}/o?uploadType=resumable"
+        ),
+    }
+
+    with bucket.get_storage_client() as client:
+        assert isinstance(client, FakeGCSClient)
+        assert _http.Connection.API_BASE_URL == fake["api_base_url"]
+        assert blob._API_ACCESS_ENDPOINT == fake["api_access_endpoint"]
+        assert blob._DOWNLOAD_URL_TEMPLATE == fake["download_url_template"]
+        assert blob._MULTIPART_URL_TEMPLATE == fake["multipart_url_template"]
+        assert blob._RESUMABLE_URL_TEMPLATE == fake["resumable_url_template"]
+
+    # Exiting client-as-context returns the constants to the original values
+    assert _http.Connection.API_BASE_URL == orig["api_base_url"]
+    assert blob._API_ACCESS_ENDPOINT == orig["api_access_endpoint"]
+    assert blob._DOWNLOAD_URL_TEMPLATE == orig["download_url_template"]
+    assert blob._MULTIPART_URL_TEMPLATE == orig["multipart_url_template"]
+    assert blob._RESUMABLE_URL_TEMPLATE == orig["resumable_url_template"]
+
+
+def test_fake_gcs_client_init_fake_urls():
+    """URL faking can be done outside of using the FakeGCSClient."""
+    server_url = "https://gcs-emulator.127.0.0.1.nip.io:4443"
+    public_host = "storage.gcs-emulator.127.0.0.1.nip.io:4443"
+    orig_api_base_url = "https://www.googleapis.com"
+    fake_api_base_url = "https://gcs-emulator.127.0.0.1.nip.io:4443"
+
+    # URLs can be manually faked
+    FakeGCSClient.init_fake_urls(server_url, public_host)
+    assert _http.Connection.API_BASE_URL == fake_api_base_url
+    # A second call with the same URLs is OK
+    FakeGCSClient.init_fake_urls(server_url, public_host)
+    assert _http.Connection.API_BASE_URL == fake_api_base_url
+    # URLs can not be changed, since they are shared with all clients
+    with pytest.raises(ValueError):
+        FakeGCSClient.init_fake_urls("https://example.com", public_host)
+    with pytest.raises(ValueError):
+        FakeGCSClient.init_fake_urls(server_url, "storage.example.com")
+
+    # Faked URLs are undone as many times as they were faked (twice now)
+    assert not FakeGCSClient.undo_fake_urls()  # False = still fake
+    assert _http.Connection.API_BASE_URL == fake_api_base_url
+    assert FakeGCSClient.undo_fake_urls()  # True = back to original
+    assert _http.Connection.API_BASE_URL == orig_api_base_url
+    assert FakeGCSClient.undo_fake_urls()  # OK to undo too many times
+    assert _http.Connection.API_BASE_URL == orig_api_base_url
 
 
 def test_scrub_credentials():

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -16,6 +16,7 @@ from django.contrib.auth.models import Permission, User
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import timezone
 
+from tecken.storage import StorageBucket
 from tecken.tokens.models import Token
 from tecken.upload.models import Upload, FileUpload, UploadsCreated
 from tecken.upload import utils
@@ -111,7 +112,7 @@ def test_upload_archive_happy_path(
     settings,
 ):
     # The default upload URL setting uses Google Cloud Storage.
-    assert "googleapis" in settings.UPLOAD_DEFAULT_URL
+    assert StorageBucket.URL_FINGERPRINT["gcs"] in settings.UPLOAD_DEFAULT_URL
 
     token = Token.objects.create(user=fakeuser)
     permission, = Permission.objects.filter(codename="upload_symbols")
@@ -336,7 +337,7 @@ def test_upload_archive_with_ignorable_files(
     settings,
 ):
     # The default upload URL setting uses Google Cloud Storage.
-    assert "googleapis" in settings.UPLOAD_DEFAULT_URL
+    assert StorageBucket.URL_FINGERPRINT["gcs"] in settings.UPLOAD_DEFAULT_URL
 
     token = Token.objects.create(user=fakeuser)
     permission, = Permission.objects.filter(codename="upload_symbols")


### PR DESCRIPTION
**This is work in progress**, to preview my approach so far. Feel free to ignore or give feedback here or on [bug 1552950](https://bugzilla.mozilla.org/show_bug.cgi?id=1552950). This PR will probably not be the one submitted for review.

Add ``gcs-emulator``, an emulator for Google Cloud Storage, analogous to ``minio`` for AWS S3.

## Working
* Create the bucket during startup
* Upload symbols from a .zip, create file records

## To Fix
* [x] Uploads are not committed, so not stored on disk
* [x] ~~Uploads have null Download URL and Bucket Region~~ - not a bug
* [x] Downloads don't work, since uploads not committed
* [x] Download by direct URL

## Not yet tested
* [x] Upload via URL

## Possible Refactors
* Make interfaces on ``StorageBucket`` to handle differences between S3 and GCS, and real and emulated services, rather than handling differences in the client code. For example, currently to check if the bucket defined in ``DJANGO_UPLOAD_DEFAULT_URL`` exists:

```
from botocore.exceptions import ClientError
from google.cloud.exceptions import NotFound
from tecken.storage import StorageBucket
from django.conf import settings

bucket = StorageBucket(settings.DJANGO_UPLOAD_DEFAULT_URL)
exists = False
if bucket.is_google_cloud_storage:
    try:
        bucket.client.get_bucket(bucket.name)
    except NotFound:
        pass
    else:
        exists = True
else:
    try:
        bucket.client.head_bucket(Bucket=bucket.name)
    except ClientError as exception:
        if exception.response["Error"]["Code"] != "404":
            raise
    else:
        exists = True
```

This could be written as:

```
from tecken.storage import StorageBucket
from django.conf import settings

exists = StorageBucket(settings.DJANGO_UPLOAD_DEFAULT_URL).exists()
```

## To test

Add to ``.env``:
```
DJANGO_SYMBOL_URLS=https://gcs-emulator:4443/tecken
DJANGO_UPLOAD_DEFAULT_URL=https://gcs-emulator:4443/tecken
```

## Next Steps
* [x] Test current behavior of ``minio`` in local dev
* [x] Test current behavior of GCS in local dev
* [x] Survey use of ``StorageBucket``, investigate the refactor to interfaces.
* [x] Debug non-committed uploads