### PR TITLE
bug 1564452: Add StorageBucket.exists(), .backend()

### DIFF
--- a/tecken/dockerflow_extra.py
+++ b/tecken/dockerflow_extra.py
@@ -2,9 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from google.api_core.exceptions import GoogleAPIError
-from botocore.exceptions import ClientError, EndpointConnectionError
-
 from django.core import checks
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -14,7 +11,7 @@ from dockerflow.health import (
     ERROR_MISCONFIGURED_REDIS,
     ERROR_REDIS_PING_FAILED,
 )
-from tecken.storage import StorageBucket
+from tecken.storage import StorageBucket, StorageError
 
 
 def check_redis_store_connected(app_configs, **kwargs):
@@ -63,24 +60,15 @@ def check_storage_urls(app_configs, **kwargs):
                     checks.Error(
                         f"Unable to connect to {url} (bucket={bucket.name!r}), "
                         f"because bucket not found",
-                        id="tecken.health.E003",
+                        id="tecken.health.E001",
                     )
                 )
-        except (GoogleAPIError, ClientError) as exception:
+        except StorageError as error:
             errors.append(
                 checks.Error(
                     f"Unable to connect to {url} (bucket={bucket.name!r}), "
-                    f"due to {type(exception).__name__}: {exception}",
+                    f"due to {error.backend_msg}",
                     id="tecken.health.E002",
-                )
-            )
-        except EndpointConnectionError:
-            errors.append(
-                checks.Error(
-                    f"Unable to connect to {url} (bucket={bucket.name!r}, "
-                    f"found in settings.{setting_key}) due to "
-                    f"EndpointConnectionError",
-                    id="tecken.health.E001",
                 )
             )
         else:

--- a/tecken/download/views.py
+++ b/tecken/download/views.py
@@ -151,7 +151,7 @@ def download_symbol(request, symbol, debugid, filename, try_symbols=False):
             # from the host.
             if (
                 settings.DEBUG
-                and StorageBucket.URL_FINGERPRINT["emulated-s3"] in url
+                and StorageBucket(url).backend == "emulated-s3"
                 and "http://minio:9000" in url
                 and request.get_host() == "localhost:8000"
             ):  # pragma: no cover

--- a/tecken/storage.py
+++ b/tecken/storage.py
@@ -144,7 +144,11 @@ class StorageBucket:
 
     @property
     def client(self):
-        """return a boto3 session client based on 'self'"""
+        """Return a backend-specific client, cached on first access.
+
+        TODO(jwhitlock): Build up StorageBucket API so users don't work directly with
+        the backend-specific clients (bug 1564452).
+        """
         if not getattr(self, "_client", None):
             self._client = get_storage_client(
                 endpoint_url=self.endpoint_url,
@@ -155,7 +159,11 @@ class StorageBucket:
         return self._client
 
     def get_storage_client(self, **config_params):
-        """return a boto3 session client with different config parameters"""
+        """Return a backend-specific client, overriding default config parameters.
+
+        TODO(jwhitlock): Build up StorageBucket API so users don't work directly with
+        the backend-specific clients (bug 1564452).
+        """
         return get_storage_client(
             endpoint_url=self.endpoint_url,
             region_name=self.region,
@@ -165,6 +173,11 @@ class StorageBucket:
         )
 
     def get_or_load_bucket(self):
+        """Return a Google Storage Bucket instance, cached on first access.
+
+        TODO(jwhitlock): Build up StorageBucket API so users don't work directly with
+        the backend-specific clients (bug 1564452).
+        """
         if not hasattr(self, "_bucket"):
             assert self.is_google_cloud_storage
             self._bucket = self.client.get_bucket(self.name)

--- a/tecken/upload/utils.py
+++ b/tecken/upload/utils.py
@@ -174,6 +174,8 @@ def upload_file_upload(
     # files, we don't want this rather simple operation to be allowed
     # to take too long. Because if it times out, it's safe to just
     # assume the file doesn't already exist.
+    # TODO(jwhitlock): Create StorageBucket API rather than directly use
+    # backend clients.
     existing_size, existing_metadata = key_existing(
         client_lookup or client, bucket_name, key_name
     )

--- a/tests/test_dockerflow_extra.py
+++ b/tests/test_dockerflow_extra.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from unittest.mock import call, patch, Mock
+from unittest.mock import patch
 import pytest
-from google.api_core.exceptions import NotFound, BadRequest as google_BadRequest
+from google.api_core.exceptions import BadRequest
 from botocore.exceptions import ClientError, EndpointConnectionError
 
 from tecken import dockerflow_extra
@@ -14,129 +14,51 @@ def test_check_redis_store_connected_happy_path():
     assert not dockerflow_extra.check_redis_store_connected(None)
 
 
-def test_check_storage_urls_happy_path(gcsmock, settings):
-    mock_bucket = gcsmock.MockBucket()
-    gcsmock.get_bucket = lambda name: mock_bucket
-
-    assert not dockerflow_extra.check_storage_urls(None)
-
-
-def test_check_storage_urls_happy_path_s3(botomock, settings):
-    settings.SYMBOL_URLS = [
-        "https://s3.example.com/public/prefix/?access=public",
-        "https://s3.example.com/private/prefix/",
-    ]
-    settings.UPLOAD_URL_EXCEPTIONS = {
-        "*@peterbe.com": "https://s3.example.com/peterbe-com"
-    }
-
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "HeadBucket"
-        # These come from settings.Test
-        fixture_bucket_names = ("private", "mybucket", "peterbe-com")
-        assert api_params["Bucket"] in fixture_bucket_names
-        return {}
-
-    with botomock(mock_api_call):
+def test_check_storage_urls_happy_path():
+    with patch("tecken.storage.StorageBucket.exists", return_value=True):
         assert not dockerflow_extra.check_storage_urls(None)
 
 
-def test_check_storage_urls_missing(gcsmock, settings):
-    def mock_get_bucket(name):
-        if name == "private":
-            raise NotFound("Never heard of it!")
-        return gcsmock.MockBucket()
-
-    gcsmock.get_bucket = mock_get_bucket
-
-    errors = dockerflow_extra.check_storage_urls(None)
-    assert errors
-    error, = errors
-    assert "private" in error.msg
-    assert "bucket not found" in error.msg
-
-
-def test_check_storage_urls_client_error(gcsmock, settings):
-    def mock_get_bucket(name):
-        if name == "private":
-            raise google_BadRequest("Never heard of it!")
-        return gcsmock.MockBucket()
-
-    gcsmock.get_bucket = mock_get_bucket
-
-    errors = dockerflow_extra.check_storage_urls(None)
-    assert errors
-    error, = errors
-    assert "private" in error.msg
-    assert "Never heard of it!" in error.msg
-
-
-def test_check_storage_urls_client_error_s3(botomock, settings):
-    settings.SYMBOL_URLS = ["https://s3.example.com/private/prefix/"]
-    settings.UPLOAD_URL_EXCEPTIONS = {
-        "*@peterbe.com": "https://s3.example.com/peterbe-com"
-    }
-
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "HeadBucket"
-        if api_params["Bucket"] == "private":
-            response = {"Error": {"Code": "403", "Message": "Not allowed"}}
-            raise ClientError(response, operation_name)
-        return {}
-
-    with botomock(mock_api_call):
+def test_check_storage_urls_missing():
+    with patch("tecken.storage.StorageBucket.exists", return_value=False):
         errors = dockerflow_extra.check_storage_urls(None)
-        assert errors
-        error, = errors
-        assert "private" in error.msg
-        assert "ClientError" in error.msg
+    assert len(errors) == 2
+    assert "private" in errors[0].msg
+    assert "peterbe-com" in errors[1].msg
+    for error in errors:
+        assert "bucket not found" in error.msg
+        assert error.id == "tecken.health.E003"
 
 
-def test_check_storage_urls_endpointconnectionerror_s3(botomock, settings):
-    settings.SYMBOL_URLS = ["https://s3.example.com/private/prefix/"]
-    settings.UPLOAD_URL_EXCEPTIONS = {
-        "*@peterbe.com": "https://s3.example.com/peterbe-com"
-    }
-
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "HeadBucket"
-        if api_params["Bucket"] == "private":
-            raise EndpointConnectionError(endpoint_url="http://s3.example.com")
-        return {}
-
-    with botomock(mock_api_call):
+@pytest.mark.parametrize(
+    "exception",
+    (
+        BadRequest("Never heard of it!"),
+        ClientError({"Error": {"Code": "403", "Message": "Not allowed"}}, "HeadBucket"),
+    ),
+)
+def test_check_storage_urls_api_error(exception):
+    with patch("tecken.storage.StorageBucket.exists", side_effect=exception):
         errors = dockerflow_extra.check_storage_urls(None)
-        assert errors
-        error, = errors
-        assert "private" in error.msg
-        assert "EndpointConnectionError" in error.msg
+    assert len(errors) == 2
+    for error in errors:
+        assert str(exception) in error.msg
+        assert error.id == "tecken.health.E002"
+
+
+def test_check_storage_urls_endpointconnectionerror_s3():
+    exception = EndpointConnectionError(endpoint_url="http://s3.example.com")
+    with patch("tecken.storage.StorageBucket.exists", side_effect=exception):
+        errors = dockerflow_extra.check_storage_urls(None)
+    assert len(errors) == 2
+    for error in errors:
+        assert "Unable to connect" in error.msg
+        assert error.id == "tecken.health.E001"
 
 
 def test_check_storage_urls_other_client_error_s3(botomock, settings):
-    settings.SYMBOL_URLS = ["https://s3.example.com/private/prefix/"]
-    settings.UPLOAD_URL_EXCEPTIONS = {
-        "*@peterbe.com": "https://s3.example.com/peterbe-com"
-    }
-
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "HeadBucket"
-        if api_params["Bucket"] == "private":
-            raise RuntimeError("A different error")
-        return {}
-
-    with botomock(mock_api_call):
-        with pytest.raises(RuntimeError):
-            dockerflow_extra.check_storage_urls(None)
-
-
-def test_check_storage_urls_emulated_gcs(settings):
-    settings.SYMBOL_URLS = ["https://gcs-emulator.example.com/bucket"]
-    settings.UPLOAD_URL_EXCEPTIONS = {
-        "*@peterbe.com": "https://gcs-emulator.example.com/peterbe-com"
-    }
-    mock_client = Mock(spec_set=("get_bucket",))
-    with patch("tecken.storage.FakeGCSClient") as mock_class:
-        mock_class.return_value = mock_client
+    exception = RuntimeError("A different error")
+    with patch(
+        "tecken.storage.StorageBucket.exists", side_effect=exception
+    ), pytest.raises(RuntimeError):
         dockerflow_extra.check_storage_urls(None)
-    assert mock_class.call_count == 2
-    mock_client.get_bucket.assert_has_calls((call("bucket"), call("peterbe-com")))

--- a/tests/test_dockerflow_extra.py
+++ b/tests/test_dockerflow_extra.py
@@ -8,6 +8,7 @@ from google.api_core.exceptions import BadRequest
 from botocore.exceptions import ClientError, EndpointConnectionError
 
 from tecken import dockerflow_extra
+from tecken.storage import StorageBucket, StorageError
 
 
 def test_check_redis_store_connected_happy_path():
@@ -27,7 +28,7 @@ def test_check_storage_urls_missing():
     assert "peterbe-com" in errors[1].msg
     for error in errors:
         assert "bucket not found" in error.msg
-        assert error.id == "tecken.health.E003"
+        assert error.id == "tecken.health.E001"
 
 
 @pytest.mark.parametrize(
@@ -35,10 +36,13 @@ def test_check_storage_urls_missing():
     (
         BadRequest("Never heard of it!"),
         ClientError({"Error": {"Code": "403", "Message": "Not allowed"}}, "HeadBucket"),
+        EndpointConnectionError(endpoint_url="http://s3.example.com"),
     ),
 )
-def test_check_storage_urls_api_error(exception):
-    with patch("tecken.storage.StorageBucket.exists", side_effect=exception):
+def test_check_storage_urls_storageerror(exception, settings):
+    fake_bucket = StorageBucket(url=settings.SYMBOL_URLS[0])
+    error = StorageError(bucket=fake_bucket, backend_error=exception)
+    with patch("tecken.storage.StorageBucket.exists", side_effect=error):
         errors = dockerflow_extra.check_storage_urls(None)
     assert len(errors) == 2
     for error in errors:
@@ -46,17 +50,7 @@ def test_check_storage_urls_api_error(exception):
         assert error.id == "tecken.health.E002"
 
 
-def test_check_storage_urls_endpointconnectionerror_s3():
-    exception = EndpointConnectionError(endpoint_url="http://s3.example.com")
-    with patch("tecken.storage.StorageBucket.exists", side_effect=exception):
-        errors = dockerflow_extra.check_storage_urls(None)
-    assert len(errors) == 2
-    for error in errors:
-        assert "Unable to connect" in error.msg
-        assert error.id == "tecken.health.E001"
-
-
-def test_check_storage_urls_other_client_error_s3(botomock, settings):
+def test_check_storage_urls_other_error():
     exception = RuntimeError("A different error")
     with patch(
         "tecken.storage.StorageBucket.exists", side_effect=exception

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -12,6 +12,7 @@ from tecken.storage import StorageBucket, scrub_credentials, FakeGCSClient
 
 INIT_CASES = {
     "https://s3.amazonaws.com/some-bucket": {
+        "backend": "s3",
         "base_url": "https://s3.amazonaws.com/some-bucket",
         "endpoint_url": None,
         "name": "some-bucket",
@@ -20,6 +21,7 @@ INIT_CASES = {
         "region": None,
     },
     "https://s3.amazonaws.com/some-bucket?access=public": {
+        "backend": "s3",
         "base_url": "https://s3.amazonaws.com/some-bucket",
         "endpoint_url": None,
         "name": "some-bucket",
@@ -28,6 +30,7 @@ INIT_CASES = {
         "region": None,
     },
     "https://s3-eu-west-2.amazonaws.com/some-bucket": {
+        "backend": "s3",
         "base_url": "https://s3-eu-west-2.amazonaws.com/some-bucket",
         "endpoint_url": None,
         "name": "some-bucket",
@@ -36,6 +39,7 @@ INIT_CASES = {
         "region": "eu-west-2",
     },
     "http://s3.example.com/buck/prfx": {
+        "backend": "test-s3",
         "base_url": "http://s3.example.com/buck",
         "endpoint_url": "http://s3.example.com",
         "name": "buck",
@@ -43,7 +47,17 @@ INIT_CASES = {
         "private": True,
         "region": None,
     },
+    "http://minio:9000/testbucket": {
+        "backend": "emulated-s3",
+        "base_url": "http://minio:9000/testbucket",
+        "endpoint_url": "http://minio:9000",
+        "name": "testbucket",
+        "prefix": "",
+        "private": True,
+        "region": None,
+    },
     "https://storage.googleapis.com/foo-bar-bucket": {
+        "backend": "gcs",
         "base_url": "https://storage.googleapis.com/foo-bar-bucket",
         "endpoint_url": "https://storage.googleapis.com/foo-bar-bucket",
         "name": "foo-bar-bucket",
@@ -52,6 +66,7 @@ INIT_CASES = {
         "region": None,
     },
     "https://storage.googleapis.com/foo-bar-bucket/myprefix": {
+        "backend": "gcs",
         "base_url": "https://storage.googleapis.com/foo-bar-bucket",
         "endpoint_url": "https://storage.googleapis.com/foo-bar-bucket/myprefix",
         "name": "foo-bar-bucket",
@@ -60,6 +75,7 @@ INIT_CASES = {
         "region": None,
     },
     "https://gcs-emulator.127.0.0.1.nip.io:4443/emulated-bucket": {
+        "backend": "emulated-gcs",
         "base_url": "https://gcs-emulator.127.0.0.1.nip.io:4443/emulated-bucket",
         "endpoint_url": "https://gcs-emulator.127.0.0.1.nip.io:4443",
         "name": "emulated-bucket",
@@ -76,6 +92,7 @@ INIT_CASES = {
 def test_init(url, expected):
     """The URL is processed during initialization."""
     bucket = StorageBucket(url)
+    assert bucket.backend == expected["backend"]
     assert bucket.base_url == expected["base_url"]
     assert bucket.endpoint_url == expected["endpoint_url"]
     assert bucket.name == expected["name"]
@@ -89,6 +106,12 @@ def test_init_unknown_region_raises():
     """An exception is raised by a S3 URL with an unknown region."""
     with pytest.raises(ValueError):
         StorageBucket("https://s3-unheardof.amazonaws.com/some-bucket")
+
+
+def test_init_unknown_backend_raises():
+    """An exception is raised if the backend can't be determined from the URL."""
+    with pytest.raises(ValueError):
+        StorageBucket("https://unknown-backend.example.com/some-bucket")
 
 
 def test_StorageBucket_client():

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2,44 +2,93 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import mock
+from unittest import mock
+
 import pytest
 from google.cloud.storage import _http, blob
 from google.cloud.storage.client import Client as google_Client
 
 from tecken.storage import StorageBucket, scrub_credentials, FakeGCSClient
 
+INIT_CASES = {
+    "https://s3.amazonaws.com/some-bucket": {
+        "base_url": "https://s3.amazonaws.com/some-bucket",
+        "endpoint_url": None,
+        "name": "some-bucket",
+        "prefix": "",
+        "private": True,
+        "region": None,
+    },
+    "https://s3.amazonaws.com/some-bucket?access=public": {
+        "base_url": "https://s3.amazonaws.com/some-bucket",
+        "endpoint_url": None,
+        "name": "some-bucket",
+        "prefix": "",
+        "private": False,
+        "region": None,
+    },
+    "https://s3-eu-west-2.amazonaws.com/some-bucket": {
+        "base_url": "https://s3-eu-west-2.amazonaws.com/some-bucket",
+        "endpoint_url": None,
+        "name": "some-bucket",
+        "prefix": "",
+        "private": True,
+        "region": "eu-west-2",
+    },
+    "http://s3.example.com/buck/prfx": {
+        "base_url": "http://s3.example.com/buck",
+        "endpoint_url": "http://s3.example.com",
+        "name": "buck",
+        "prefix": "prfx",
+        "private": True,
+        "region": None,
+    },
+    "https://storage.googleapis.com/foo-bar-bucket": {
+        "base_url": "https://storage.googleapis.com/foo-bar-bucket",
+        "endpoint_url": "https://storage.googleapis.com/foo-bar-bucket",
+        "name": "foo-bar-bucket",
+        "prefix": "",
+        "private": True,
+        "region": None,
+    },
+    "https://storage.googleapis.com/foo-bar-bucket/myprefix": {
+        "base_url": "https://storage.googleapis.com/foo-bar-bucket",
+        "endpoint_url": "https://storage.googleapis.com/foo-bar-bucket/myprefix",
+        "name": "foo-bar-bucket",
+        "prefix": "myprefix",
+        "private": True,
+        "region": None,
+    },
+    "https://gcs-emulator.127.0.0.1.nip.io:4443/emulated-bucket": {
+        "base_url": "https://gcs-emulator.127.0.0.1.nip.io:4443/emulated-bucket",
+        "endpoint_url": "https://gcs-emulator.127.0.0.1.nip.io:4443",
+        "name": "emulated-bucket",
+        "prefix": "",
+        "private": True,
+        "region": None,
+    },
+}
 
-def test_use_StorageBucket():
-    bucket = StorageBucket("https://s3.amazonaws.com/some-bucket")
-    assert bucket.name == "some-bucket"
-    assert bucket.endpoint_url is None
-    assert bucket.region is None
-    assert bucket.private  # because it's the default
-    assert bucket.base_url == "https://s3.amazonaws.com/some-bucket"
 
-    bucket = StorageBucket("https://s3.amazonaws.com/some-bucket?access=public")
-    assert bucket.name == "some-bucket"
-    assert bucket.endpoint_url is None
-    assert bucket.region is None
-    assert not bucket.private
-    assert bucket.base_url == "https://s3.amazonaws.com/some-bucket"
-
-    bucket = StorageBucket("https://s3-eu-west-2.amazonaws.com/some-bucket")
-    assert bucket.name == "some-bucket"
-    assert bucket.endpoint_url is None
-    assert bucket.region == "eu-west-2"
-    assert bucket.base_url == "https://s3-eu-west-2.amazonaws.com/some-bucket"
-
-    bucket = StorageBucket("http://s3.example.com/buck/prfx")
-    assert bucket.name == "buck"
-    assert bucket.endpoint_url == "http://s3.example.com"
-    assert bucket.region is None
-    assert bucket.prefix == "prfx"
-    assert bucket.base_url == "http://s3.example.com/buck"
-
-    # Just check that __repr__ it works at all
+@pytest.mark.parametrize(
+    "url, expected", INIT_CASES.items(), ids=tuple(INIT_CASES.keys())
+)
+def test_init(url, expected):
+    """The URL is processed during initialization."""
+    bucket = StorageBucket(url)
+    assert bucket.base_url == expected["base_url"]
+    assert bucket.endpoint_url == expected["endpoint_url"]
+    assert bucket.name == expected["name"]
+    assert bucket.prefix == expected["prefix"]
+    assert bucket.private == expected["private"]
+    assert bucket.region == expected["region"]
     assert repr(bucket)
+
+
+def test_init_unknown_region_raises():
+    """An exception is raised by a S3 URL with an unknown region."""
+    with pytest.raises(ValueError):
+        StorageBucket("https://s3-unheardof.amazonaws.com/some-bucket")
 
 
 def test_StorageBucket_client():
@@ -79,34 +128,14 @@ def test_StorageBucket_client():
         assert client_kwargs_calls[-1]["region_name"] == ("eu-west-2")
 
 
-def test_region_checking():
-    bucket = StorageBucket("https://s3.amazonaws.com/some-bucket")
-    assert bucket.region is None
-
-    # a known and classic one
-    bucket = StorageBucket("https://s3-us-west-2.amazonaws.com/some-bucket")
-    assert bucket.region == "us-west-2"
-
-    with pytest.raises(ValueError):
-        StorageBucket("https://s3-unheardof.amazonaws.com/some-bucket")
-
-
 def test_google_cloud_storage_client(gcsmock):
     bucket = StorageBucket("https://storage.googleapis.com/foo-bar-bucket")
-    assert bucket.name == "foo-bar-bucket"
     client = bucket.get_storage_client()
     assert isinstance(client, google_Client)
 
 
-def test_google_cloud_storage_client_with_prefix():
-    bucket = StorageBucket("https://storage.googleapis.com/foo-bar-bucket/myprefix")
-    assert bucket.name == "foo-bar-bucket"
-    assert bucket.prefix == "myprefix"
-
-
 def test_emulated_gcs_client():
     bucket = StorageBucket("https://gcs-emulator.127.0.0.1.nip.io:4443/emulated-bucket")
-    assert bucket.name == "emulated-bucket"
     assert bucket.is_google_cloud_storage
     assert bucket.is_emulated_gcs
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -9,7 +9,7 @@ from io import BytesIO
 import pytest
 from botocore.exceptions import ClientError
 from requests.exceptions import ConnectionError, RetryError
-from google.api_core.exceptions import BadRequest as google_BadRequest
+from google.api_core.exceptions import NotFound
 
 from django.urls import reverse
 from django.contrib.auth.models import Permission, User
@@ -2185,7 +2185,7 @@ def test_upload_client_unrecognized_bucket(gcsmock, fakeuser, client):
     url = reverse("upload:upload_archive")
 
     def mocked_get_bucket(name):
-        raise google_BadRequest("Never heard of it")
+        raise NotFound("Never heard of it")
 
     gcsmock.get_bucket = mocked_get_bucket
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -112,7 +112,7 @@ def test_upload_archive_happy_path(
     settings,
 ):
     # The default upload URL setting uses Google Cloud Storage.
-    assert StorageBucket.URL_FINGERPRINT["gcs"] in settings.UPLOAD_DEFAULT_URL
+    assert StorageBucket(settings.UPLOAD_DEFAULT_URL).backend == "gcs"
 
     token = Token.objects.create(user=fakeuser)
     permission, = Permission.objects.filter(codename="upload_symbols")
@@ -337,7 +337,7 @@ def test_upload_archive_with_ignorable_files(
     settings,
 ):
     # The default upload URL setting uses Google Cloud Storage.
-    assert StorageBucket.URL_FINGERPRINT["gcs"] in settings.UPLOAD_DEFAULT_URL
+    assert StorageBucket(settings.UPLOAD_DEFAULT_URL).backend == "gcs"
 
     token = Token.objects.create(user=fakeuser)
     permission, = Permission.objects.filter(codename="upload_symbols")


### PR DESCRIPTION
This PR, part of [bug 1564452](https://bugzilla.mozilla.org/show_bug.cgi?id=1564452), adds some methods to ``StorageBucket`` so that client code can use object storage without being as concerned whether it is S3 or GCS, emulated or "real".

* ``exists()``: Returns ``True`` if the bucket exists, ``False`` if it does not, and raises a backend-specific exception for issues like authentication and authorization issues.
* ``backend()``: Set to a string like ``"s3"`` or ``"emulated-gcs"``, to classify the backend if needed.

This expands the code and tests in ``StorageBucket``, and simplifies the code and tests for the code that checks for bucket existence.

This first PR took more time than I planned, as I got my S3 and GCS accounts setup, and made a bunch of test requests to investigate the API, and became more familiar with the code. According the lines added and deleted, it looks like the complexity mostly moved, rather than things being simplified. I hope as more API methods are implemented, we can see larger gains in simplicity for client code and tests.