### PR TITLE
bug 1563036: Switch to official gcs emulator image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,11 +158,12 @@ services:
 
   # Fake Google Cloud Storage
   gcs-emulator:
-    # TODO: Switch to official image, when it is ready (bug 1563036)
-    image: jwhitlock/gc-fake-storage:test
-    environment:
-      - GCS_FAKE_EXTERNAL_URL=https://gcs-emulator.127.0.0.1.nip.io:4443
-      - GCS_FAKE_PUBLIC_HOST=storage.gcs-emulator.127.0.0.1.nip.io:4443
+    image: fsouza/fake-gcs-server:latest
+    command:
+      - -host=0.0.0.0
+      - -port=4443
+      - -external-url=https://gcs-emulator.127.0.0.1.nip.io:4443
+      - -public-host=storage.gcs-emulator.127.0.0.1.nip.io:4443
     ports:
       - "4443:4443"
     volumes:


### PR DESCRIPTION
Switch from the test Docker image to [fsouza/fake-gcs-server](https://hub.docker.com/r/fsouza/fake-gcs-server), which is maintained by the [upstream project](https://github.com/fsouza/fake-gcs-server/), and is configured via the command line instead of environment variables.

As documented, to switch to the GCS emulator, override the URLs in the ``.env`` file:

```
DJANGO_SYMBOL_URLS=https://gcs-emulator.127.0.0.1.nip.io:4443/tecken
DJANGO_UPLOAD_DEFAULT_URL=https://gcs-emulator.127.0.0.1.nip.io:4443/tecken
```

I was able to upload a symbols .zip with the new server.