### PR TITLE
Fix uploads page

### DIFF
--- a/frontend/src/Uploads.js
+++ b/frontend/src/Uploads.js
@@ -428,7 +428,7 @@ class DisplayUploads extends React.PureComponent {
     const { loading, uploads, aggregates } = this.props;
 
     const todayStr = format(new Date(), "yyyy-MM-dd");
-    const todayFullStr = format(new Date(), "yyyy-MM-ddTHH:MM.SSSZ");
+    const todayFullStr = format(new Date(), "yyyy-MM-ddTHH:MM.SSS");
     return (
       <form onSubmit={this.submitForm}>
         <table className="table is-fullwidth">


### PR DESCRIPTION
The page was failing with a RangeError because of the Z. This fixes that.

```
08:49:24.557 RangeError: "Format string contains an unescaped latin alphabet character `Z`"
    F index.js:422
    F index.js:395
    render Uploads.js:431
    React 11
    _fetchUploads Uploads.js:108
    promise callback*be/this._fetchUploads/< Uploads.js:107
    promise callback*be/this._fetchUploads Uploads.js:90
    componentDidMount Uploads.js:68
    React 3
    unstable_runWithPriority scheduler.production.min.js:266
    React 12
    61 index.js:7
    Webpack 6
console.js:39
```

`format()` comes from date-fns which renovate updated from 2.0.0-beta3 to 2.0.0-beta4. Pretty sure this broke then. I skimmed the changelog, but don't really know this library so I'm not sure what caused it to break.