### PR TITLE
Re-add Z, but escape it

### DIFF
--- a/frontend/src/Uploads.js
+++ b/frontend/src/Uploads.js
@@ -428,7 +428,7 @@ class DisplayUploads extends React.PureComponent {
     const { loading, uploads, aggregates } = this.props;
 
     const todayStr = format(new Date(), "yyyy-MM-dd");
-    const todayFullStr = format(new Date(), "yyyy-MM-ddTHH:MM.SSS");
+    const todayFullStr = format(new Date(), "yyyy-MM-ddTHH:MM.SSS'Z");
     return (
       <form onSubmit={this.submitForm}>
         <table className="table is-fullwidth">


### PR DESCRIPTION
This is a fix to 3470baa8. In that, I removed the Z altogether, but the
Z needs to be there as a Z--not a formatting symbol. This re-adds it, but
escaped.