### PR TITLE
Fix uploads date-fmt format usage

### DIFF
--- a/frontend/src/Uploads.js
+++ b/frontend/src/Uploads.js
@@ -428,7 +428,7 @@ class DisplayUploads extends React.PureComponent {
     const { loading, uploads, aggregates } = this.props;
 
     const todayStr = format(new Date(), "yyyy-MM-dd");
-    const todayFullStr = format(new Date(), "yyyy-MM-ddTHH:MM.SSS'Z");
+    const todayFullStr = format(new Date(), "yyyy-MM-ddTHH:MM.SSS'Z'");
     return (
       <form onSubmit={this.submitForm}>
         <table className="table is-fullwidth">


### PR DESCRIPTION
In date-fmt, ' is an "escape character", but "escaped" things actually
need to be quoted. This adds the end '.