### PR TITLE
bug 1628802: fix permissions issues in docker containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,9 @@ jobs:
       - run:
           name: Run tests
           command: |
-            make test
+            # Run ./bin/test.sh so it doesn't execute make rules that don't work
+            # in CI
+            ./bin/test.sh
 
       - run:
           name: Run lint check

--- a/.env-dist
+++ b/.env-dist
@@ -1,3 +1,12 @@
+# This file is for settings that are specific to your docker local development
+# environment. Since these are specific to your local development environment,
+# don't check them in.
+
+# If you want to set the uid and gid of the app user that we use in the
+# containers, you can do that with these two variables.
+# USE_UID=
+# USE_GID=
+
 PYTHONUNBUFFERED=1
 PYTHONDONTWRITEBYTECODE=1
 

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ frontend/build/:
 
 .PHONY: build-frontend
 build-frontend:
-	docker-compose run -e CI web ./bin/build_frontend.sh
+	docker-compose run --no-deps -e CI web ./bin/build_frontend.sh
 
 .PHONY: lint
 lint: .env .docker-build

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# Include my.env and export it so variables set in there are available
+# in the Makefile.
+include .env
+export
+
+# Set these in the environment to override them. This is helpful for
+# development if you have file ownership problems because the user
+# in the container doesn't match the user on your host.
+USE_UID ?= 10001
+USE_GID ?= 10001
+
 .PHONY: help
 help: default
 
@@ -19,11 +30,8 @@ default:
 	@echo "  redis-store-cli  Opens a Redis CLI to the store Redis server"
 	@echo "  clear-caches     Clear Redis caches"
 	@echo "  shell            Opens a Bash shell"
-	@echo "  currentshell     Opens a Bash shell into existing running 'web' container"
 	@echo "  test             Runs the Python test suite"
 	@echo "  testshell        Runs a shell in the test environment"
-	@echo "  gunicorn         Runs the whole stack using gunicorn on http://localhost:8000/"
-	@echo "  django-shell     Django integrative shell"
 	@echo "  psql             Open the psql cli"
 	@echo "  lint             Lint code"
 	@echo "  lintfix          Reformat code"
@@ -38,7 +46,7 @@ default:
 
 .PHONY: build
 build: .env
-	docker-compose build base frontend linting
+	docker-compose build --build-arg userid=${USE_UID} --build-arg groupid=${USE_GID} base frontend linting
 	touch .docker-build
 
 .PHONY: clean
@@ -54,17 +62,11 @@ clear-caches:
 
 .PHONY: setup
 setup: .env
-	docker-compose run web /app/bin/setup-services.sh
+	docker-compose run --rm web /app/bin/setup-services.sh
 
 .PHONY: shell
 shell: .env .docker-build
-	# Use `-u 0` to automatically become root in the shell
-	docker-compose run --user 0 web bash
-
-.PHONY: currentshell
-currentshell: .env .docker-build
-	# Use `-u 0` to automatically become root in the shell
-	docker-compose exec --user 0 web bash
+	docker-compose run --rm web bash
 
 .PHONY: redis-cache-cli
 redis-cache-cli: .env .docker-build
@@ -84,32 +86,27 @@ stop: .env
 	docker-compose stop
 
 .PHONY: test
-test: .env .docker-build
-	@bin/test.sh
+test: .env .docker-build frontend/build/
+	bin/test.sh
 
 .PHONY: testshell
 testshell: .env .docker-build
-	@bin/test.sh --shell
+	bin/test.sh --shell
 
 .PHONY: run
 run: .env .docker-build
 	docker-compose up web worker frontend
 
-.PHONY: gunicorn
-gunicorn: .env .docker-build
-	docker-compose run --service-ports web web
-
-.PHONY: django-shell
-django-shell: .env .docker-build
-	docker-compose run web python manage.py shell
-
 .PHONY: docs
 docs:
-	@bin/build-docs-locally.sh
+	bin/build-docs-locally.sh
+
+frontend/build/:
+	make build-frontend
 
 .PHONY: build-frontend
 build-frontend:
-	docker-compose run -u 0 -e CI base ./bin/build_frontend.sh
+	docker-compose run -e CI web ./bin/build_frontend.sh
 
 .PHONY: lint
 lint: .env .docker-build

--- a/bin/build_frontend.sh
+++ b/bin/build_frontend.sh
@@ -21,13 +21,13 @@ if [[ ! -z "${CI}" ]]; then
     yarn run --no-progress build
     popd
 else
-    # If you're NOT in CI, you're most likely in a local development mode.
-    # You need the Dockerfile to build as normal but you don't want to
-    # build the production grade static assets necessarily (it's slow
-    # and for local development you have the 'frontend' container in
-    # docker-compose.yml).
+    # If you're NOT in CI, you're most likely in a local development mode.  You
+    # need the Dockerfile to build as normal but you don't want to build the
+    # production grade static assets necessarily (it's slow and for local
+    # development you have the 'frontend' container in docker-compose.yml).
+    #
     # This just makes sure there exists a directory called 'frontend/build'.
-    # If it's empty, that's OK. It it already existed, it won't be
-    # affected.
+    # If it's empty, that's OK. It it already existed, it won't be affected.
+    echo "Creating frontend/build/ ..."
     mkdir -p frontend/build
 fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,9 @@ RUN bin/build_frontend.sh
 # to build dump_syms.
 FROM python:3.7.7-slim-stretch@sha256:4e437e97b01b4209de3e8af3d132b7198a7fd7e27cea634cf33afc0e246be7c1
 
+ARG userid=10001
+ARG groupid=10001
+
 ENV PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app/ \
     DJANGO_CONFIGURATION=Prod \
@@ -24,12 +27,12 @@ ENV PYTHONUNBUFFERED=1 \
 
 EXPOSE $PORT
 
+WORKDIR /app
+
 # add a non-privileged user for installing and running the application
-# don't use --create-home option to prevent populating with skeleton files
-RUN mkdir /app && \
-    chown 10001:10001 /app && \
-    groupadd --gid 10001 app && \
-    useradd --no-create-home --uid 10001 --gid 10001 --home-dir /app app
+RUN groupadd --gid $groupid app && \
+    useradd -g app --uid $userid --shell /usr/sbin/nologin --create-home app && \
+    chown app:app /app/
 
 # install a few essentials and clean apt caches afterwards
 RUN apt-get update && \
@@ -65,9 +68,9 @@ WORKDIR /app
 # Copy static assets
 COPY --from=frontend /app/frontend/build /app/frontend/build
 
-RUN chown -R 10001:10001 /app
+RUN chown -R app:app /app
 
-USER 10001
+USER app
 
 # Using /bin/bash as the entrypoint works around some volume mount issues on Windows
 # where volume-mounted files do not have execute bits set.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,6 +17,5 @@ ADD frontend /app
 EXPOSE 3000
 EXPOSE 35729
 
-
 ENTRYPOINT ["/bin/bash", "/app/bin/run_frontend.sh"]
 CMD ["start"]


### PR DESCRIPTION
This fixes permission issues when running the docker containers on Linux where the uid/gid of the host user doesn't match the app user.

To test:

1. add `USE_UID` and `USE_GID` to `.env`
2. `make build`
3. `make setup`
4. `make lintfix`
5. `make test`
6. `make run` (though this is broken because of a different issue that I'll get to next)

None of those should result in files that are owned by root or some other user.