### PR TITLE
Add note about redis==3.4.1

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -38,9 +38,6 @@ botocore==1.16.21 \
 python-dateutil==2.8.1 \
     --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
     --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a
-redis==3.4.1 \
-    --hash=sha256:b205cffd05ebfd0a468db74f0eedbff8df1a7bfc47521516ade4692991bb0833 \
-    --hash=sha256:0dcfb335921b88a850d461dc255ff4708294943322bd55de6cfd68972490ca1f
 django-redis==4.12.1 \
     --hash=sha256:1133b26b75baa3664164c3f44b9d5d133d1b8de45d94d79f38d1adc5b1d502e5 \
     --hash=sha256:306589c7021e6468b2656edc89f62b8ba67e8d5a1c8877e2688042263daa7a63
@@ -159,3 +156,9 @@ click==7.1.2 \
 jsonschema==3.2.0 \
     --hash=sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163 \
     --hash=sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
+
+# NOTE(willkg): Need to keep redis at this version because after this, the Python
+# library doesn't work with the version of Redis we're using in production.
+redis==3.4.1 \
+    --hash=sha256:b205cffd05ebfd0a468db74f0eedbff8df1a7bfc47521516ade4692991bb0833 \
+    --hash=sha256:0dcfb335921b88a850d461dc255ff4708294943322bd55de6cfd68972490ca1f


### PR DESCRIPTION
Redis deprecated HMSET. We're still using 3.4.2 in production. Redis 4 added variadic arguments to HSET which is what you're supposed to switch to. That's all super....

However, updating the Python redis library to 3.5.0 deprecates hmset so you have to switch to hset, but we can't use variadic arguments because the version of Redis we're using doesn't support it. Ergo, we're hosed.

We have a few of options:

1. Update Redis in stage/prod to something >= 4.
2. Rewrite the symbolicate API view code to not use hmset.
3. Pin the library to 3.4.1 and push this off until another day.

I'm choosing option 3 for now.