### PR TITLE
bug 1627052: rewrite symbolication API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,8 @@ sys.path.insert(0, str(BASEDIR))
 
 # -- Custom configuration -------------------------------------------------
 
+import sphinx_rtd_theme
+
 extlinks = {
     "base_url": ("https://symbols.mozilla.org/%s", "https://symbols.mozilla.org")
 }
@@ -40,8 +42,7 @@ extlinks = {
 # ones.
 extensions = [
     "sphinx.ext.extlinks",
-    # 'sphinx.ext.autodoc',
-    # 'everett.sphinx_autoconfig',
+    "sphinxcontrib.httpdomain",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -122,7 +123,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "default"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -131,6 +132,7 @@ html_theme = "default"
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.

--- a/docs/symbolication.rst
+++ b/docs/symbolication.rst
@@ -2,356 +2,254 @@
 Symbolication
 =============
 
+.. contents::
 
-History
-=======
 
-The original implementation was Vladan Djeric's
-`Snappy-Symbolication-Server`_ which was written in Tornado and was never
-hosted with ops support or monitoring.
-
-This is a re-write of that and baked in as one of multiple features in
-Mozilla Symbol Server.
-
-.. _`Snappy-Symbolication-Server`: https://github.com/vdjeric/Snappy-Symbolication-Server
-
-What It Is
+Background
 ==========
 
-You make a POST request to :base_url:`/symbolicate/v5` with a JSON body.
-That JSON body has to contain certain keys and adhere to a specific format.
-Here is an example:
+Stacks
+------
 
-.. code-block:: json
+The stack is denoted as a list of lists. Each frame in the stack is composed
+of two things:
 
-    {
+1. the index in the modules list for the module for this frame
+2. the memory offset relative to the base memory address for that module as
+   an integer
+
+For example, ``[1, 65802]`` is the 1-index module in the ``memoryMap`` and
+module offset 65802.
+
+
+Modules
+-------
+
+Modules are denoted by a debug filename and debug id. Without those, Tecken
+can't find the symbols file for that module.
+
+Each debug filename/debug id corresponds to a path in the symbols store. The
+full URL comes from taking the base url, appending the debug filename,
+appending the debug id, and then appending the debug filename with a ``.sym``
+extensions.
+
+For example, ``["wntdll.pdb", "D74F79EB1F8D4A45ABCD2F476CCABACC2"]`` becomes
+``https://example.com/v1/wntdll.pdb/D74F79EB1F8D4A45ABCD2F476CCABACC2/wntdll.sym``.
+
+
+Symbolication
+-------------
+
+Given a set of modules and a set of stacks, symbolication is the act of fetching
+the debug symbols files for the modules, looking up the module offsets, and
+then returning the symbol information.
+
+For eaxmple, given this set of modules::
+
+    [ "firefox.pdb", "5F84ACF1D63667F44C4C44205044422E1" ],
+    [ "mozavcodec.pdb", "9A8AF7836EE6141F4C4C44205044422E1" ],
+    [ "Windows.Media.pdb", "01B7C51B62E95FD9C8CD73A45B4446C71" ],
+    [ "xul.pdb", "09F9D7ECF31F60E34C4C44205044422E1" ],
+    ...
+
+and this stack::
+
+    [ 3, 6516407 ],
+    [ 3, 12856365 ],
+    [ 3, 12899916 ],
+    [ 3, 13034426 ],
+    ...
+
+you might end up with something like this::
+
+    0  xul.pdb  mozilla::ConsoleReportCollector::FlushReportsToConsole(unsigned long long, nsIConsoleReportCollector::ReportAction)
+    1  xul.pdb  mozilla::net::HttpBaseChannel::MaybeFlushConsoleReports()",
+    2  xul.pdb  mozilla::net::HttpChannelChild::OnStopRequest(nsresult const&, mozilla::net::ResourceTimingStructArgs const&, mozilla::net::nsHttpHeaderArray const&, nsTArray<mozilla::net::ConsoleReportCollected> const&)
+    3  xul.pdb  std::_Func_impl_no_alloc<`lambda at /builds/worker/checkouts/gecko/netwerk/protocol/http/HttpChannelChild.cpp:1001:11',void>::_Do_call()
+    ...
+
+
+Symbolication: /symbolicate/v5
+==============================
+
+.. http:post:: /symbolicate/v5
+   :synopsis: Symbolicates stacks.
+
+   Symbolicate one or more stacks.
+
+   Send an HTTP POST request with a JSON payload.
+
+   **Example request:**
+
+   .. sourcecode:: http
+
+      POST /symbolicate/v5 HTTP/1.1
+
+      {
         "jobs": [
-            {
-              "memoryMap": [
-                [
-                  "xul.pdb",
-                  "44E4EC8C2F41492B9369D6B9A059577C2"
-                ],
-                [
-                  "wntdll.pdb",
-                  "D74F79EB1F8D4A45ABCD2F476CCABACC2"
-                ]
+          {
+            "memoryMap": [
+              [
+                "xul.pdb",
+                "44E4EC8C2F41492B9369D6B9A059577C2"
               ],
-              "stacks": [
-                [
-                  [0, 11723767],
-                  [1, 65802]
-                ]
+              [
+                "wntdll.pdb",
+                "D74F79EB1F8D4A45ABCD2F476CCABACC2"
               ]
-            }
-        ]
-    }
-
-
-As a shortcut, you don't have to have a list ``jobs``. E.g. this works
-the same as the example above:
-
-.. code-block:: json
-
-    {
-      "memoryMap": [
-        [
-          "xul.pdb",
-          "44E4EC8C2F41492B9369D6B9A059577C2"
-        ],
-        [
-          "wntdll.pdb",
-          "D74F79EB1F8D4A45ABCD2F476CCABACC2"
-        ]
-      ],
-      "stacks": [
-        [
-          [0, 11723767],
-          [1, 65802]
-        ]
-      ]
-    }
-
-
-
-The ``memoryMap`` is list of symbol filenames and their debug ID. Each 2-D
-tuple corresponds to a path in our S3 symbol store. The full URL comes
-from taking the base URL (e.g. ``https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/``)
-plus the first first part (e.g. ``wntdll.pdb``) and then the debug ID
-(e.g. ``D74F79EB1F8D4A45ABCD2F476CCABACC2``) and then lastly the first part
-again but instead of ``.pdb`` it's replaced with ``.sym``.
-
-So, as a full example, ``["wntdll.pdb", "D74F79EB1F8D4A45ABCD2F476CCABACC2"]``
-becomes ``https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/wntdll.pdb/D74F79EB1F8D4A45ABCD2F476CCABACC2/wntdll.sym``.
-
-The ``stacks`` part is a list of lists, also known as "an array of stack traces".
-Each stack trace is a list of "frames". Each frame is a 2-D tuple of
-"module index" and "module offset". That module index is a number that corresponds
-to an item in the ``memoryMap`` (see above). And the module offset is the
-offset of this frame's instruction pointer relative to the base memory
-address of the module in which the code is contained as an integer (in base 16).
-
-So, in the example above, ``[1, 65802]`` means the 1th element (starting with 0)
-in the ``memoryMap`` which in this example is
-``["wntdll.pdb", "D74F79EB1F8D4A45ABCD2F476CCABACC2"]``.
-
-What you get back is a JSON output that looks like this:
-
-.. code-block:: json
-
-    {
-      "results": [
-        {
-          "stacks": [
-            [
-              {
-                "frame": 0,
-                "module_offset": "0xb2e3f7",
-                "module": "xul.pdb",
-                "function": "sctp_send_initiate",
-                "function_offset": "0x4ca"
-              },
-              {
-                "frame": 1,
-                "module_offset": "0x1010a",
-                "module": "wntdll.pdb"
-              }
+            ],
+            "stacks": [
+              [
+                [0, 11723767],
+                [1, 65802]
+              ]
             ]
-          ],
-          "found_modules": {
-            "wntdll.pdb/D74F79EB1F8D4A45ABCD2F476CCABACC2": false,
-            "xul.pdb/44E4EC8C2F41492B9369D6B9A059577C2": true
           }
-        }
-      ]
-    }
-
-The ``results`` list's order matches the list of ``jobs`` in the input.
-
-
-Legacy API, Version 4
-=====================
-
-Prior to Version 5, was version 4 and the difference are as follows. The
-input could only be exactly 1 job. And the JSON input had to contain
-``"version": 4``.
-
-The output had less information and it was always the output of exactly 1 job.
-And example output:
-
-.. code-block:: json
-
-    {
-      "symbolicatedStacks": [
-        [
-          "XREMain::XRE_mainRun() (in xul.pdb)",
-          "KiUserCallbackDispatcher (in wntdll.pdb)"
         ]
-      ],
-      "knownModules": [
-        true,
-        true
-      ]
-    }
+      }
 
-The order of the ``symbolicatedStacks`` matches the order of the ``stacks``
-sent in. Each item is a string of the format
-``{function name} in ({module file name})``.
+   **Example response:**
 
-If the symbol can't find found a particular module, then the format becomes
-``{module offset in hex} in ({module file name})``.
+   .. sourcecode:: http
 
-The ``knownModules`` list matches the order of the ``memoryMap`` list.
-For each module and debug ID tuple, this is either ``True`` if the symbol file
-could be found or ``False`` if it couldn't be found or couldn't be downloaded.
+      HTTP/1.1 200 OK
+      Content-Type: application/json
 
-Note! ``knownModules`` makes no distinction if the symbol file failure to download is permanent
-or temporary. The symbolication server attempts to retry failed downloads but
-it uses caching to remember that it failed for a limited amount of time to
-avoid hitting the same failure over and over.
-
-The module offset (e.g. ``65802``) might not correspond to an exact location
-in the module. If no exact location is found, it uses the nearest offset
-rounded down.
-
-
-How It Works
-============
-
-Each module index and module offset pair is iterated over in each stack.
-The module index is used to load the symbol. Either from cache or from
-the S3 source.
-
-When it was not available in the cache and had to be downloaded, we parse
-every line of the symbol file and extract all offsets and their function
-names from the lines that start with either ``FUNC{space}`` or ``PUBLIC{space}``.
-Only this mapping is saved in the cache.
-
-Once the symbols have been loaded from that module, we try to look up
-the offset. First we try to look up the exact offset and if that fails
-we sort ALL offsets in that module and find the nearest one, rounded down.
-
-If any of the offsets can't be converted to a hex, it gets skipped and
-ignored. For example if you have a frame tuple that looks like this:
-``[0, 1.00000]`` the resulting symbolication of that will simply be
-``["1.00000"]`` as a string.
-
-
-Example Symbolication
-=====================
-
-Here's an example you can copy and paste::
-
-    curl -d '{"jobs": [{"stacks":[[[0,11723767],[1, 65802]]],"memoryMap":[["xul.pdb","44E4EC8C2F41492B9369D6B9A059577C2"],["wntdll.pdb","D74F79EB1F8D4A45ABCD2F476CCABACC2"]]}]}' http://localhost:8000/symbolicate/v5
-
-Note, if you only have a single job you can write it as this too::
-
-    curl -d '{"stacks":[[[0,11723767],[1, 65802]]],"memoryMap":[["xul.pdb","44E4EC8C2F41492B9369D6B9A059577C2"],["wntdll.pdb","D74F79EB1F8D4A45ABCD2F476CCABACC2"]]}' http://localhost:8000/symbolicate/v5
-
-
-Symbolication With Debug
-========================
-
-To get more debug information in the response output, you can add a header
-to the request. Simply set header ``Debug`` to something like ``true``.
-For example:
-
-.. code-block:: shell
-
-    curl -H 'Debug: true' -d '{"stacks":[[[0,11723767],[1, 65802]]],"memoryMap":[["xul.pdb","44E4EC8C2F41492B9369D6B9A059577C2"],["wntdll.pdb","D74F79EB1F8D4A45ABCD2F476CCABACC2"]],"version":4}' http://localhost:8000/symbolicate/v4
-
-This will return an output that can look like this:
-
-.. code-block:: json
-
-    {
-        "debug": {
-            "cache_lookups": {
-                "count": 2,
-                "size": 0,
-                "time": 0.006340742111206055
-            },
-            "downloads": {
-                "count": 2,
-                "size": 70490521,
-                "time": 16.34278154373169
-            },
-            "modules": {
-                "count": 2,
-                "stacks_per_module": {
-                    "wntdll.pdb/D74F79EB1F8D4A45ABCD2F476CCABACC2": 1,
-                    "xul.pdb/44E4EC8C2F41492B9369D6B9A059577C2": 1
+      {
+        "results": [
+          {
+            "stacks": [
+              [
+                {
+                  "frame": 0,
+                  "module_offset": "0xb2e3f7",
+                  "module": "xul.pdb",
+                  "function": "sctp_send_initiate",
+                  "function_offset": "0x4ca"
+                },
+                {
+                  "frame": 1,
+                  "module_offset": "0x1010a",
+                  "module": "wntdll.pdb"
                 }
-            },
-            "stacks": {
-                "count": 2,
-                "real": 2
-            },
-            "time": 16.75939154624939
-        },
-        "knownModules": [
-            true,
-            true
-        ],
-        "symbolicatedStacks": [
-            [
-                "XREMain::XRE_mainRun() (in xul.pdb)",
-                "KiUserCallbackDispatcher (in wntdll.pdb)"
-            ]
+              ]
+            ],
+            "found_modules": {
+              "wntdll.pdb/D74F79EB1F8D4A45ABCD2F476CCABACC2": false,
+              "xul.pdb/44E4EC8C2F41492B9369D6B9A059577C2": true
+            }
+          }
         ]
-    }
+      }
 
-The keys inside the ``debug`` block means as follows:
+   Here's an example you can copy and paste:
 
-* ``cache_lookups.count`` - how many times it tried to do a query on
-  the LRU cache
+   .. code-block:: shell
 
-* ``cache_lookups.size`` - the total bytes size of data returned by the
-  LRU cache
-
-* ``cache_lookups.time`` - total time it took to make these queries on the
-  LRU cache
-
-* ``downloads.count`` - number of successful downloads of symbols over
-  the network
-
-* ``downloads.size`` - the total bytes size of symbols downloaded
-  when uncompressed
-
-* ``downloads.time`` - total time it took to make these downloads over
-  the network
-
-* ``modules.count`` - number of modules that needed to be looked up
-
-* ``modules.stacks_per_module`` - number of stacks that were referring to
-  each module
-
-* ``stacks.count`` - total number of frames in all stack traces that were
-  symbolicated
-
-* ``stacks.real`` - total number of frames in all stack traces that were
-  symbolicated except those offsets that couldn't be converted to hex.
+       curl -d '{"jobs": [{"stacks":[[[0,11723767],[1, 65802]]],"memoryMap":[["xul.pdb","44E4EC8C2F41492B9369D6B9A059577C2"],["wntdll.pdb","D74F79EB1F8D4A45ABCD2F476CCABACC2"]]}]}' http://localhost:8000/symbolicate/v5
 
 
-URL shortcut
-============
+   **Tips:**
 
-The ideal URL to POST request to is :base_url:`/symbolicate/v4`
-but to support legacy usage when the domain was `symbolapi.mozilla.org`
-you can also do the same POST request to :base_url:`/` too.
+   1. Try to batch symbolication so a single request contains multiple jobs. That'll
+      reduce the HTTP request/response overhead.
+   2. If you get a non-200 response, wait a bit and try again.
+   3. You should always get back a JSON response. If you don't, treat that like
+      a failure, wait a bit and try again.
+   4. If you're getting a 200 response, but some frames aren't symbolicated,
+      then either Tecken doesn't have debugging symbols for that module or
+      the debugging symbols for that module are malformed.
+
+   :<json jobs: array of json objects each specifying a job
+       to symbolicate
+
+       :[].memoryMap: array of ``[debug name (str), debug id (str)]`` arrays
+
+       :[].stacks: array of stacks where each stack is an array of
+           ``[module index (int), memory offset (int)]`` arrays
+
+   :>json results: array of result objects--one for every job
+
+       :[].stacks: array of symbolicated stacks where each stack is an array
+           of JSON objects
+
+           :frame (int): frame index
+           :module_offset (str): the module offset in hex
+           :module (str): the module name
+           :function (str): the function name
+           :function_offset (str): the function offset in hex
+
+       :[].found_modules: json object indicating which modules we had symbols
+           for and which ones we didn't
+
+           :<debug_filename>/<debug_id> (str): `true` if we found symbols, `false` if we didn't, and `null` if we
+               didn't need to look up symbols because it's not referenced in the stacks
 
 
-Sporadic Network Errors
-=======================
+   :reqheader Debug: if you add ``Debug: true`` to the headers, then symbolication
+       will also return debug information about cache lookups, how many downloads,
+       timings, and some other things
 
-If, during symbolication, we fail to download a symbol from the S3 store,
-the symbolication fails and a ``503 Service Unavailable`` is returned.
-This only happens if the communication with S3 fails in an **operational
-way** such as failing to connect, SSL errors, or timeouts.
+   :statuscode 200: success symbolicating stacks
+   :statuscode 500: something bad happened--please open up a bug
+   :statuscode 503: problem downloading from symbols stores when symbolicating
+       stacks; wait a bit and try again
 
-If you, as a client receive this error it means you can try again later
-and it should work then.
 
-If however there are problems with the symbol files downloaded from S3,
-the client will receive a ``200 OK`` modules needed will be reported as
-**not found**. For example, if a certain ``xul.sym`` file is corrupt,
-the symbolication will work but it will say the module can't be found.
+Symbolication: /symbolicate/v4 (deprecated)
+===========================================
 
-How Caching Works
-=================
+.. http:post:: /symbolicate/v4
+   :deprecated:
+   :synopsis: Symbolicates stacks.
 
-The S3 symbol storage is vastly bigger than the Symbol Server Symbolication
-can have available at short notice so each symbol is looked up on the fly
-and when looked up once, stored in a `Redis server`_ that is configured to work
-to work as an LRU_ (Least Recently Used) cache.
+   Symbolicate one or more stacks.
 
-It means it's capped and it will keep symbols that are frequently used hot.
-When the Redis LRU cache saves an entry, it compares if the total memory used
-is now going to be bigger than the maximum memory amount
-(configured by config or by  the limit of the server it runs on) allowed.
-If so, it figures out which keys were **least recently** used and deletes
-them from Redis. The default configuration for how many it deletes is 5 but
-you can change that in configuration.
+   Send an HTTP POST request with a JSON payload.
 
-The eviction policy of the Redis LRU is ``allkeys-lru``. If the eviction
-policy is not changed to one that evicts, every write would cause an error
-when you try to save new symbols.
+   **Example request:**
 
-.. _LRU: https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_Recently_Used_.28LRU.29
-.. _`Redis server`: https://redis.io/topics/lru-cache
+   .. sourcecode:: http
 
-Symbolication Caching and New Uploads
-=====================================
+      POST /symbolicate/v4 HTTP/1.1
 
-Symbolication relies on using Redis as a LRU cache. Meaning, if the
-symbolication process has to use the Internet (i.e. AWS S3) to
-download a symbol file, it prevents this from "happening again" by storing
-that in the LRU *without* an expiration time. That means that if a new
-symbol upload comes in that replaces an existing symbol file, in S3,
-the LRU cache needs to be informed.
+      {
+        "memoryMap": [
+          [
+            "xul.pdb",
+            "44E4EC8C2F41492B9369D6B9A059577C2"
+          ],
+          [
+            "wntdll.pdb",
+            "D74F79EB1F8D4A45ABCD2F476CCABACC2"
+          ]
+        ],
+        "stacks": [
+          [
+            [0, 11723767],
+            [1, 65802]
+          ]
+        ],
+        "version": 4
+      }
 
-The way it works is that for every single file that is uploaded (the
-individual file, not the ``.zip`` file), its key is sent to the LRU to be
-invalidated. It currently does not replace what gets invalidated. Instead
-that "void" is left untouched until the symbolication process needs it
-and it will then have to re-download it and store it again.
+
+   **Example response:**
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "symbolicatedStacks": [
+          [
+            "XREMain::XRE_mainRun() (in xul.pdb)",
+            "KiUserCallbackDispatcher (in wntdll.pdb)"
+          ]
+        ],
+        "knownModules": [
+          true,
+          true
+        ]
+      }

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,2 +1,3 @@
 Sphinx==3.0.4
 sphinx-rtd-theme==0.4.3
+sphinxcontrib-httpdomain==1.7.0


### PR DESCRIPTION
This overhauls the symbolication API docs to make them more user-focused. It should be easier to read the docs and understand how to use the API now.

Further, this fixes the docs so they use the sphinx-rtd-theme when building locally. This is what we use on RTD, so it makes it easier to edit and author them locally.