### PR TITLE
bug 1650917: update bugzilla links to Tecken product

### DIFF
--- a/contribute.json
+++ b/contribute.json
@@ -13,9 +13,9 @@
   },
   "bugs": {
     "list":
-      "https://bugzilla.mozilla.org/buglist.cgi?resolution=---&query_format=advanced&component=Symbols&product=Socorro&list_id=14003234",
+      "https://bugzilla.mozilla.org/buglist.cgi?resolution=---&query_format=advanced&product=Tecken",
     "report":
-      "https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro&component=Symbols"
+      "https://bugzilla.mozilla.org/enter_bug.cgi?product=Tecken&component=General"
   },
   "urls": {
     "dev": "https://symbols.dev.mozaws.net",

--- a/docs/upload.rst
+++ b/docs/upload.rst
@@ -18,7 +18,7 @@ Uploading basics
 Uploading requires special permission. The process for requesting access to
 upload symbols is roughly the following:
 
-1. `Create a bug <https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Socorro&component=Tecken>`
+1. `Create a bug <https://bugzilla.mozilla.org/enter_bug.cgi?product=Tecken&component=General>`
    requesting access to upload symbols.
 
 2. A Tecken admin will process the request.
@@ -97,7 +97,7 @@ of this writing is set to::
     public-artifacts.taskcluster.net
 
 If you need another domain supported,
-`file a bug <https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro&component=Tecken>`_.
+`file a bug <https://bugzilla.mozilla.org/enter_bug.cgi?product=Tecken&component=General>`_.
 
 Note that Tecken will check redirects. At first a HEAD request is made with the
 URL and Tecken will check both the original URL and the redirected URL against

--- a/frontend/src/Help.js
+++ b/frontend/src/Help.js
@@ -24,7 +24,7 @@ class Help extends PureComponent {
           superuser. <br />
           <a
             rel="noopener noreferrer"
-            href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro&component=Symbols"
+            href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tecken&component=General"
           >
             The best way to do that is to file a bug
           </a>

--- a/frontend/src/Home.js
+++ b/frontend/src/Home.js
@@ -353,7 +353,7 @@ const LinksTile = () => (
     </p>
     <p>
       <a
-        href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro&component=Symbols"
+        href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tecken&component=General"
         className="is-size-5"
         rel="noopener noreferrer"
       >
@@ -386,7 +386,7 @@ const AboutPermissions = () => (
   <p>
     <i>None!</i>{" "}
     <a
-      href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro&component=Symbols"
+      href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tecken&component=General"
       rel="noopener noreferrer"
     >
       File a bug to ask for permissions.


### PR DESCRIPTION
We created a Tecken product in Bugzilla and all Tecken bugs should get filed there. This updates the links accordingly.