### PR TITLE
bug 1649531: handle empty string debug filename and id

### DIFF
--- a/systemtests/bin/make-stacks.py
+++ b/systemtests/bin/make-stacks.py
@@ -60,8 +60,7 @@ def build_stack(data):
     for module in json_dump.get("modules", []):
         debug_file = module.get("debug_file", "")
         debug_id = module.get("debug_id", "")
-        if not debug_file or not debug_id:
-            continue
+
         # Add the module information to the map
         modules.append((debug_file, debug_id))
         # Keep track of which modules are at which index

--- a/tecken/symbolicate/views.py
+++ b/tecken/symbolicate/views.py
@@ -165,7 +165,7 @@ class SymbolicateJSON:
         needed_modules_lookups = {
             key: modules_lookups[key]
             for key in modules_lookups
-            if key not in self.all_symbol_offsets
+            if key[0] and key[1] and key not in self.all_symbol_offsets
         }
 
         if needed_modules_lookups:
@@ -826,14 +826,12 @@ def validate_memory_map(memory_map):
     if not isinstance(memory_map, list):
         raise InvalidMemoryMap("Must be a list")
 
-    for each in memory_map:
-        if not isinstance(each, list) or len(each) != 2:
+    for item in memory_map:
+        if not isinstance(item, list) or len(item) != 2:
             raise InvalidMemoryMap("Must be a list of lists of size 2")
-        module_name, debug_id = each
+        module_name, debug_id = item
         if len(module_name) > 1024:
             raise InvalidMemoryMap("module name too long")
-        if not debug_id:
-            raise InvalidMemoryMap("debugID empty or missing")
         if "\x00" in module_name:
             raise InvalidMemoryMap("module_name contains null-byte")
 
@@ -844,7 +842,6 @@ def validate_memory_map(memory_map):
 @metrics.timer_decorator("symbolicate_json", tags=["version:v4"])
 @json_post
 def symbolicate_v4_json(request, json_body):
-
     try:
         stacks = json_body["stacks"]
         try:


### PR DESCRIPTION
This fixes symbolication to handle empty strings for the debug filename
and debug id in the memoryMap portion of the symbolication request.
Previously, it would raise an error. It no longer raises an error.
Instead, the code doesn't check cache and doesn't try to download the
module and treats it as if the module isn't available.

I also fixed make-stacks so it no longer drops modules where the debug
filename or id aren't known.