### PR TITLE
bug 1651190: maintain missingsymbol table

### DIFF
--- a/tecken/api/views.py
+++ b/tecken/api/views.py
@@ -1177,15 +1177,7 @@ def downloads_missing(request):
     start = (page - 1) * batch_size
     end = start + batch_size
 
-    # The MissingSymbol class has a classmethod called `total_count`
-    # which returns basically the same as `MissingSymbol.objects.count()`
-    # but it comes from a counter in the cache instead.
-    if any(v for v in form.cleaned_data.values()):
-        # Use the queryset
-        total_count = qs.count()
-    else:
-        # No specific filtering was done, we can use the increment counter.
-        total_count = MissingSymbol.total_count()
+    total_count = qs.count()
 
     context["aggregates"] = {"missing": {"total": total_count}}
 

--- a/tecken/download/management/__init__.py
+++ b/tecken/download/management/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tecken/download/management/commands/__init__.py
+++ b/tecken/download/management/commands/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tecken/download/management/commands/cleanse_missingsymbol.py
+++ b/tecken/download/management/commands/cleanse_missingsymbol.py
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from tecken.download.models import MissingSymbol
+
+
+# Number of days to keep records--anything with a modified older than this will
+# get deleted.
+RECORD_AGE_CUTOFF = 30
+
+
+class Command(BaseCommand):
+    """Periodic maintenance task for deleting old missing symbol records.
+
+    If we haven't updated a missing symbol record in over RECORD_AGE_CUTOFF
+    days, then it's either that no one is looking for that symbol or that the
+    file isn't missing anymore. In either case, we don't need to keep track of
+    it anymore.
+
+    """
+
+    help = "Cleanse the downloads_missingsymbol table of impurities."
+
+    def handle(self, *args, **options):
+        today = timezone.now()
+        cutoff = today - datetime.timedelta(days=RECORD_AGE_CUTOFF)
+
+        ret = MissingSymbol.objects.filter(modified_at__lte=cutoff).delete()
+        self.stdout.write(
+            f"cleanse_missingsymbol: Deleted {ret[0]} records older than {cutoff}."
+        )

--- a/tecken/download/models.py
+++ b/tecken/download/models.py
@@ -3,36 +3,12 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import hashlib
-import random
 
 from django.db import models
-from django.core.cache import cache
 from django.utils.encoding import force_bytes
 
 
-class TotalCountMixin:
-    @classmethod
-    def total_count(cls, refresh=False):
-        cache_key = f"total_count:{cls.__name__}"
-        value = cache.get(cache_key)
-        if refresh or value is None:
-            value = cls.objects.all().count()
-            # The slight-random on the expiry time is to avoid a stampeding
-            # herd if they all expire at the same time.
-            expires = int(60 * 60 * 24 * 31 + 10000 * random.random())
-            cache.set(cache_key, value, expires)
-        return value
-
-    @classmethod
-    def incr_total_count(cls, amount=1):
-        cache_key = f"total_count:{cls.__name__}"
-        try:
-            cache.incr(cache_key, amount)
-        except ValueError:
-            cls.total_count()
-
-
-class MissingSymbol(models.Model, TotalCountMixin):
+class MissingSymbol(models.Model):
     # Use this to quickly identify symbols when you need to look them up
     hash = models.CharField(max_length=32, unique=True)
     # Looking through 70,000 old symbol uploads, the longest

--- a/tecken/download/utils.py
+++ b/tecken/download/utils.py
@@ -50,16 +50,6 @@ def store_missing_symbol(symbol, debugid, filename, code_file=None, code_id=None
             """,
         (hash_, symbol, debugid, filename, code_file or None, code_id or None, hash_),
     ):
-        # You can now use the created_at and modified_at to see if it caused an
-        # update or a creation.
-        # Because there is a miniscule delay, in PostgreSQL, between calling
-        # CLOCK_TIMESTAMP() one time and CLOCK_TIMESTAMP() immediately after,
-        # we can't compare the dates after the upsert.
-        equal = (
-            missing_symbol.modified_at - missing_symbol.created_at
-        ).total_seconds() < 0.0001
-        if equal:
-            # it was an insert!
-            MissingSymbol.incr_total_count()
+        pass
 
     return hash_

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1316,7 +1316,6 @@ def test_downloads_missing(client):
     MissingSymbol.objects.create(
         hash="x2", symbol="foo.pdb", debugid="01010101", filename="foo.ex_", count=2
     )
-    MissingSymbol.total_count(refresh=True)
     response = client.get(url)
     data = response.json()
     assert data["total"] == 2


### PR DESCRIPTION
This removes some code about total counts that we don't really need. This also adds a Django management command and test for removing old entries in the missingsymbol table.

To test:

1. run tests
2. create entries in missingsymbol and run `manage.py cleanse_missingsymbol`