### PR TITLE
bug 1655944: fix bad token responses so the client gets them

### DIFF
--- a/systemtests/bin/list-firefox-symbols-zips.py
+++ b/systemtests/bin/list-firefox-symbols-zips.py
@@ -15,13 +15,14 @@ import requests
 
 SYMBOLS_ZIP_SUFFIX = ".crashreporter-symbols.zip"
 SYMBOLS_FULL_ZIP_SUFFIX = ".crashreporter-symbols-full.zip"
-INDEX = "https://index.taskcluster.net/v1/"
-QUEUE = "https://queue.taskcluster.net/v1/"
+INDEX = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/"
+QUEUE = "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/"
 NAMESPACE = "gecko.v2.mozilla-central.revision.REV.firefox"
 
 
 def index_namespaces(namespace, limit=1000):
-    resp = requests.post(INDEX + "namespaces/" + namespace, json={"limit": limit})
+    url = INDEX + "namespaces/" + namespace
+    resp = requests.post(url, json={"limit": limit})
     for namespace in resp.json()["namespaces"]:
         yield namespace["namespace"]
 

--- a/systemtests/bin/upload-symbols-by-download.py
+++ b/systemtests/bin/upload-symbols-by-download.py
@@ -8,6 +8,7 @@
 
 # Usage: ./bin/upload-symbols-by-download.py
 
+import time
 from urllib.parse import urljoin
 
 import click
@@ -69,7 +70,10 @@ def upload_symbols_by_download(ctx, base_url, auth_token, url):
                     headers={"auth-token": auth_token},
                     timeout=CONNECTION_TIMEOUT,
                 )
-                if resp.status_code != 201:
+                if resp.status_code == 429:
+                    click.echo(click.style("429--sleeping for 5", fg="yellow"))
+                    time.sleep(5)
+                elif resp.status_code != 201:
                     click.echo(
                         click.style(
                             "Error: %s %s" % (resp.status_code, resp.content), fg="red"

--- a/systemtests/bin/upload-symbols-by-download.py
+++ b/systemtests/bin/upload-symbols-by-download.py
@@ -25,6 +25,9 @@ MAX_ATTEMPTS = 5
 # to happen
 CONNECTION_TIMEOUT = 180
 
+# Number of seconds to sleep between tries to account for rate limiting
+SLEEP_TIMEOUT = 10
+
 
 class StdoutMetrics(BackendBase):
     def emit(self, record):
@@ -46,15 +49,21 @@ METRICS = markus.get_metrics()
 @click.option(
     "--auth-token", required=True, help="Auth token for uploading SYM files.",
 )
+@click.option(
+    "--expect-code",
+    required=False,
+    default=201,
+    type=int,
+    help="The expected response status code.",
+)
 @click.argument("url")
 @click.pass_context
-def upload_symbols_by_download(ctx, base_url, auth_token, url):
+def upload_symbols_by_download(ctx, base_url, auth_token, url, expect_code):
     """Upload SYM file to a host using a download url."""
 
     api_url = urljoin(base_url, "/upload/")
 
     # It's possible this can fail, so we put it in a retry loop.
-    success = False
     for i in range(MAX_ATTEMPTS):
         click.echo(
             click.style(
@@ -70,24 +79,46 @@ def upload_symbols_by_download(ctx, base_url, auth_token, url):
                     headers={"auth-token": auth_token},
                     timeout=CONNECTION_TIMEOUT,
                 )
-                if resp.status_code == 429:
-                    click.echo(click.style("429--sleeping for 5", fg="yellow"))
-                    time.sleep(5)
-                elif resp.status_code != 201:
+
+                click.echo(
+                    click.style(
+                        "Response: %s %r" % (resp.status_code, resp.content),
+                        fg="yellow",
+                    )
+                )
+
+                if resp.status_code == 403:
+                    # 403 means the auth token is bad which is not a retryable error
+                    if resp.status_code == expect_code:
+                        click.echo(click.style("Success! %r" % resp.json(), fg="green"))
+                        return
+                    else:
+                        ctx.exit(1)
+                elif resp.status_code == 429:
+                    # 429 means we've been rate-limited, so wait and retry
+                    click.echo(
+                        click.style("429--sleeping for %s" % SLEEP_TIMEOUT, fg="yellow")
+                    )
+                    time.sleep(SLEEP_TIMEOUT)
+                else:
+                    if resp.status_code == expect_code:
+                        # This is the expected status code, so this is a success
+                        click.echo(click.style("Success!", fg="green"))
+                        return
+
                     click.echo(
                         click.style(
                             "Error: %s %s" % (resp.status_code, resp.content), fg="red"
                         )
                     )
-                else:
-                    success = True
-                    click.echo(click.style("Success! %r" % resp.json(), fg="green"))
-                    break
+                    continue
         except Exception as exc:
-            click.echo(click.style("Error: %s" % exc, fg="red"))
+            click.echo(click.style("Unexpected error: %s" % exc, fg="red"))
 
-    if not success:
-        click.echo(click.style("Error: Max retry attempts reached.", fg="red"))
+    # We've retried multiple times and never hit the expected status code, so
+    # this is a fail
+    click.echo(click.style("Error: Max retry attempts reached.", fg="red"))
+    ctx.exit(1)
 
 
 if __name__ == "__main__":

--- a/systemtests/bin/upload-symbols.py
+++ b/systemtests/bin/upload-symbols.py
@@ -9,6 +9,7 @@
 # Usage: ./bin/upload-symbols.py FILE
 
 import os
+import time
 from urllib.parse import urljoin
 
 import click
@@ -82,7 +83,10 @@ def upload_symbols(ctx, base_url, auth_token, symbolsfile):
                         headers={"auth-token": auth_token},
                         timeout=CONNECTION_TIMEOUT,
                     )
-                if resp.status_code != 201:
+                if resp.status_code == 429:
+                    click.echo(click.style("429--sleeping for 5", fg="yellow"))
+                    time.sleep(5)
+                elif resp.status_code != 201:
                     click.echo(
                         click.style(
                             "Error: %s %s" % (resp.status_code, resp.content), fg="red"

--- a/systemtests/bin/upload-symbols.py
+++ b/systemtests/bin/upload-symbols.py
@@ -24,6 +24,9 @@ MAX_ATTEMPTS = 5
 # Number of seconds to wait for a response from server
 CONNECTION_TIMEOUT = 60
 
+# Number of seconds to sleep between tries to account for rate limiting
+SLEEP_TIMEOUT = 10
+
 
 class StdoutMetrics(BackendBase):
     def emit(self, record):
@@ -45,9 +48,16 @@ METRICS = markus.get_metrics()
 @click.option(
     "--auth-token", required=True, help="Auth token for uploading SYM files.",
 )
+@click.option(
+    "--expect-code",
+    required=False,
+    default=201,
+    type=int,
+    help="The expected response status code.",
+)
 @click.argument("symbolsfile")
 @click.pass_context
-def upload_symbols(ctx, base_url, auth_token, symbolsfile):
+def upload_symbols(ctx, base_url, auth_token, symbolsfile, expect_code):
     """Upload SYM file to a host."""
 
     if not os.path.exists(symbolsfile):
@@ -65,7 +75,6 @@ def upload_symbols(ctx, base_url, auth_token, symbolsfile):
     # connection's upload bandwidth. Because it's run in a local dev
     # environment, it's entirely possible uploading will fail periodically.
     # Given that, we wrap uploading in a retry loop.
-    success = False
     for i in range(MAX_ATTEMPTS):
         click.echo(
             click.style(
@@ -83,24 +92,46 @@ def upload_symbols(ctx, base_url, auth_token, symbolsfile):
                         headers={"auth-token": auth_token},
                         timeout=CONNECTION_TIMEOUT,
                     )
-                if resp.status_code == 429:
-                    click.echo(click.style("429--sleeping for 5", fg="yellow"))
-                    time.sleep(5)
-                elif resp.status_code != 201:
+
+                click.echo(
+                    click.style(
+                        "Response: %s %r" % (resp.status_code, resp.content),
+                        fg="yellow",
+                    )
+                )
+
+                if resp.status_code == 403:
+                    # 403 means the auth token is bad which is not a retryable error
+                    if resp.status_code == expect_code:
+                        click.echo(click.style("Success! %r" % resp.json(), fg="green"))
+                        return
+                    else:
+                        ctx.exit(1)
+                elif resp.status_code == 429:
+                    # 429 means we've been rate-limited, so wait and retry
+                    click.echo(
+                        click.style("429--sleeping for %s" % SLEEP_TIMEOUT, fg="yellow")
+                    )
+                    time.sleep(SLEEP_TIMEOUT)
+                else:
+                    if resp.status_code == expect_code:
+                        # This is the expected status code, so this is a success
+                        click.echo(click.style("Success!", fg="green"))
+                        return
+
                     click.echo(
                         click.style(
                             "Error: %s %s" % (resp.status_code, resp.content), fg="red"
                         )
                     )
-                else:
-                    success = True
-                    click.echo(click.style("Success! %r" % resp.json(), fg="green"))
-                    break
+                    continue
         except Exception as exc:
-            click.echo(click.style("Error: %s" % exc, fg="red"))
+            click.echo(click.style("Unexpected error: %s" % exc, fg="red"))
 
-    if not success:
-        click.echo(click.style("Error: Max retry attempts reached.", fg="red"))
+    # We've retried multiple times and never hit the expected status code, so
+    # this is a fail
+    click.echo(click.style("Error: Max retry attempts reached.", fg="red"))
+    ctx.exit(1)
 
 
 if __name__ == "__main__":

--- a/systemtests/test_env.sh
+++ b/systemtests/test_env.sh
@@ -30,11 +30,13 @@ fi
 case $1 in
     "local")
         export DESTRUCTIVE_TESTS=1
+        export BAD_TOKEN_TEST=1
         HOST=http://web:8000/
         export AUTH_TOKEN="${LOCAL_AUTH_TOKEN}"
         ;;
     "stage")
         export DESTRUCTIVE_TESTS=1
+        export BAD_TOKEN_TEST=1
         HOST=https://symbols.stage.mozaws.net/
         export AUTH_TOKEN="${STAGE_AUTH_TOKEN}"
         ;;
@@ -68,6 +70,14 @@ if [ "${DESTRUCTIVE_TESTS}" == "1" ]; then
 else
     echo ">>> SKIPPING DESTRUCTIVE TESTS"
     echo ""
+fi
+
+if [ "${BAD_TOKEN_TEST}" == "1" ]; then
+    # This tests a situation that occurs when nginx is a reverse-proxy to
+    # tecken and doesn't work in the local dev environment. bug 1655944
+    echo ">>> UPLOAD WITH BAD TOKEN TEST--this should return a 403 and error and not a RemoteDisconnected"
+    FN=$(ls -S ./data/zip-files/*.zip | head -n 1)
+    python ./bin/upload-symbols.py --auth-token="badtoken" --base-url="${HOST}" "${FN}"
 fi
 
 echo ">>> SYMBOLICATION V4 and V5 TEST"

--- a/systemtests/test_env.sh
+++ b/systemtests/test_env.sh
@@ -59,7 +59,7 @@ if [ "${DESTRUCTIVE_TESTS}" == "1" ]; then
     echo ">>> UPLOAD TEST (DESTRUCTIVE)"
     for FN in ./data/zip-files/*.zip
     do
-        python ./bin/upload-symbols.py --auth-token="${AUTH_TOKEN}" --base-url="${HOST}" "${FN}"
+        python ./bin/upload-symbols.py --expect-code=201 --auth-token="${AUTH_TOKEN}" --base-url="${HOST}" "${FN}"
     done
     echo ""
 
@@ -77,8 +77,10 @@ if [ "${BAD_TOKEN_TEST}" == "1" ]; then
     # tecken and doesn't work in the local dev environment. bug 1655944
     echo ">>> UPLOAD WITH BAD TOKEN TEST--this should return a 403 and error and not a RemoteDisconnected"
     FN=$(ls -S ./data/zip-files/*.zip | head -n 1)
-    python ./bin/upload-symbols.py --auth-token="badtoken" --base-url="${HOST}" "${FN}"
+    python ./bin/upload-symbols.py --expect-code=403 --auth-token="badtoken" --base-url="${HOST}" "${FN}"
 fi
+
+exit;  # FIXME
 
 echo ">>> SYMBOLICATION V4 and V5 TEST"
 for FN in ./data/stacks/*.json

--- a/systemtests/test_env.sh
+++ b/systemtests/test_env.sh
@@ -80,8 +80,6 @@ if [ "${BAD_TOKEN_TEST}" == "1" ]; then
     python ./bin/upload-symbols.py --expect-code=403 --auth-token="badtoken" --base-url="${HOST}" "${FN}"
 fi
 
-exit;  # FIXME
-
 echo ">>> SYMBOLICATION V4 and V5 TEST"
 for FN in ./data/stacks/*.json
 do


### PR DESCRIPTION
This fixes the issue where the client is trying to upload a big symbols file using a bad token. The Tecken middleware will see the auth header, recognize it's a bad token, and then return a 403 with some message. However, if the client is using chunked transfer encoding and the request body hasn't been fully sent, the connection gets dropped before the client gets the 403 response.

This fixes that by forcing the middleware to slurp the entire request body (if possible) before sending the 403 response.

This adds a system test that tests the situation in stage and prod environments.

To test:

1. run tests to make sure they still pass
2. run the system test against the stage environment to verify it fails in the "UPLOAD WITH BAD TOKEN TEST--this should return a 403 and error and not a RemoteDisconnected" test
3. run the system test against the local dev environment to make sure it doesn't run that test and that all the system tests pass
