### PR TITLE
bug 1655944: fix force_full_request_body_read function

### DIFF
--- a/systemtests/test_env.sh
+++ b/systemtests/test_env.sh
@@ -77,6 +77,7 @@ if [ "${BAD_TOKEN_TEST}" == "1" ]; then
     # tecken and doesn't work in the local dev environment. bug 1655944
     echo ">>> UPLOAD WITH BAD TOKEN TEST--this should return a 403 and error and not a RemoteDisconnected"
     FN=$(ls -S ./data/zip-files/*.zip | head -n 1)
+    ls -l ${FN}
     python ./bin/upload-symbols.py --expect-code=403 --auth-token="badtoken" --base-url="${HOST}" "${FN}"
 fi
 

--- a/tecken/tokens/middleware.py
+++ b/tecken/tokens/middleware.py
@@ -43,20 +43,18 @@ class APITokenAuthenticationMiddleware:
         See bug 1655944.
 
         """
-        content_length = request.META.get("content-length", 0)
-        if content_length == 0:
-            return
-
         total_size = 0
         try:
-            while total_size < content_length:
+            size = len(request.read())
+            total_size += size
+            while size > 0:
                 size = len(request.read())
                 total_size += size
-            logging.debug(
-                "draining request body because of token problem; %d", total_size
+            logging.info(
+                "force_full_request_body_read: drained request body: %d", total_size
             )
         except Exception as exc:
-            logging.info("exception thrown when draining request body: %r", exc)
+            logging.info("force_full_request_body_read: exception thrown: %r", exc)
 
     def process_request(self, request):
         key = request.META.get("HTTP_AUTH_TOKEN")


### PR DESCRIPTION
In a chunked transfer encoding scenario, the content length will be 0
so using that to guard against reading forever won't work. Underneath
the Django request .read() is gunicorn's read which will handle
dropped connections, timeouts, and other possible data transfer issues.

Given that, we can just loop until there's nothing left to read and
that'll be ok.