### PR TITLE
bug 1665127: add notes about user-agent

### DIFF
--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -35,7 +35,7 @@ Now a development server should be available at
 
 To test the symbolication run::
 
-   $ curl -d '{"stacks":[[[0,11723767],[1, 65802]]],"memoryMap":[["xul.pdb","44E4EC8C2F41492B9369D6B9A059577C2"],["wntdll.pdb","D74F79EB1F8D4A45ABCD2F476CCABACC2"]],"version":4}' http://localhost:3000/symbolicate/v5
+   $ curl --user-agent "example/1.0" -d '{"stacks":[[[0,11723767],[1, 65802]]],"memoryMap":[["xul.pdb","44E4EC8C2F41492B9369D6B9A059577C2"],["wntdll.pdb","D74F79EB1F8D4A45ABCD2F476CCABACC2"]],"version":4}' http://localhost:3000/symbolicate/v5
 
 
 Database migrations

--- a/docs/download.rst
+++ b/docs/download.rst
@@ -58,7 +58,8 @@ it takes to send the request to Tecken for a specific symbol. For example:
 
 .. code-block:: shell
 
-    $ time curl https://symbols.mozilla.org/firefox.pdb/448794C699914DB8A8F9B9F88B98D7412/firefox.sym
+    $ time curl --user-agent "example/1.0" \
+        https://symbols.mozilla.org/firefox.pdb/448794C699914DB8A8F9B9F88B98D7412/firefox.sym
 
 Note, that will tell you the total time it took your computer to make the
 request to Tecken **plus** Tecken's time to talk to S3.
@@ -68,7 +69,7 @@ add a header to your outgoing request. For example:
 
 .. code-block:: shell
 
-    $ curl -v -H 'Debug: true' \
+    $ curl --user-agent "example/1.0" -v -H 'Debug: true' \
         https://symbols.mozilla.org/firefox.pdb/448794C699914DB8A8F9B9F88B98D7412/firefox.sym
 
 Then you'll get a response header called ``Debug-Time``. In the ``curl`` output
@@ -92,21 +93,21 @@ For example:
 
 .. code-block:: shell
 
-    $ curl https://symbols.mozilla.org/foo.pdb/HEX/foo.sym
+    $ curl --user-agent "example/1.0" https://symbols.mozilla.org/foo.pdb/HEX/foo.sym
     ...302 Found...
 
     # Now suppose you delete the file manually from S3 in the AWS Console.
     # And without any delay do the curl again:
-    $ curl https://symbols.mozilla.org/foo.pdb/HEX/foo.sym
+    $ curl --user-agent "example/1.0" https://symbols.mozilla.org/foo.pdb/HEX/foo.sym
     ...302 Found...
     # Same old "broken", which is wrong.
 
     # Avoid it by adding ?_refresh
-    $ curl https://symbols.mozilla.org/foo.pdb/HEX/foo.sym?_refresh
+    $ curl --user-agent "example/1.0" https://symbols.mozilla.org/foo.pdb/HEX/foo.sym?_refresh
     ...404 Symbol Not Found...
 
     # Now our cache will be updated.
-    $ curl https://symbols.mozilla.org/foo.pdb/HEX/foo.sym
+    $ curl --user-agent "example/1.0" https://symbols.mozilla.org/foo.pdb/HEX/foo.sym
     ...404 Symbol Not Found...
 
 
@@ -124,10 +125,10 @@ For example:
 
 .. code-block:: shell
 
-    $ curl https://symbols.mozilla.org/tried.pdb/HEX/tried.sym?try
+    $ curl --user-agent "example/1.0" https://symbols.mozilla.org/tried.pdb/HEX/tried.sym?try
     ...302 Found...
 
-    $ curl https://symbols.mozilla.org/try/tried.pdb/HEX/tried.sym
+    $ curl --user-agent "example/1.0" https://symbols.mozilla.org/try/tried.pdb/HEX/tried.sym
     ...302 Found...
 
 If you specify that you're requesting a try build, Tecken will look at

--- a/docs/endtoendtesting.rst
+++ b/docs/endtoendtesting.rst
@@ -60,7 +60,7 @@ To run the test, first HTTP POST as per this example...:
 
 .. code-block:: shell
 
-    ▶ curl -v -XPOST localhost:8000/__task_tester__
+    ▶ curl --user-agent "e2etesting/1.0" -v -XPOST localhost:8000/__task_tester__
     > POST /__task_tester__ HTTP/1.1
     >
     < HTTP/1.1 201 Created
@@ -71,7 +71,7 @@ Then, the HTTP GET:
 
 .. code-block:: shell
 
-    ▶ curl -v localhost:8000/__task_tester__
+    ▶ curl --user-agent "e2etesting/1.0" -v localhost:8000/__task_tester__
     > GET /__task_tester__ HTTP/1.1
     >
     < HTTP/1.1 200 OK

--- a/docs/symbolication.rst
+++ b/docs/symbolication.rst
@@ -147,7 +147,7 @@ Symbolication: /symbolicate/v5
 
    .. code-block:: shell
 
-       curl -d '{"jobs": [{"stacks":[[[0,11723767],[1, 65802]]],"memoryMap":[["xul.pdb","44E4EC8C2F41492B9369D6B9A059577C2"],["wntdll.pdb","D74F79EB1F8D4A45ABCD2F476CCABACC2"]]}]}' http://localhost:8000/symbolicate/v5
+       curl --user-agent "example/1.0" -d '{"jobs": [{"stacks":[[[0,11723767],[1, 65802]]],"memoryMap":[["xul.pdb","44E4EC8C2F41492B9369D6B9A059577C2"],["wntdll.pdb","D74F79EB1F8D4A45ABCD2F476CCABACC2"]]}]}' http://localhost:8000/symbolicate/v5
 
 
    **Tips:**

--- a/docs/upload.rst
+++ b/docs/upload.rst
@@ -52,7 +52,7 @@ Example with ``curl``:
 
 .. code-block:: shell
 
-    $ curl -X POST -H 'auth-token: xxx' \
+    $ curl --user-agent "example/1.0" -X POST -H 'auth-token: xxx' \
         --form try=1 \
         --form myfile.zip=@myfile.zip \
         https://symbols.mozilla.org/upload/
@@ -83,7 +83,7 @@ Here's a ``curl`` example:
 
 .. code-block:: shell
 
-    $ curl -X POST -H 'auth-token: xxx' \
+    $ curl --user-agent "example/1.0" -X POST -H 'auth-token: xxx' \
         --form myfile.zip=@myfile.zip \
         https://symbols.mozilla.org/upload/
 
@@ -94,7 +94,8 @@ Here's a Python example using the ``requests`` library:
     >>> import requests
     >>> files = {"myfile.zip": open("path/to/myfile.zip", "rb")}
     >>> url = "https://symbols.mozilla.org/upload/"
-    >>> response = requests.post(url, files=files, headers={"Auth-token": "xxx"})
+    >>> headers = {"User-Agent": "example/1.0", "Auth-token": "xxx"}
+    >>> response = requests.post(url, files=files, headers=headers)
     >>> response.status_code
     201
 
@@ -128,7 +129,7 @@ An example with ``curl``:
 
 .. code-block:: shell
 
-    $ curl -X POST -H 'auth-token: xxx' \
+    $ curl --user-agent "example/1.0" -X POST -H 'auth-token: xxx' \
        -d url="https://queue.taskcluster.net/YC0FgOlE/artifacts/symbols.zip" \
        https://symbols.mozilla.org/upload/
 
@@ -137,9 +138,10 @@ An example with ``Python`` and the ``requests`` library:
 .. code-block:: python
 
     >>> import requests
-    >>> url = 'https://symbols.mozilla.org/upload/'
-    >>> data = {'url': 'https://queue.taskcluster.net/YC0FgOlE/artifacts/symbols.zip'}
-    >>> response = requests.post(url, data=data, headers={'Auth-token': 'xxx'})
+    >>> url = "https://symbols.mozilla.org/upload/"
+    >>> headers = {"User-Agent": "example/1.0", "Auth-token": "xxx"}
+    >>> data = {"url": "https://queue.taskcluster.net/YC0FgOlE/artifacts/symbols.zip"}
+    >>> response = requests.post(url, data=data, headers=headers)
     >>> response.status_code
     201
 

--- a/frontend/src/APIRequests.js
+++ b/frontend/src/APIRequests.js
@@ -54,13 +54,14 @@ const DisplayAPIRequests = observer(
                 <p key={i}>
                   {request.requiresAuth ? (
                     <code>
-                      curl -X {request.method} -H 'Auth-Token:{" "}
-                      <Link to="/tokens">YOURTOKENHERE</Link>'{" "}
+                      curl --user-agent "example/1.0" -X {request.method} -H
+                      'Auth-Token: <Link to="/tokens">YOURTOKENHERE</Link>'{" "}
                       <a href={fullUrl}>{fullUrl}</a>
                     </code>
                   ) : (
                     <code>
-                      curl -X {request.method} <a href={fullUrl}>{fullUrl}</a>
+                      curl --user-agent "example/1.0" -X {request.method}{" "}
+                      <a href={fullUrl}>{fullUrl}</a>
                     </code>
                   )}
                 </p>

--- a/frontend/src/Symbolication.js
+++ b/frontend/src/Symbolication.js
@@ -251,7 +251,7 @@ class ShowCurl extends CopyToClipboardPureComponent {
       "localhost:8000"
     );
     const absoluteUrl = `${protocol}//${hostname}/symbolicate/v5`;
-    const command = `curl -XPOST -d '${json}' ${absoluteUrl}`;
+    const command = `curl --user-agent "example/1.0" -XPOST -d '${json}' ${absoluteUrl}`;
     return (
       <div className="box">
         <h3>


### PR DESCRIPTION
We really want people to specify the User-Agent HTTP header so we can
better know who we need to talk to when changing API things.