### PR TITLE
bug 1665692: add missingsymbols endpoint

### DIFF
--- a/docs/download.rst
+++ b/docs/download.rst
@@ -119,7 +119,7 @@ Missing symbols APIs
 
 .. http:get:: /missingsymbols.csv
 
-   Download missing symbols list as a CSV.
+   Download missing symbol information as a CSV.
 
    Format::
 
@@ -128,10 +128,78 @@ Missing symbols APIs
    :reqheader User-Agent: please provide a unique user agent to make it easier for us
        to help you debug problems
 
+   :statuscode 200: ok
    :statuscode 429: sleep for a bit and retry
    :statuscode 500: sleep for a bit and retry; if retrying doesn't work, then please
        file a bug report
    :statuscode 503: sleep for a bit and retry
 
 
-.. http:get:: /api/download/missing/
+.. http:get:: /missingsymbols/
+
+   Download missing symbol information.
+
+   For example:
+
+   .. code-block:: shell
+
+      curl --user-agent "example/1.0" \
+         'https://symbols.mozilla.org/missingsymbols/?filename=libxul'
+
+   :reqheader User-Agent: please provide a unique user agent to make it easier for us
+       to help you debug problems
+
+   :query symbol: (optional) the symbol to filter on by substring match
+   :query debugid: (optional) the debugid to filter on by substring match
+   :query filename: (optional) the filename to filter on by substring match
+   :query code_file: (optional) the code_file to filter on by substring match
+   :query code_id: (optional) the code_id to filter on by substring match
+   :query modified_at: (optional) comma-separated date filters for modified_at timestamp
+
+       Valid comparisons: ``<=``, ``>=``, ``=``, ``<``, ``>``
+
+       Example: ``modified_at=>=2020-09-01,<2020-09-02``
+       (url-encoded ``modified_at=%3E%3D=2020-09-01%2C%3C2020-09-02``)
+
+   :query created_at: (optional) comma-separated date filters for created_at timestamp
+
+       Valid comparisons: ``<=``, ``>=``, ``=``, ``<``, ``>``
+
+       Example: ``created_at=>=2020-09-01,<2020-09-02``
+       (url-encoded ``created_at=%3E%3D=2020-09-01%2C%3C2020-09-02``)
+
+   :query sort: (optional) the field to sort by; defaults to ``modified_at``
+   :query reverse: (optional) if you want the sort reversed; defaults to
+       ``false``
+
+   :resheader Content-Type: application/json
+
+   :>json obj order_by: sort specification
+
+       :sort (str): the sort field
+       :reverse (bool): whether or not it's reversed
+
+   :>json int batch_size: the number of records in a page
+   :>json int page: the page being returned
+   :>json int total_count: the total number of records in the query
+
+   :>json array records: the list of records where each record consists of
+
+       :id (int): the record id
+       :symbol (str): the debug symbol
+       :debugid (str): the debug id
+       :filename (str): the filename
+       :code_file (str): the code_file or null
+       :code_id (str): the code_id or null
+       :count (int): how many times this symbol file was requested
+       :modified_at (timestamp): the last time this symbol file was requested;
+           iso8601 in UTC; YYYY-MM-DDThh:mm:ss.sssZ
+       :created_at (timestamp): the first time this symbol file was requested;
+           iso8601 in UTC; YYYY-MM-DDThh:mm:ss.sssZ
+
+   :statuscode 200: ok
+   :statuscode 400: request was invalid; fix and retry
+   :statuscode 429: sleep for a bit and retry
+   :statuscode 500: sleep for a bit and retry; if retrying doesn't work, then please
+       file a bug report
+   :statuscode 503: sleep for a bit and retry

--- a/docs/symbolication.rst
+++ b/docs/symbolication.rst
@@ -147,7 +147,7 @@ Symbolication: /symbolicate/v5
 
    .. code-block:: shell
 
-       curl --user-agent "example/1.0" -d '{"jobs": [{"stacks":[[[0,11723767],[1, 65802]]],"memoryMap":[["xul.pdb","44E4EC8C2F41492B9369D6B9A059577C2"],["wntdll.pdb","D74F79EB1F8D4A45ABCD2F476CCABACC2"]]}]}' http://localhost:8000/symbolicate/v5
+       curl --user-agent "example/1.0" -d '{"jobs": [{"stacks":[[[0,11723767],[1, 65802]]],"memoryMap":[["xul.pdb","44E4EC8C2F41492B9369D6B9A059577C2"],["wntdll.pdb","D74F79EB1F8D4A45ABCD2F476CCABACC2"]]}]}' https://symbols.mozilla.org/symbolicate/v5
 
 
    **Tips:**

--- a/tecken/api/forms.py
+++ b/tecken/api/forms.py
@@ -80,20 +80,6 @@ class UserEditForm(forms.ModelForm):
         return groups
 
 
-class PaginationForm(forms.Form):
-    page = forms.CharField(required=False)
-
-    def clean_page(self):
-        value = self.cleaned_data["page"]
-        try:
-            value = int(value or 1)
-        except ValueError:
-            raise forms.ValidationError(f"Not a number {value!r}")
-        if value < 1:
-            value = 1
-        return value
-
-
 class BaseFilteringForm(forms.Form):
     sort = forms.CharField(required=False)
     reverse = forms.CharField(required=False)

--- a/tecken/api/views.py
+++ b/tecken/api/views.py
@@ -31,7 +31,7 @@ from tecken.base.decorators import (
     api_require_http_methods,
     api_superuser_required,
 )
-from tecken.base.form_utils import filter_form_dates, ORM_OPERATORS
+from tecken.base.form_utils import filter_form_dates, ORM_OPERATORS, PaginationForm
 from tecken.base.utils import filesizeformat
 from tecken.download.models import MissingSymbol
 from tecken.storage import StorageBucket
@@ -349,7 +349,7 @@ def uploads(request):
     if not form.is_valid():
         return http.JsonResponse({"errors": form.errors}, status=400)
 
-    pagination_form = forms.PaginationForm(request.GET)
+    pagination_form = PaginationForm(request.GET)
     if not pagination_form.is_valid():
         return http.JsonResponse({"errors": pagination_form.errors}, status=400)
 
@@ -563,7 +563,7 @@ def uploads_created(request):
     if not form.is_valid():
         return http.JsonResponse({"errors": form.errors}, status=400)
 
-    pagination_form = forms.PaginationForm(request.GET)
+    pagination_form = PaginationForm(request.GET)
     if not pagination_form.is_valid():
         return http.JsonResponse({"errors": pagination_form.errors}, status=400)
 
@@ -673,7 +673,7 @@ def uploads_created_backfilled(request):
 @api_login_required
 @api_permission_required("upload.view_all_uploads")
 def upload_files(request):
-    pagination_form = forms.PaginationForm(request.GET)
+    pagination_form = PaginationForm(request.GET)
     if not pagination_form.is_valid():
         return http.JsonResponse({"errors": pagination_form.errors}, status=400)
     page = pagination_form.cleaned_data["page"]
@@ -1128,7 +1128,7 @@ def downloads_missing(request):
     if not form.is_valid():
         return http.JsonResponse({"errors": form.errors}, status=400)
 
-    pagination_form = forms.PaginationForm(request.GET)
+    pagination_form = PaginationForm(request.GET)
     if not pagination_form.is_valid():
         return http.JsonResponse({"errors": pagination_form.errors}, status=400)
 

--- a/tecken/api/views.py
+++ b/tecken/api/views.py
@@ -24,20 +24,21 @@ from django.db import connection
 from django.core.exceptions import PermissionDenied
 from django.core.cache import cache
 
-from tecken.tokens.models import Token
-from tecken.upload.models import Upload, FileUpload, UploadsCreated
-from tecken.upload.views import get_possible_bucket_urls
-from tecken.storage import StorageBucket
-from tecken.download.models import MissingSymbol
-from tecken.symbolicate.views import get_symbolication_count_key
+from tecken.api import forms
 from tecken.base.decorators import (
     api_login_required,
     api_permission_required,
     api_require_http_methods,
     api_superuser_required,
 )
+from tecken.base.form_utils import filter_form_dates, ORM_OPERATORS
 from tecken.base.utils import filesizeformat
-from . import forms
+from tecken.download.models import MissingSymbol
+from tecken.storage import StorageBucket
+from tecken.symbolicate.views import get_symbolication_count_key
+from tecken.tokens.models import Token
+from tecken.upload.models import Upload, FileUpload, UploadsCreated
+from tecken.upload.views import get_possible_bucket_urls
 
 logger = logging.getLogger("tecken")
 metrics = markus.get_metrics("tecken")
@@ -45,40 +46,6 @@ metrics = markus.get_metrics("tecken")
 
 class SumCardinality(Aggregate):
     template = "SUM(CARDINALITY(%(expressions)s))"
-
-
-ORM_OPERATORS = {"<=": "lte", ">=": "gte", "=": "exact", "<": "lt", ">": "gt"}
-
-
-def _filter_form_dates(qs, form, keys):
-    for key in keys:
-        for operator, value in form.cleaned_data.get(key, []):
-            if value is None:
-                orm_operator = f"{key}__isnull"
-                qs = qs.filter(**{orm_operator: True})
-            elif operator == "=" and (
-                not isinstance(value, datetime.datetime)
-                or value.hour == 0
-                and value.minute == 0
-            ):
-                # When querying on a specific day, make it a little easier
-                qs = qs.filter(
-                    **{
-                        f"{key}__gte": value,
-                        f"{key}__lt": value + datetime.timedelta(days=1),
-                    }
-                )
-            else:
-                if operator == ">":
-                    # Because we use microseconds in the ORM, but when
-                    # datetimes are passed back end forth in XHR, the
-                    # datetimes are converted with isoformat() which
-                    # drops microseconds. Therefore add 1 second to
-                    # avoid matching the latest date.
-                    value += datetime.timedelta(seconds=1)
-                orm_operator = "{}__{}".format(key, ORM_OPERATORS[operator])
-                qs = qs.filter(**{orm_operator: value})
-    return qs
 
 
 @metrics.timer_decorator("api", tags=["endpoint:auth"])
@@ -520,7 +487,7 @@ def filter_uploads(qs, can_view_all, user, form):
     for operator, value in form.cleaned_data["size"]:
         orm_operator = "size__{}".format(ORM_OPERATORS[operator])
         qs = qs.filter(**{orm_operator: value})
-    qs = _filter_form_dates(qs, form, ("created_at", "completed_at"))
+    qs = filter_form_dates(qs, form, ("created_at", "completed_at"))
     return qs
 
 
@@ -665,7 +632,7 @@ def filter_uploads_created(qs, form):
         for operator, value in form.cleaned_data[key]:
             orm_operator = "{}__{}".format(key, ORM_OPERATORS[operator])
             qs = qs.filter(**{orm_operator: value})
-    qs = _filter_form_dates(qs, form, ("date",))
+    qs = filter_form_dates(qs, form, ("date",))
     return qs
 
 
@@ -719,7 +686,7 @@ def upload_files(request):
     for operator, value in form.cleaned_data["size"]:
         orm_operator = "size__{}".format(ORM_OPERATORS[operator])
         qs = qs.filter(**{orm_operator: value})
-    qs = _filter_form_dates(qs, form, ("created_at", "completed_at"))
+    qs = filter_form_dates(qs, form, ("created_at", "completed_at"))
     if form.cleaned_data.get("key"):
         key_q = Q(key__icontains=form.cleaned_data["key"][0])
         for other in form.cleaned_data["key"][1:]:
@@ -1216,7 +1183,7 @@ def downloads_missing(request):
 
 
 def filter_missing_symbols(qs, form):
-    qs = _filter_form_dates(qs, form, ("created_at", "modified_at"))
+    qs = filter_form_dates(qs, form, ("created_at", "modified_at"))
     for operator, value in form.cleaned_data["count"]:
         orm_operator = "count__{}".format(ORM_OPERATORS[operator])
         qs = qs.filter(**{orm_operator: value})

--- a/tecken/base/form_utils.py
+++ b/tecken/base/form_utils.py
@@ -1,0 +1,40 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Form-related utilities"""
+
+import datetime
+
+
+ORM_OPERATORS = {"<=": "lte", ">=": "gte", "=": "exact", "<": "lt", ">": "gt"}
+
+
+def filter_form_dates(qs, form, keys):
+    for key in keys:
+        for operator, value in form.cleaned_data.get(key, []):
+            if value is None:
+                orm_operator = f"{key}__isnull"
+                qs = qs.filter(**{orm_operator: True})
+            elif operator == "=" and (
+                not isinstance(value, datetime.datetime)
+                or value.hour == 0
+                and value.minute == 0
+            ):
+                # When querying on a specific day, make it a little easier
+                qs = qs.filter(
+                    **{
+                        f"{key}__gte": value,
+                        f"{key}__lt": value + datetime.timedelta(days=1),
+                    }
+                )
+            else:
+                if operator == ">":
+                    # Because we use microseconds in the ORM, but when
+                    # datetimes are passed back end forth in XHR, the datetimes
+                    # are converted with isoformat() which drops microseconds.
+                    # Therefore add 1 second to avoid matching the latest date.
+                    value += datetime.timedelta(seconds=1)
+                orm_operator = "{}__{}".format(key, ORM_OPERATORS[operator])
+                qs = qs.filter(**{orm_operator: value})
+    return qs

--- a/tecken/base/form_utils.py
+++ b/tecken/base/form_utils.py
@@ -6,6 +6,8 @@
 
 import datetime
 
+from django import forms
+
 
 ORM_OPERATORS = {"<=": "lte", ">=": "gte", "=": "exact", "<": "lt", ">": "gt"}
 
@@ -38,3 +40,17 @@ def filter_form_dates(qs, form, keys):
                 orm_operator = "{}__{}".format(key, ORM_OPERATORS[operator])
                 qs = qs.filter(**{orm_operator: value})
     return qs
+
+
+class PaginationForm(forms.Form):
+    page = forms.CharField(required=False)
+
+    def clean_page(self):
+        value = self.cleaned_data["page"]
+        try:
+            value = int(value or 1)
+        except ValueError:
+            raise forms.ValidationError(f"Not a number {value!r}")
+        if value < 1:
+            value = 1
+        return value

--- a/tecken/download/forms.py
+++ b/tecken/download/forms.py
@@ -2,10 +2,97 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import datetime
+import re
+
+import dateutil
+
 from django import forms
+from django.utils import timezone
+
+
+class PaginationForm(forms.Form):
+    page = forms.CharField(required=False)
+
+    def clean_page(self):
+        value = self.cleaned_data["page"]
+        try:
+            value = int(value or 1)
+        except ValueError:
+            raise forms.ValidationError(f"Not a number {value!r}")
+        if value < 1:
+            value = 1
+        return value
 
 
 class DownloadForm(forms.Form):
-
     code_file = forms.CharField(required=False)
     code_id = forms.CharField(required=False)
+
+
+class DownloadsMissingForm(forms.Form):
+    symbol = forms.CharField(required=False)
+    debugid = forms.CharField(required=False)
+    filename = forms.CharField(required=False)
+    code_file = forms.CharField(required=False)
+    code_id = forms.CharField(required=False)
+    modified_at = forms.CharField(required=False)
+    sort = forms.CharField(required=False)
+    reverse = forms.CharField(required=False)
+
+    def _clean_dates(self, values):
+        """Return a list of either a date or None.
+
+        Each one can have an operator.
+
+        """
+        if not values:
+            return []
+        dates = []
+        operators = re.compile("<=|>=|<|>|=")
+        for block in [x.strip() for x in values.split(",") if x.strip()]:
+            if operators.findall(block):
+                (operator,) = operators.findall(block)
+            else:
+                operator = "="
+            rest = operators.sub("", block).strip()
+            if rest.lower() in ("null", "incomplete"):
+                date_obj = None
+            elif rest.lower() == "today":
+                date_obj = timezone.now().replace(hour=0, minute=0, second=0)
+            elif rest.lower() == "yesterday":
+                date_obj = timezone.now().replace(hour=0, minute=0, second=0)
+                date_obj -= datetime.timedelta(days=1)
+            else:
+                try:
+                    date_obj = dateutil.parser.parse(rest)
+                except ValueError:
+                    raise forms.ValidationError(f"Unable to parse {rest!r}")
+                if timezone.is_naive(date_obj):
+                    date_obj = timezone.make_aware(date_obj)
+            dates.append((operator, date_obj.date()))
+
+        return dates
+
+    def clean_modified_at(self):
+        return self._clean_dates(self.cleaned_data["modified_at"])
+
+    def clean_sort(self):
+        value = self.cleaned_data["sort"]
+        if value and value not in ["modified_at", "created_at"]:
+            raise forms.ValidationError(f"Invalid sort '{value}'")
+        return value
+
+    def clean_reverse(self):
+        value = self.cleaned_data["reverse"]
+        if value:
+            return value == "true"
+
+    def clean(self):
+        cleaned = super().clean()
+        if cleaned.get("sort"):
+            cleaned["order_by"] = {
+                "sort": cleaned.pop("sort"),
+                "reverse": cleaned.pop("reverse"),
+            }
+        return cleaned

--- a/tecken/download/forms.py
+++ b/tecken/download/forms.py
@@ -11,20 +11,6 @@ from django import forms
 from django.utils import timezone
 
 
-class PaginationForm(forms.Form):
-    page = forms.CharField(required=False)
-
-    def clean_page(self):
-        value = self.cleaned_data["page"]
-        try:
-            value = int(value or 1)
-        except ValueError:
-            raise forms.ValidationError(f"Not a number {value!r}")
-        if value < 1:
-            value = 1
-        return value
-
-
 class DownloadForm(forms.Form):
     code_file = forms.CharField(required=False)
     code_id = forms.CharField(required=False)

--- a/tecken/download/urls.py
+++ b/tecken/download/urls.py
@@ -36,7 +36,8 @@ register_converter(LegacyProductPrefixesConverter, "legacyproduct")
 app_name = "download"
 
 urlpatterns = [
-    path("missingsymbols.csv", views.missing_symbols_csv, name="missing_symbols_csv"),
+    path("missingsymbols.csv", views.missingsymbols_csv, name="missingsymbols_csv"),
+    path("missingsymbols/", views.missingsymbols, name="missingsymbols"),
     path(
         "try/<str:symbol>/<hex:debugid>/<str:filename>",
         views.download_symbol_try,

--- a/tecken/download/views.py
+++ b/tecken/download/views.py
@@ -15,13 +15,13 @@ from tecken.base.decorators import (
     api_require_http_methods,
     set_cors_headers,
 )
-from tecken.base.form_utils import filter_form_dates
+from tecken.base.form_utils import filter_form_dates, PaginationForm
 from tecken.base.symboldownloader import SymbolDownloader
 from tecken.base.utils import invalid_key_name_characters
 from tecken.download.models import MissingSymbol
 from tecken.download.utils import store_missing_symbol
 from tecken.download.tasks import store_missing_symbol_task
-from tecken.download.forms import DownloadForm, DownloadsMissingForm, PaginationForm
+from tecken.download.forms import DownloadForm, DownloadsMissingForm
 from tecken.storage import StorageBucket
 
 logger = logging.getLogger("tecken")

--- a/tecken/download/views.py
+++ b/tecken/download/views.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import csv
 import datetime
 import logging
@@ -14,17 +10,18 @@ from django.conf import settings
 from django.utils import timezone
 from django.db import OperationalError
 
-from tecken.base.utils import invalid_key_name_characters
-from tecken.base.symboldownloader import SymbolDownloader
 from tecken.base.decorators import (
     set_request_debug,
     api_require_http_methods,
     set_cors_headers,
 )
+from tecken.base.form_utils import filter_form_dates
+from tecken.base.symboldownloader import SymbolDownloader
+from tecken.base.utils import invalid_key_name_characters
 from tecken.download.models import MissingSymbol
 from tecken.download.utils import store_missing_symbol
 from tecken.download.tasks import store_missing_symbol_task
-from tecken.download.forms import DownloadForm
+from tecken.download.forms import DownloadForm, DownloadsMissingForm, PaginationForm
 from tecken.storage import StorageBucket
 
 logger = logging.getLogger("tecken")
@@ -183,6 +180,7 @@ def log_symbol_get_404(symbol, debugid, filename, code_file="", code_id=""):
     stackwalker is actually aware of other parameters that are
     relevant only to this URL. Hence 'code_file' and 'code_id' which
     are both optional.
+
     """
     if settings.ENABLE_STORE_MISSING_SYMBOLS:
         try:
@@ -195,26 +193,18 @@ def log_symbol_get_404(symbol, debugid, filename, code_file="", code_id=""):
             )
 
 
-def missing_symbols_csv(request):
-    """return a CSV payload that has yesterdays missing symbols.
+@metrics.timer("missingsymbols_csv")
+def missingsymbols_csv(request):
+    """Return a CSV payload that has yesterdays missing symbols
 
-    We have a record of every 'symbol', 'debugid', 'filename', 'code_file'
-    and 'code_id'. In the CSV export we only want 'symbol', 'debugid',
-    'code_file' and 'code_id'.
+    We have a record of every 'symbol', 'debugid', 'filename', 'code_file' and
+    'code_id'. In the CSV export we only want 'symbol', 'debugid', 'code_file'
+    and 'code_id'.
 
-    There's an opportunity of optimization here.
-    This payload is pretty large and requires a lot of memory to generate
-    and respond. We could instead use an S3 bucket to store this and
-    let S3 handle the download repeatedly.
+    FIXME(willkg): This doesn't change day-to-day (unless you specify today, so
+    maybe we should generate this and save/cache it?
 
-    Note that this view is expected to be quite resource intensive.
-    In Socorro we used to upload a .csv file to S3 on a daily basis.
-    This file is what's downloaded and parsed to figure what needs to be
-    improved in the symbol store ultimately. We could do some serious
-    caching of this view by letting it generate *to* S3 if it hasn't
-    already been generated and uploaded to S3.
     """
-
     date = timezone.now()
     if not request.GET.get("today"):
         # By default we want to look at keys inserted yesterday, but
@@ -240,10 +230,66 @@ def missing_symbols_csv(request):
         filename__iendswith=".sym",
     )
 
-    only = ("symbol", "debugid", "code_file", "code_id")
-    for missing in qs.only(*only):
-        writer.writerow(
-            [missing.symbol, missing.debugid, missing.code_file, missing.code_id]
-        )
+    fields = ("symbol", "debugid", "code_file", "code_id")
+    for missing in qs.values_list(*fields):
+        writer.writerow(missing)
 
     return response
+
+
+@metrics.timer("missingsymbols")
+def missingsymbols(request):
+    context = {}
+    form = DownloadsMissingForm(request.GET)
+    if not form.is_valid():
+        return http.JsonResponse({"errors": form.errors}, status=400)
+
+    qs = MissingSymbol.objects.all()
+    # Apply date filters
+    qs = filter_form_dates(qs, form, ("created_at", "modified_at"))
+
+    # Apply symbol, debugid, filename filters
+    for key in ("symbol", "debugid", "filename"):
+        if form.cleaned_data[key]:
+            qs = qs.filter(**{f"{key}__contains": form.cleaned_data[key]})
+
+    # Apply order_by
+    if form.cleaned_data.get("order_by"):
+        order_by = form.cleaned_data["order_by"]
+    else:
+        order_by = {"sort": "modified_at", "reverse": True}
+    order_by_string = ("-" if order_by["reverse"] else "") + order_by["sort"]
+    qs = qs.order_by(order_by_string)
+    context["order_by"] = order_by
+
+    # Figure out page
+    pagination_form = PaginationForm(request.GET)
+    if not pagination_form.is_valid():
+        return http.JsonResponse({"errors": pagination_form.errors}, status=400)
+
+    page = pagination_form.cleaned_data["page"]
+
+    batch_size = 100
+    context["batch_size"] = batch_size
+    context["page"] = page
+
+    start = (page - 1) * batch_size
+    end = start + batch_size
+
+    context["total_count"] = qs.count()
+
+    qs = qs.values(
+        "id",
+        "symbol",
+        "debugid",
+        "filename",
+        "code_file",
+        "code_id",
+        "count",
+        "modified_at",
+        "created_at",
+    )
+
+    context["records"] = list(qs[start:end])
+
+    return http.JsonResponse(context)

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -543,9 +543,10 @@ class Base(Core):
     # A list of file extensions that if a file is NOT one of these extensions
     # we can immediately return 404 and not bother to process for anything
     # else.
-    # It's case sensitive and has to be lower case.
-    # As a way to get marginal optimization of this, make sure '.sym' is
-    # first in the list since it's the most common.
+    #
+    # It's case sensitive and has to be lower case.  As a way to get marginal
+    # optimization of this, make sure '.sym' is first in the list since it's
+    # the most common.
     DOWNLOAD_FILE_EXTENSIONS_ALLOWED = values.ListValue(
         [".sym", ".dl_", ".ex_", ".pd_", ".dbg.gz", ".tar.bz2"]
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,15 +4,15 @@
 
 import json
 import tempfile
+from unittest import mock
 
-import pytest
-import mock
-import requests_mock
 import botocore
 from markus.testing import MetricsMock
+import pytest
+import requests_mock
 
-from django.core.cache import caches
 from django.contrib.auth.models import User
+from django.core.cache import caches
 
 
 @pytest.fixture

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -8,8 +8,8 @@ import os
 from io import BytesIO, StringIO
 from unittest import mock
 
-import pytest
 from botocore.exceptions import ClientError
+import pytest
 from requests.exceptions import ConnectionError, RetryError
 
 from django.contrib.auth.models import Permission, User
@@ -21,21 +21,21 @@ from django.utils import timezone
 from tecken.base.symboldownloader import SymbolDownloader
 from tecken.storage import StorageBucket
 from tecken.tokens.models import Token
-from tecken.upload.models import Upload, FileUpload, UploadsCreated
 from tecken.upload import utils
-from tecken.upload.views import (
-    NoPossibleBucketName,
-    get_bucket_info,
-    get_possible_bucket_urls,
-)
 from tecken.upload.forms import UploadByDownloadForm, UploadByDownloadRemoteError
+from tecken.upload.models import Upload, FileUpload, UploadsCreated
+from tecken.upload.tasks import update_uploads_created_task
 from tecken.upload.utils import (
     dump_and_extract,
     key_existing,
     should_compressed_key,
     get_key_content_type,
 )
-from tecken.upload.tasks import update_uploads_created_task
+from tecken.upload.views import (
+    NoPossibleBucketName,
+    get_bucket_info,
+    get_possible_bucket_urls,
+)
 
 
 def _join(x):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,13 +4,13 @@
 
 import json
 import os
+from unittest import mock
 
 import pytest
-import mock
 
-from django.urls import reverse
-from django.core.exceptions import PermissionDenied
 from django.core.cache import cache
+from django.core.exceptions import PermissionDenied
+from django.urls import reverse
 
 from tecken.tasks import sample_task
 from tecken.views import handler500, handler400, handler403


### PR DESCRIPTION
Previously, we had a `/missingsymbols.csv` endpoint which returned missing symbol data from yesterday as a CSV.

This adds a `/missingsymbols/` endpoint which lets you query missing symbol data.

This is a first-pass to get something on stage that Gabriele can test out to see if it meets his needs.

This needs:

1. a systemtest because it's officially supported
2. documentation

I'll probably do item 2 in this PR.