### PR TITLE
bug 1667213: reduce race condition between tests and services

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -12,6 +12,10 @@ set -eo pipefail
 # create a frontend/build/ directory if it doesn't exist
 [ ! -d frontend/build/ ] && mkdir -p frontend/build/
 
+# start services--this gives them a little time to start up before we
+# start the test container
+docker-compose up -d db redis-store redis-cache minio statsd oidcprovider
+
 # default variables
 export DEVELOPMENT=1
 export DJANGO_CONFIGURATION=Test


### PR DESCRIPTION
The tests are kicking off before the backing services have started up.

What we should really be doing is using urlwait or something like that
which will cause everything to pause while the service is coming up, but
because of the way configuration works, we may not have the service urls
in the environment so we'll have to go with this "start it up a little
bit before" method for now.