### PR TITLE
Fixes to systemtests

### DIFF
--- a/systemtests/bin/symbolicate.py
+++ b/systemtests/bin/symbolicate.py
@@ -103,7 +103,12 @@ def print_stack(ctx, api_url, api_version, debug, stackfile):
             param_hint="api_version",
         )
 
-    payload = json.loads(data)
+    try:
+        payload = json.loads(data)
+    except json.decoder.JSONDecodeError as jde:
+        click.echo("Error: request is not valid JSON: %r\n%r" % (jde, data))
+        return
+
     response_data = request_stack(api_url, payload, api_version, debug)
     if debug:
         click.echo(json.dumps(response_data, indent=2))

--- a/systemtests/data/sym_files_to_download.csv
+++ b/systemtests/data/sym_files_to_download.csv
@@ -18,7 +18,7 @@ libmozglue.dylib/11FB836EE6723C07BFF775900077457B0/libmozglue.dylib.sym,200
 libEGL.so/8787CB75CD6E976D87477CA9AC1EB98D0/libEGL.so.sym,404
 libvlc.dll/3BDB3BCF29000/libvlc.dl_,404
 
-# These are in the private bucket, so they're 403. However, since we're not
-# using a token, they show up as 404.
+# These are in the private bucket which isn't accessible via the
+# downloading API, so these return a 404.
 libc.so/8B654FF16EA5103DF06284EDA4EE8C730/libc.so.sym,404
 libsqlite.so/2D932347B05044E333C97A1915A08ADA0/libsqlite.so.sym,404


### PR DESCRIPTION
This improves the error message for a user when the stack to be
symbolicated isn't valid JSON.

This fixes the comment in the `sym_files_to_download.csv` to be
correct--the response HTTP status code doesn't have anything to do with
tokens.