### PR TITLE
bug 1669498: handle upload-by-download download url failure

### DIFF
--- a/docs/upload.rst
+++ b/docs/upload.rst
@@ -206,6 +206,8 @@ Upload: /upload/
    :form try: use ``try=1`` if this is an upload of try symbols
 
    :statuscode 201: successful upload of symbols
+   :statuscode 400: if the specified url can't be downloaded; verify that the url
+       can be downloaded and retry
    :statuscode 403: your auth token is invalid and you need to get a new one
    :statuscode 413: your upload is too large; split it into smaller files or switch to
        upload by download url

--- a/tecken/upload/views.py
+++ b/tecken/upload/views.py
@@ -218,6 +218,18 @@ def upload_archive(request, upload_dir):
                         response_stream = requests.get(
                             url, stream=True, timeout=(5, 300)
                         )
+                        # NOTE(willkg): The UploadByDownloadForm handles most errors
+                        # when it does a HEAD, so this mostly covers transient errors
+                        # between the HEAD and this GET request.
+                        if response_stream.status_code != 200:
+                            return http.JsonResponse(
+                                {
+                                    "error": "non-200 status code when retrieving %s"
+                                    % url
+                                },
+                                status=400,
+                            )
+
                         with open(download_name, "wb") as f:
                             # Read 1MB at a time
                             chunk_size = 1024 * 1024


### PR DESCRIPTION
If the specified url in an upload-by-download request can't be downloaded, the `UploadByDownloadForm` will probably catch it when it does a HEAD request. It's vaguely possible that if the HEAD succeeds, the following GET might fail.

This adds some minor handling in the case where the HEAD succeeds and the GET fails. It returns an HTTP 400 telling the user the error. The user should check the download works and retry.