### PR TITLE
bug 1669519: always set a timeout when using requests

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -32,7 +32,7 @@ web)  ## Run Tecken web service
     exec ./bin/run_web.sh $@
     ;;
 worker)  ## Run Celery worker
-    exec ${CMD_PREFIX} celery -A tecken.celery:app worker -l info
+    exec ${CMD_PREFIX} celery -A tecken.celery:app worker --loglevel INFO
     ;;
 worker-purge)  ## Purge Celery tasks
     # Start worker but first purge ALL old stale tasks.
@@ -40,7 +40,7 @@ worker-purge)  ## Purge Celery tasks
     # started waaaay too make background tasks when debugging something.
     # Or perhaps the jobs belong to the wrong branch as you stop/checkout/start
     # the docker container.
-    exec celery -A tecken.celery:app worker -l info --purge
+    exec celery -A tecken.celery:app worker --loglevel INFO --purge
     ;;
 bash)  ## Open a bash shell or run something else
     if [ -z "$*" ]; then

--- a/tecken/base/utils.py
+++ b/tecken/base/utils.py
@@ -4,47 +4,7 @@
 
 import re
 
-import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
-
 from django.template.defaultfilters import filesizeformat as dj_filesizeformat
-
-
-def requests_retry_session(
-    retries=3, backoff_factor=0.3, status_forcelist=(500, 502, 504)
-):
-    """Opinionated wrapper that creates a requests session with a
-    HTTPAdapter that sets up a Retry policy that includes connection
-    retries.
-
-    If you do the more naive retry by simply setting a number. E.g.::
-
-        adapter = HTTPAdapter(max_retries=3)
-
-    then it will raise immediately on any connection errors.
-    Retrying on connection errors guards better on unpredictable networks.
-    From https://2.python-requests.org/en/master/api/?highlight=retries#requests.adapters.HTTPAdapter
-    it says: "By default, Requests does not retry failed connections."
-
-    The backoff_factor is documented here:
-    https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.retry.Retry
-    A default of retries=3 and backoff_factor=0.3 means it will sleep like::
-
-        [0.3, 0.6, 1.2]
-    """  # noqa
-    session = requests.Session()
-    retry = Retry(
-        total=retries,
-        read=retries,
-        connect=retries,
-        backoff_factor=backoff_factor,
-        status_forcelist=status_forcelist,
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    return session
 
 
 def filesizeformat(bytes):

--- a/tecken/requests_extra.py
+++ b/tecken/requests_extra.py
@@ -1,0 +1,79 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+
+class HTTPAdapterWithTimeout(HTTPAdapter):
+    """HTTPAdapter with a default timeout
+
+    This allows you to set a default timeout when creating the adapter.
+    It can be overridden here as well as when doing individual
+    requests.
+
+    :arg varies default_timeout: number of seconds before timing out
+
+        This can be a float or a (connect timeout, read timeout) tuple
+        of floats.
+
+        Defaults to 5.0 seconds.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._default_timeout = kwargs.pop("default_timeout", 5.0)
+        super().__init__(*args, **kwargs)
+
+    def send(self, *args, **kwargs):
+        # If there's a timeout, use that. Otherwise, use the default.
+        kwargs["timeout"] = kwargs.get("timeout") or self._default_timeout
+        return super().send(*args, **kwargs)
+
+
+def session_with_retries(
+    total_retries=5,
+    backoff_factor=0.2,
+    status_forcelist=(429, 500),
+    default_timeout=5.0,
+):
+    """Returns session that retries on HTTP 429 and 500 with default timeout
+
+    :arg int total_retries: total number of times to retry
+
+    :arg float backoff_factor: number of seconds to increment by between
+        attempts
+
+        For example, 0.1 will back off 0.1s, then 0.2s, then 0.3s, ...
+
+    :arg tuple of HTTP codes status_forcelist: tuple of HTTP codes to
+        retry on
+
+    :arg varies default_timeout: number of seconds before timing out
+
+        This can be a float or a (connect timeout, read timeout) tuple
+        of floats.
+
+    :returns: a requests Session instance
+
+    """
+    retries = Retry(
+        total=total_retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=list(status_forcelist),
+    )
+
+    session = requests.Session()
+
+    # Set the User-Agent header so we can distinguish our stuff from other stuff
+    session.headers.update({"User-Agent": "tecken-requests/1.0"})
+
+    adapter = HTTPAdapterWithTimeout(
+        max_retries=retries, default_timeout=default_timeout
+    )
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    return session

--- a/tecken/upload/forms.py
+++ b/tecken/upload/forms.py
@@ -10,7 +10,7 @@ from requests.exceptions import ConnectionError, RetryError
 from django import forms
 from django.conf import settings
 
-from tecken.base.utils import requests_retry_session
+from tecken.requests_extra import session_with_retries
 
 
 class UploadByDownloadRemoteError(Exception):
@@ -75,7 +75,7 @@ class UploadByDownloadForm(forms.Form):
 
         def get_response(url):
             try:
-                response = requests_retry_session().head(url)
+                response = session_with_retries().head(url)
                 status_code = response.status_code
             except ConnectionError:
                 raise UploadByDownloadRemoteError(

--- a/tecken/useradmin/management/commands/is-blocked-in-auth0.py
+++ b/tecken/useradmin/management/commands/is-blocked-in-auth0.py
@@ -4,11 +4,10 @@
 
 from urllib.parse import urlparse
 
-import requests
-
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
+from tecken.requests_extra import session_with_retries
 from tecken.useradmin.middleware import find_users
 
 
@@ -22,12 +21,13 @@ class Command(BaseCommand):
         email = options["email"]
         if " " in email or email.count("@") != 1:
             raise CommandError(f"Invalid email {email!r}")
+        session = session_with_retries()
         users = find_users(
             settings.OIDC_RP_CLIENT_ID,
             settings.OIDC_RP_CLIENT_SECRET,
             urlparse(settings.OIDC_OP_USER_ENDPOINT).netloc,
             email,
-            requests,
+            session,
         )
         for user in users:
             if user.get("blocked"):

--- a/tecken/useradmin/middleware.py
+++ b/tecken/useradmin/middleware.py
@@ -12,7 +12,7 @@ from django.core.cache import cache
 from django.core.exceptions import MiddlewareNotUsed, PermissionDenied
 from django.contrib import auth
 
-from tecken.base.utils import requests_retry_session
+from tecken.requests_extra import session_with_retries
 
 
 logger = logging.getLogger("tecken")
@@ -25,7 +25,7 @@ class Auth0ManagementAPIError(Exception):
 
 @metrics.timer_decorator("useradmin_is_blocked_in_auth0")
 def is_blocked_in_auth0(email):
-    session = requests_retry_session(retries=5)
+    session = session_with_retries(total_retries=5)
     users = find_users(
         settings.OIDC_RP_CLIENT_ID,
         settings.OIDC_RP_CLIENT_SECRET,


### PR DESCRIPTION
The requests library defaults to an infinite timeout, so it's possible that a request could cause a Python process to hang forever. That's super bad for Tecken, so this fixes requests uses to always have a default timeout and always retry.