### PR TITLE
bug 1674406: reimplement metrics in Eliot and add new ones

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,9 @@ sys.path.insert(0, str(BASEDIR))
 # Insert Eliot base dir for Eliot things
 sys.path.insert(0, str(BASEDIR / "eliot-service"))
 
+# Insert this directory to pick up extensions
+sys.path.insert(0, str(Path(__file__).parent))
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -48,6 +51,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinxcontrib.httpdomain",
     "everett.sphinxext",
+    "exts.eliot_metrics",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -425,6 +425,14 @@ The disk cache manager process deletes least recently used items from the disk
 cache to keep it under ``ELIOT_SYMBOLS_CACHE_MAX_SIZE`` bytes.
 
 
+.. _dev-eliot-metrics:
+
+Metrics
+-------
+
+.. autometrics:: eliot.libmarkus.ELIOT_METRICS
+
+
 .. _dev-eliot-tests:
 
 Python tests for Eliot

--- a/docs/exts/eliot_metrics.py
+++ b/docs/exts/eliot_metrics.py
@@ -1,0 +1,109 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Generates the documentation for Eliot metrics."""
+
+import importlib
+import sys
+import textwrap
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.statemachine import ViewList
+
+
+def build_table(table):
+    col_size = [0] * len(table[0])
+    for row in table:
+        for i, col in enumerate(row):
+            col_size[i] = max(col_size[i], len(col))
+
+    col_size = [width + 2 for width in col_size]
+
+    yield "  ".join("=" * width for width in col_size)
+    yield "  ".join(
+        header + (" " * (width - len(header)))
+        for header, width in zip(table[0], col_size)
+    )
+    yield "  ".join("=" * width for width in col_size)
+    for row in table[1:]:
+        yield "  ".join(
+            col + (" " * (width - len(col)))
+            for col, width in zip(row, col_size)
+        )
+    yield "  ".join("=" * width for width in col_size)
+
+
+class AutoMetricsDirective(Directive):
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+
+    option_spec = {}
+
+    def add_line(self, line, source, *lineno):
+        """Add a line to the result"""
+        self.result.append(line, source, *lineno)
+
+    def generate_docs(self, clspath):
+        modpath, name = clspath.rsplit(".", 1)
+        importlib.import_module(modpath)
+        module = sys.modules[modpath]
+        metrics = getattr(module, name)
+
+        sourcename = "metrics of %s" % clspath
+
+        # First build a table of metric items
+        self.add_line("Table of metrics:", sourcename)
+        self.add_line("", sourcename)
+
+        table = []
+        table.append(("Key", "Type"))
+        for key, metric in metrics.items():
+            table.append((":py:data:`%s`" % key, metric.stat_type))
+
+        for line in build_table(table):
+            self.add_line(line, sourcename)
+
+        self.add_line("", sourcename)
+        self.add_line("Metrics details:", sourcename)
+        self.add_line("", sourcename)
+
+        for key, metric in metrics.items():
+            self.add_line(".. py:data:: %s" % key, sourcename)
+            self.add_line("", sourcename)
+            self.add_line("", sourcename)
+            self.add_line("   Type: %s" % metric.stat_type, sourcename)
+            self.add_line("", sourcename)
+            self.add_line("", sourcename)
+            for line in textwrap.dedent(metric.description).splitlines():
+                self.add_line("   " + line, sourcename)
+            self.add_line("", sourcename)
+            self.add_line("", sourcename)
+
+    def run(self):
+        self.reporter = self.state.document.reporter
+        self.result = ViewList()
+
+        self.generate_docs(self.arguments[0])
+
+        if not self.result:
+            return []
+
+        node = nodes.paragraph()
+        node.document = self.state.document
+        self.state.nested_parse(self.result, 0, node)
+        return node.children
+
+
+def setup(app):
+    """Register directive in Sphinx."""
+    app.add_directive("autometrics", AutoMetricsDirective)
+
+    return {
+        "version": 1.0,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/eliot-service/eliot/cache.py
+++ b/eliot-service/eliot/cache.py
@@ -10,12 +10,12 @@ import logging
 from pathlib import Path
 import re
 import tempfile
+import time
 
-import markus
+from eliot.libmarkus import METRICS
 
 
 LOGGER = logging.getLogger(__name__)
-METRICS = markus.get_metrics(__name__)
 
 
 NO_DEFAULT = object()
@@ -87,18 +87,28 @@ class DiskCache:
         :raises KeyError: if there's no key and no default is given
 
         """
+        error = False
+        start_time = time.perf_counter()
         filepath = self.key_to_filepath(key)
         if filepath.is_file():
             try:
                 with filepath.open(mode="rb") as fp:
                     data = fp.read()
-                    METRICS.incr("diskcache.cache_hit")
+                    delta = (time.perf_counter() - start_time) * 1000.0
+                    METRICS.histogram(
+                        "eliot.diskcache.get", value=delta, tags=["result:hit"]
+                    )
                     return data
             except (OSError, IOError):
-                METRICS.incr("diskcache.read_error")
+                error = True
                 LOGGER.exception("Cache error on read")
 
-        METRICS.incr("diskcache.cache_miss")
+        delta = (time.perf_counter() - start_time) * 1000.0
+        METRICS.histogram(
+            "eliot.diskcache.get",
+            value=delta,
+            tags=["result:" + ("error" if error else "miss")],
+        )
         if default != NO_DEFAULT:
             return default
         raise KeyError(f"key {filepath!r} does not exist")
@@ -112,6 +122,8 @@ class DiskCache:
         :arg bytes data: the data to save
 
         """
+        result = ""
+        start_time = time.perf_counter()
         filepath = self.key_to_filepath(key)
 
         # Save the file to a temp file and then rename that so as to avoid race
@@ -125,7 +137,11 @@ class DiskCache:
 
             filepath.parent.mkdir(parents=True, exist_ok=True)
             Path(temp_fp.name).rename(filepath)
+            result = "success"
 
         except (IOError, OSError):
             LOGGER.exception("Exception when writing to disk cache")
-            METRICS.incr("diskcache.write_error")
+            result = "fail"
+
+        delta = (time.perf_counter() - start_time) * 1000.0
+        METRICS.histogram("eliot.diskcache.set", value=delta, tags=["result:" + result])

--- a/eliot-service/eliot/libmarkus.py
+++ b/eliot-service/eliot/libmarkus.py
@@ -6,10 +6,155 @@
 Utilities for setting up markus.
 """
 
+from dataclasses import dataclass
+import logging
+
 import markus
+from markus.main import MetricsFilter
 
 
 _IS_MARKUS_SETUP = False
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Metric:
+    stat_type: str
+    description: str
+
+
+# Complete index of all Eliot metrics. This is used in documentation and to filter
+# outgoing metrics.
+ELIOT_METRICS = {
+    "eliot.symbolicate.api": Metric(
+        stat_type="histogram",
+        description="""\
+        Timer for long a symbolication API request takes to handle.
+
+        Tags:
+
+        * ``version``: the symbolication api version
+
+           * ``v4``: the v4 API
+           * ``v5``: the v5 API
+        """,
+    ),
+    "eliot.symbolicate.request_error": Metric(
+        stat_type="incr",
+        description="""\
+        Counter for errors in incoming symbolication requests.
+
+        Tags:
+
+        * ``reason``: the error reason
+
+          * ``bad_json``: the payload is not valid JSON
+          * ``invalid_modules``: the payload has invalid modules
+          * ``invalid_stacks``: the payload has invalid stacks
+          * ``too_many_jobs``: (v5) the payload has too many jobs in it
+        """,
+    ),
+    "eliot.downloader.download": Metric(
+        stat_type="histogram",
+        description="""\
+        Timer for how long it takes to download SYM files.
+
+        Tags:
+
+        * ``response``: the HTTP response we got back
+
+          * ``success``: HTTP 200
+          * ``fail``: HTTP 404, 500, etc
+        """,
+    ),
+    "eliot.symbolicate.parse_sym_file.error": Metric(
+        stat_type="incr",
+        description="""\
+        Counter for when a sym file fails to parse.
+
+        Tags:
+
+        * ``reason``: the reason it failed to parse
+
+          * ``bad_debug_id``: debug_id is not valid
+          * ``sym_debug_id_lookup_error``: when the debug_id isn't in the sym file
+          * ``sym_tmp_file_error``: error creating tmp file to save the sym file
+            to disk
+        """,
+    ),
+    "eliot.symbolicate.parse_sym_file.parse": Metric(
+        stat_type="timing",
+        description="""\
+        Timer for how long it takes to parse sym files with Symbolic.
+        """,
+    ),
+    "eliot.symbolicate.num_jobs": Metric(
+        stat_type="gauge",
+        description="""\
+        Gauge for how many jobs were in the symbolication request.
+
+        Tags:
+
+        * ``version``: the symbolication api version
+
+           * ``v4``: the v4 API
+           * ``v5``: the v5 API
+        """,
+    ),
+    "eliot.symbolicate.num_stacks": Metric(
+        stat_type="gauge",
+        description="""\
+        Gauge for how many stacks per job were in the symbolication request.
+
+        Tags:
+
+        * ``version``: the symbolication api version
+
+           * ``v4``: the v4 API
+           * ``v5``: the v5 API
+        """,
+    ),
+    "eliot.symbolicate.num_frames": Metric(
+        stat_type="gauge",
+        description="""\
+        Gauge for how many frames per stack were in the symbolication request.
+        """,
+    ),
+    "eliot.diskcache.get": Metric(
+        stat_type="histogram",
+        description="""\
+        Timer for how long it takes to get symcache files from the disk cache.
+
+        Tags:
+
+        * ``result``: the cache result
+
+          * ``hit``: the file was in cache
+          * ``error``: the file was in cache, but there was an error reading it
+          * ``miss``: the file was not in cache
+        """,
+    ),
+    "eliot.diskcache.set": Metric(
+        stat_type="histogram",
+        description="""\
+        Timer for how long it takes to save a symcache file to the disk cache.
+
+        Tags:
+
+        * ``result``: the cache result
+
+          * ``success``: the file was saved successfully
+          * ``fail``: the file was not saved successfully
+        """,
+    ),
+    "eliot.diskcache.evict": Metric(
+        stat_type="incr",
+        description="""\
+        Counter for disk cache evictions.
+        """,
+    ),
+}
 
 
 def setup_metrics(app_config, logger=None):
@@ -40,3 +185,28 @@ def setup_metrics(app_config, logger=None):
         )
     markus.configure(markus_backends)
     _IS_MARKUS_SETUP = True
+
+
+class RegisteredMetricsFilter(MetricsFilter):
+    """Filter for enforcing registered metrics emission."""
+
+    def __init__(self, metrics):
+        self.metrics = metrics
+
+    def filter(self, record):
+        metric = self.metrics.get(record.key)
+        if metric is None:
+            LOGGER.warning("metrics key %r is unknown", record.key)
+
+        elif record.stat_type != metric.stat_type:
+            LOGGER.warning(
+                "metrics key %r has wrong type; got %s expecting %s",
+                record.key,
+                record.stat_type,
+                metric.stat_type,
+            )
+
+        return record
+
+
+METRICS = markus.get_metrics(filters=[RegisteredMetricsFilter(ELIOT_METRICS)])

--- a/eliot-service/tests/test_symbolicate_resource.py
+++ b/eliot-service/tests/test_symbolicate_resource.py
@@ -245,7 +245,10 @@ class TestSymbolicateBase:
                     f"Error looking up debug id in SYM file: {debug_filename} {debug_id}",
                 )
             ]
-            mm.assert_incr("eliot.symbolicate_resource.sym_debug_id_lookup_error")
+            mm.assert_incr(
+                "eliot.symbolicate.parse_sym_file.error",
+                tags=["reason:sym_debug_id_lookup_error"],
+            )
 
     def test_parse_sym_file_debugids(self, caplog, metricsmock, tmpdir):
         """Verify normalizing bad debug ids logs error and metric"""
@@ -262,7 +265,9 @@ class TestSymbolicateBase:
             assert caplog.record_tuples == [
                 ("eliot.symbolicate_resource", 40, "debug_id parse error: 'abcde'")
             ]
-            mm.assert_incr("eliot.symbolicate_resource.bad_debug_id")
+            mm.assert_incr(
+                "eliot.symbolicate.parse_sym_file.error", tags=["reason:bad_debug_id"]
+            )
 
     def test_get_symcache_in_cache(self, tmpcachedir, tmpdir):
         # Set up a DiskCache


### PR DESCRIPTION
This reimplements how metrics work in Eliot and adds the ones we need
for the bug.

The new system centralizes all the metrics that Eliot generates into a
single file. It adds an extension for extracting that data and
auto-generating documentation. It also shapes the metrics data as a
Markus MetricsFilter so it validates any metrics being emitted.

Adding a new metric involves adding it to ELIOT_METRICS and then adding
the code to emit the metric. That's about how much effort it was before,
so I think this seems promising. I'm inclined to redo Tecken webapp
accordingly.