### PR TITLE
Update pip-tools to 5.4.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ markus[datadog]==2.2.0
 mock==4.0.2
 mozilla-django-oidc==1.2.4
 msgpack==1.0.0
-pip-tools==5.3.1
+pip-tools==5.4.0
 psycopg2==2.8.6
 pytest-django==4.1.0
 pytest-mock==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -317,9 +317,9 @@ pathspec==0.8.0 \
     --hash=sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0 \
     --hash=sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061 \
     # via black
-pip-tools==5.3.1 \
-    --hash=sha256:5672c2b6ca0f1fd803f3b45568c2cf7fadf135b4971e7d665232b2075544c0ef \
-    --hash=sha256:73787e23269bf8a9230f376c351297b9037ed0d32ab0f9bef4a187d976acc054 \
+pip-tools==5.4.0 \
+    --hash=sha256:a4d3990df2d65961af8b41dacc242e600fdc8a65a2e155ed3d2fc18a5c209f20 \
+    --hash=sha256:b73f76fe6464b95e41d595a9c0302c55a786dbc54b63ae776c540c04e31914fb \
     # via -r requirements.in
 pluggy==0.13.1 \
     --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \


### PR DESCRIPTION
This fixes the issue where pip-compile was using something in pip that
isn't there anymore and throwing a TypeError.