### PR TITLE
bug 1681632: rework things so everything is in the cachedir

### DIFF
--- a/eliot-service/eliot/cache.py
+++ b/eliot-service/eliot/cache.py
@@ -37,7 +37,7 @@ class DiskCache:
     def __init__(self, cachedir, tmpdir):
         """
         :arg Path cachedir: location for cache--should already exist
-        :arg Path tmpdir: location for temp files--should already exist
+        :arg Path tmpdir: location for temporary files
         """
         self.cachedir = cachedir
         self.tmpdir = tmpdir

--- a/eliot-service/tests/conftest.py
+++ b/eliot-service/tests/conftest.py
@@ -26,13 +26,10 @@ from eliot.liblogging import setup_logging  # noqa
 
 def pytest_runtest_setup(item):
     # Clear out the tmp and cache dir from any sym files before tests run
-    tmp_dir = os.environ["ELIOT_TMP_DIR"]
-    cache_dir = os.environ["ELIOT_SYMBOLS_CACHE_DIR"]
+    cachedir = os.environ["ELIOT_SYMBOLS_CACHE_DIR"]
 
-    if os.path.exists(tmp_dir):
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-    if os.path.exists(cache_dir):
-        shutil.rmtree(cache_dir, ignore_errors=True)
+    if os.path.exists(cachedir):
+        shutil.rmtree(cachedir, ignore_errors=True)
 
 
 def pytest_collection_finish(session):


### PR DESCRIPTION
This reworks things so everything is in the cache dir. This fixes the
possible problem where the `symbols_tmp_dir` and `symbols_cache_dir` are
different volumes which causes Eliot to error out when moving files
between the two paths.