### PR TITLE
bug 1701832: remove MSGPackSerializer

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,6 @@ jsonschema==3.2.0
 markus[datadog]==3.0.0
 mock==4.0.3
 mozilla-django-oidc==1.2.4
-msgpack==1.0.2
 pip-tools==5.5.0
 psycopg2==2.8.6
 pytest-django==4.1.0
@@ -39,8 +38,13 @@ urllib3==1.25.11
 urlwait==1.0
 whitenoise==5.2.0
 
+# NOTE(willkg): django-redis doesn't have an install extras kind of thing, but
+# we use the django-redis MSGPackSerializer which uses msgpack so we need to
+# explicitly declare it a dependency
+msgpack==1.0.2
+
 # NOTE(willkg): Need to keep redis at this version because after this, the Python
-# library doesn't work with the version of Redis we're using in production.
+# library doesn't work with the version of Redis we're using in production
 redis==3.4.1
 
 # NOTE(willkg): Django 2.2 is an LTS series so don't upgrade until the next

--- a/tecken/cache_extra.py
+++ b/tecken/cache_extra.py
@@ -4,9 +4,6 @@
 
 import re
 
-import msgpack
-from django_redis.serializers.msgpack import MSGPackSerializer as _MSGPackSerializer
-
 from django.core.cache.backends.locmem import LocMemCache
 
 
@@ -44,32 +41,3 @@ class RedisLocMemCache(LocMemCache):
     @property
     def client(self):
         return MockClient()
-
-
-class MSGPackSerializer(_MSGPackSerializer):
-    """The only reason for this class is to be able to override the `loads` method
-    in the original django_redis.serializers.msg.MSGPackSerializer class.
-
-    In django_redis is uses `msgpack.loads(value, encoding='utf-8')` which is
-    deprecated in msgpack 0.6.0.
-
-    The reason django_redis can't easily make this change is that it would break
-    things for people who use msgpack <=0.5.1.
-    See https://github.com/niwinz/django-redis/issues/310
-    """
-
-    def loads(self, value):
-        # By default, msgpack.unpackb (which msgpack.loads is an alias for)
-        # has a limit to the max size of an array (a python list) and its
-        # value is 2**31 - 1 (=2,147,483,647) but we have seem symbol files
-        # with many more keys than that.
-        # Since we store the whole big list of ALL possible keys in the Redis
-        # cache, transported as a compressed msgpack byte stream, when we extract
-        # it back out we can hit this limit which results in an error like this:
-        #    `ValueError: 204599 exceeds max_array_len(131072)`
-        # So, because of the nature of our content, increase that default to
-        # 2**32 -1 (=4,294,967,295) which is double that. [Don't know what the
-        # point of the -1 is for]
-        # See documentation about overriding the default arguments:
-        # https://msgpack-python.readthedocs.io/en/latest/api.html#msgpack.Unpacker
-        return msgpack.loads(value, max_array_len=2 ** 32 - 1, raw=False)

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -308,8 +308,7 @@ class Base(Core):
                 "LOCATION": self.REDIS_URL,
                 "OPTIONS": {
                     "COMPRESSOR": "django_redis.compressors.zlib.ZlibCompressor",  # noqa
-                    # "SERIALIZER": "django_redis.serializers.msgpack.MSGPackSerializer",  # noqa
-                    "SERIALIZER": "tecken.cache_extra.MSGPackSerializer",  # noqa
+                    "SERIALIZER": "django_redis.serializers.msgpack.MSGPackSerializer",  # noqa
                     "SOCKET_CONNECT_TIMEOUT": self.REDIS_SOCKET_CONNECT_TIMEOUT,
                     "SOCKET_TIMEOUT": self.REDIS_SOCKET_TIMEOUT,
                     "IGNORE_EXCEPTIONS": self.REDIS_IGNORE_EXCEPTIONS,
@@ -320,7 +319,7 @@ class Base(Core):
                 "LOCATION": self.REDIS_STORE_URL,
                 "OPTIONS": {
                     "COMPRESSOR": "django_redis.compressors.zlib.ZlibCompressor",  # noqa
-                    "SERIALIZER": "tecken.cache_extra.MSGPackSerializer",  # noqa
+                    "SERIALIZER": "django_redis.serializers.msgpack.MSGPackSerializer",  # noqa
                     "SOCKET_CONNECT_TIMEOUT": self.REDIS_STORE_SOCKET_CONNECT_TIMEOUT,
                     "SOCKET_TIMEOUT": self.REDIS_STORE_SOCKET_TIMEOUT,
                 },


### PR DESCRIPTION
Tecken had a MSGPackSerializer that fixed an issue in django-redis
preventing us from using recent releases of msgpack. django-redis
released a version (4.12.0) that supports recent releases of msgpack, so
we don't need our MSGPackSerializer anymore.

Note that we need to keep msgpack in requirements.in because we use the
MSGPackSerializer from django-redis and django-redis doesn't have
msgpack in an install extras kind of thing.