### PR TITLE
bug 1699546: return correct value for "module" in symbolication

### DIFF
--- a/eliot-service/eliot/cache.py
+++ b/eliot-service/eliot/cache.py
@@ -12,6 +12,9 @@ import re
 import tempfile
 import time
 
+import msgpack
+import msgpack.exceptions
+
 from eliot.libmarkus import METRICS
 
 
@@ -21,8 +24,12 @@ LOGGER = logging.getLogger(__name__)
 NO_DEFAULT = object()
 
 
+class CacheReadError(Exception):
+    """Exception for errors hit when reading the cache from disk"""
+
+
 class DiskCache:
-    """Disk cache of symcache files.
+    """Disk cache of msgpack data files
 
     NOTE(willkg): This sets and checks the cache--it doesn't do any cleanup. The Disk
     Cache Manager watches the disk and enforces a max size by evicting least recently
@@ -75,6 +82,61 @@ class DiskCache:
         filepath = self.key_to_filepath(key)
         return filepath.exists()
 
+    def read_from_file(self, filepath):
+        """Reads data from a file
+
+        This reads from a file, unpacks it and returns the data.
+
+        :arg Path filepath: the file to read from
+
+        :returns: data as dict
+
+        :raises CacheReadError: if there's a problem reading from the cache file
+            or unpacking it
+
+        """
+        try:
+            with filepath.open("rb") as fp:
+                data = fp.read()
+
+            return msgpack.unpackb(data)
+
+        except (OSError, msgpack.exceptions.ExtraData):
+            raise CacheReadError(f"can't read {filepath} from cache")
+
+    def write_to_file(self, filepath, data):
+        """Write data to a file
+
+        This converts the data to msgpack then saves it to disk. It tries to account for
+        race conditions between reads and writes by writing to a temporary file and then
+        renaming it.
+
+        :arg Path filepath: the file to write to
+        :arg dict data: the data to write
+
+        :returns: True if successful, False if there was a problem
+
+        """
+        # Pack the data into a single blob
+        data = msgpack.packb(data)
+
+        # Save the file to a temp file and then rename that so as to avoid race
+        # conditions.
+        try:
+            temp_fp = tempfile.NamedTemporaryFile(
+                mode="w+b", suffix=".sym", dir=self.tmpdir, delete=False
+            )
+            temp_fp.write(data)
+            temp_fp.close()
+
+            filepath.parent.mkdir(parents=True, exist_ok=True)
+            Path(temp_fp.name).rename(filepath)
+            return True
+
+        except OSError:
+            LOGGER.exception("Exception when writing to disk cache")
+            return False
+
     def get(self, key, default=NO_DEFAULT):
         """Retrieve contents for a given key.
 
@@ -82,7 +144,7 @@ class DiskCache:
         :arg bytes default: the default to return if there's no key; otherwise this
             raises a KeyError
 
-        :returns: data as bytes
+        :returns: data as dict
 
         :raises KeyError: if there's no key and no default is given
 
@@ -92,14 +154,14 @@ class DiskCache:
         filepath = self.key_to_filepath(key)
         if filepath.is_file():
             try:
-                with filepath.open(mode="rb") as fp:
-                    data = fp.read()
-                    delta = (time.perf_counter() - start_time) * 1000.0
-                    METRICS.histogram(
-                        "eliot.diskcache.get", value=delta, tags=["result:hit"]
-                    )
-                    return data
-            except OSError:
+                data = self.read_from_file(filepath)
+
+                delta = (time.perf_counter() - start_time) * 1000.0
+                METRICS.histogram(
+                    "eliot.diskcache.get", value=delta, tags=["result:hit"]
+                )
+                return data
+            except CacheReadError:
                 error = True
                 LOGGER.exception("Cache error on read")
 
@@ -119,29 +181,16 @@ class DiskCache:
         This will log and emit metrics on OSError and IOError.
 
         :arg str key: the key to set
-        :arg bytes data: the data to save
+        :arg dict data: the data to save as a key/val dict
 
         """
-        result = ""
+        assert isinstance(data, dict)
+
         start_time = time.perf_counter()
         filepath = self.key_to_filepath(key)
 
-        # Save the file to a temp file and then rename that so as to avoid race
-        # conditions.
-        try:
-            temp_fp = tempfile.NamedTemporaryFile(
-                mode="w+b", suffix=".sym", dir=self.tmpdir, delete=False
-            )
-            temp_fp.write(data)
-            temp_fp.close()
-
-            filepath.parent.mkdir(parents=True, exist_ok=True)
-            Path(temp_fp.name).rename(filepath)
-            result = "success"
-
-        except OSError:
-            LOGGER.exception("Exception when writing to disk cache")
-            result = "fail"
+        ret = self.write_to_file(filepath, data)
+        result = "success" if ret else "fail"
 
         delta = (time.perf_counter() - start_time) * 1000.0
         METRICS.histogram("eliot.diskcache.set", value=delta, tags=["result:" + result])

--- a/eliot-service/tests/test_cache.py
+++ b/eliot-service/tests/test_cache.py
@@ -45,16 +45,17 @@ class TestDiskCache:
         key = "foo___bar.sym"
         assert key not in diskcache
 
-        diskcache.set(key, b"abcde")
+        diskcache.set(key, {"symcache": b"abcde"})
         assert key in diskcache
 
     def test_get(self, tmpcachedir, tmpdir):
         """DiskCache.get returns a bytes object of the file on the filesystem"""
         diskcache = DiskCache(cachedir=Path(tmpcachedir), tmpdir=Path(tmpdir))
+
         key = "foo___bar.sym"
-        data = b"abcde"
+        data = {"symfile": b"abcde"}
         filepath = diskcache.key_to_filepath(key)
-        filepath.write_bytes(data)
+        diskcache.write_to_file(filepath, data)
 
         assert diskcache.get(key) == data
         assert type(diskcache.get(key)) == type(data)
@@ -78,31 +79,31 @@ class TestDiskCache:
         """DiskCache.get returns file even if default is specified"""
         diskcache = DiskCache(cachedir=Path(tmpcachedir), tmpdir=Path(tmpdir))
         key = "foo/bar.sym"
-        data = b"abcde"
-        default_data = b"12345"
+        data = {"symfile": b"abcde"}
+        default_data = {"symfile": b"12345"}
         filepath = diskcache.key_to_filepath(key)
-        filepath.write_bytes(data)
+        diskcache.write_to_file(filepath, data)
         assert diskcache.get(key, default=default_data) == data
 
     def test_set(self, tmpcachedir, tmpdir):
         """DiskCache.set creates a file"""
         diskcache = DiskCache(cachedir=Path(tmpcachedir), tmpdir=Path(tmpdir))
         key = "foo/bar.sym"
-        data = b"abcde"
+        data = {"symfile": b"abcde"}
 
         diskcache.set(key, data)
         filepath = diskcache.key_to_filepath(key)
-        assert filepath.read_bytes() == data
+        assert diskcache.read_from_file(filepath) == data
 
     def test_set_overwrite(self, tmpcachedir, tmpdir):
         """DiskCache.set overwrites existing files"""
         diskcache = DiskCache(cachedir=Path(tmpcachedir), tmpdir=Path(tmpdir))
         key = "foo/bar.sym"
-        data = b"abcde"
-        data2 = b"12345"
+        data = {"symfile": b"abcde"}
+        data2 = {"symfile": b"12345"}
 
         filepath = diskcache.key_to_filepath(key)
-        filepath.write_bytes(data)
+        diskcache.write_to_file(filepath, data)
 
         diskcache.set(key, data2)
-        assert filepath.read_bytes() == data2
+        assert diskcache.read_from_file(filepath) == data2


### PR DESCRIPTION
For Windows SYM files, the debug_filename is something.pdb, but we
really want to return something.dll which is the PE filename. SYM files
encode this in the INFO line.

symbolic parses that line and captures that information, but doesn't
make it available in the symcache, so we had to add some code to peek in
the SYM file and pull out the PE filename if it's there. But then since
we're caching symcache files on disk, we needed to redo disk caching to
cache items that consist of multiple key/val pairs.

This stores the key/val data as a single file using msgpack. That way
the disk cache LRU can think about files as units and we don't have to
deal with the complexities of other possibilities.