### PR TITLE
bug 1701653: add "file" to symbolication API output

### DIFF
--- a/eliot-service/eliot/symbolicate_resource.py
+++ b/eliot-service/eliot/symbolicate_resource.py
@@ -419,6 +419,12 @@ class SymbolicateBase:
                             data["function_offset"] = hex(
                                 module_offset - lineinfo.sym_addr
                             )
+                            if lineinfo.base_dir and lineinfo.filename:
+                                data["file"] = "/".join(
+                                    [lineinfo.base_dir, lineinfo.filename]
+                                )
+                            elif lineinfo.filename:
+                                data["file"] = lineinfo.filename
                             data["line"] = lineinfo.line
 
                     data["module"] = module_info.filename

--- a/eliot-service/tests/test_symbolicate_resource.py
+++ b/eliot-service/tests/test_symbolicate_resource.py
@@ -368,6 +368,7 @@ class TestSymbolicateBase:
             "stacks": [
                 [
                     {
+                        "file": "/home/willkg/projects/testproj/src/main.rs",
                         "frame": 0,
                         "function": "testproj::main",
                         "function_offset": "0x0",
@@ -417,6 +418,10 @@ class TestSymbolicateBase:
             "stacks": [
                 [
                     {
+                        "file": (
+                            "hg:hg.mozilla.org/releases/mozilla-release"
+                            ":media/libjpeg/simd//etc"
+                        ),
                         "frame": 0,
                         "function": "somefunc",
                         "function_offset": "0x0",
@@ -670,6 +675,7 @@ class TestSymbolicateV5:
                     "stacks": [
                         [
                             {
+                                "file": "/home/willkg/projects/testproj/src/main.rs",
                                 "frame": 0,
                                 "function": "testproj::main",
                                 "function_offset": "0x0",


### PR DESCRIPTION
This adds a "file" key to the symbolication output which has the source file in it.