### PR TITLE
bug 1674406: measure disk cache usage

### DIFF
--- a/eliot-service/eliot/cache_manager.py
+++ b/eliot-service/eliot/cache_manager.py
@@ -233,6 +233,8 @@ class DiskCacheManager:
             LOGGER.debug(f"added {path} {size:,d}")
             self.lru[lru_key] = size
 
+        METRICS.gauge("eliot.diskcache.usage", value=self.total_size)
+
         LOGGER.debug(f"lru: count {len(self.lru)}, size {self.total_size:,d}")
 
     def inventory_existing(self):

--- a/eliot-service/eliot/libmarkus.py
+++ b/eliot-service/eliot/libmarkus.py
@@ -150,9 +150,10 @@ ELIOT_METRICS = {
     ),
     "eliot.diskcache.evict": Metric(
         stat_type="incr",
-        description="""\
-        Counter for disk cache evictions.
-        """,
+        description="Counter for disk cache evictions.",
+    ),
+    "eliot.diskcache.usage": Metric(
+        stat_type="gauge", description="Gauge for how much of the cache is in use."
     ),
 }
 

--- a/systemtests/bin/make-stacks.py
+++ b/systemtests/bin/make-stacks.py
@@ -146,7 +146,12 @@ def make_stacks_save(ctx, outputdir, crashids):
 
         print("%s..." % crashid)
         crash_report = fetch_crash_report(crashid)
-        data = build_stack(crash_report)
+        try:
+            data = build_stack(crash_report)
+        except Exception as exc:
+            print(f"Exception thrown: {exc!r}")
+            data = None
+
         if not data or not data["stacks"][0]:
             print("Nothing to save.")
             continue


### PR DESCRIPTION
This fixes an issue in make-stacks.py that I hit while working on the disk cache evictions issue.

This also adds an `eliot.diskcache.usage` gauge so we can see how the disk cache grows over time.