### PR TITLE
bug 1674406: fix cache hit/miss metrics generation

### DIFF
--- a/eliot-service/eliot/cache.py
+++ b/eliot-service/eliot/cache.py
@@ -74,6 +74,10 @@ class DiskCache:
 
         This lets you use the Python "in" operator.
 
+        .. Note::
+
+           This doesn't guarantee that the item can be read from cache without error.
+
         :arg str key: the key to retrieve for
 
         :returns: bool
@@ -146,7 +150,8 @@ class DiskCache:
 
         :returns: data as dict
 
-        :raises KeyError: if there's no key and no default is given
+        :raises KeyError: if there's no key or there's an error when reading from
+            cache and no default is given
 
         """
         error = False
@@ -173,7 +178,7 @@ class DiskCache:
         )
         if default != NO_DEFAULT:
             return default
-        raise KeyError(f"key {filepath!r} does not exist")
+        raise KeyError(f"key {filepath!r} not in cache")
 
     def set(self, key, data):
         """Set contents for a given key.

--- a/eliot-service/eliot/symbolicate_resource.py
+++ b/eliot-service/eliot/symbolicate_resource.py
@@ -326,13 +326,13 @@ class SymbolicateBase:
             debug_id.upper().replace("/", ""),
         )
 
-        if cache_key in self.cache:
+        try:
             # Pull it from cache if we can
             data = self.cache.get(cache_key)
             module_info.symcache = symbolic.SymCache.from_bytes(data["symcache"])
             module_info.filename = data["filename"]
 
-        else:
+        except KeyError:
             # Download the SYM file from one of the sources
             sym_file = self.download_sym_file(debug_filename, debug_id)
             if sym_file is not None:

--- a/eliot-service/tests/test_cache.py
+++ b/eliot-service/tests/test_cache.py
@@ -65,7 +65,7 @@ class TestDiskCache:
         diskcache = DiskCache(cachedir=Path(tmpcachedir), tmpdir=Path(tmpdir))
         key = "foo___bar.sym"
 
-        with pytest.raises(KeyError, match="does not exist"):
+        with pytest.raises(KeyError, match="not in cache"):
             diskcache.get(key)
 
     def test_get_default(self, tmpcachedir, tmpdir):


### PR DESCRIPTION
If we check to see if the item is in the cache before doing cache.get(),
then we miss out on metrics generation for misses and errors.

Further, the previous code didn't handle errors when cache.get() has
problems.