### PR TITLE
bug 1713667: implement CORS access control headers

### DIFF
--- a/eliot-service/eliot/app.py
+++ b/eliot-service/eliot/app.py
@@ -3,7 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
-Holds the EliotAPI code. EliotAPI is a WSGI app implemented using Falcon.
+Holds the EliotApp code. EliotApp is a WSGI app implemented using Falcon.
 """
 
 import logging
@@ -136,11 +136,26 @@ class AppConfig(RequiredConfigMixin):
             self.config(key)
 
 
-class EliotAPI(falcon.App):
-    """Falcon API for Eliot."""
+class EliotApp(falcon.App):
+    """Falcon App for Eliot."""
 
     def __init__(self, config):
-        super().__init__()
+        cors_middleware = falcon.CORSMiddleware(
+            allow_origins="*",
+            expose_headers=[
+                "accept",
+                "accept-encoding",
+                "authorization",
+                "content-type",
+                "dnt",
+                "origin",
+                "user-agent",
+                "x-csrftoken",
+                "x-requested-with",
+            ],
+        )
+
+        super().__init__(middleware=cors_middleware)
         self.config = config
         self._all_resources = {}
 
@@ -216,11 +231,11 @@ class EliotAPI(falcon.App):
 
 
 def get_app(config_manager=None):
-    """Build and return EliotAPI instance.
+    """Build and return EliotApp instance.
 
     :arg config_manager: Everet ConfigManager to use; if None, it will build one
 
-    :returns: EliotAPI instance
+    :returns: EliotApp instance
 
     """
     if config_manager is None:
@@ -230,7 +245,7 @@ def get_app(config_manager=None):
     app_config.verify_configuration()
 
     # Build the app
-    app = EliotAPI(app_config)
+    app = EliotApp(app_config)
 
     # Set the app up and verify setup
     app.setup()

--- a/eliot-service/tests/conftest.py
+++ b/eliot-service/tests/conftest.py
@@ -88,7 +88,7 @@ class EliotTestClient(TestClient):
     def get_resource_by_name(self, name):
         """Retrieves the Falcon API resource by name"""
         # NOTE(willkg): The "app" here is a middleware which should have an .application
-        # attribute which is the actual EliotAPI that we want.
+        # attribute which is the actual EliotApp that we want.
         return self.app.application.get_resource_by_name(name)
 
 

--- a/eliot-service/tests/test_symbolicate_resource.py
+++ b/eliot-service/tests/test_symbolicate_resource.py
@@ -438,6 +438,32 @@ class TestSymbolicateBase:
 class TestSymbolicateV4:
     PATH = "/symbolicate/v4"
 
+    def test_cors(self, client):
+        result = client.simulate_options(
+            self.PATH,
+            headers={
+                "Origin": "example.com",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert result.status_code == 200
+        assert result.headers["Access-Control-Allow-Origin"] == "*"
+        expected_headers = [
+            "accept",
+            "accept-encoding",
+            "authorization",
+            "content-type",
+            "dnt",
+            "origin",
+            "user-agent",
+            "x-csrftoken",
+            "x-requested-with",
+        ]
+        assert result.headers["Access-Control-Expose-Headers"] == ", ".join(
+            expected_headers
+        )
+        assert result.headers["Access-Control-Allow-Methods"] == "POST"
+
     def test_bad_request(self, client):
         # Wrong HTTP method
         result = client.simulate_get(self.PATH)
@@ -533,6 +559,32 @@ class TestSymbolicateV4:
 
 class TestSymbolicateV5:
     PATH = "/symbolicate/v5"
+
+    def test_cors(self, client):
+        result = client.simulate_options(
+            self.PATH,
+            headers={
+                "Origin": "example.com",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert result.status_code == 200
+        assert result.headers["Access-Control-Allow-Origin"] == "*"
+        expected_headers = [
+            "accept",
+            "accept-encoding",
+            "authorization",
+            "content-type",
+            "dnt",
+            "origin",
+            "user-agent",
+            "x-csrftoken",
+            "x-requested-with",
+        ]
+        assert result.headers["Access-Control-Expose-Headers"] == ", ".join(
+            expected_headers
+        )
+        assert result.headers["Access-Control-Allow-Methods"] == "POST"
 
     def test_bad_request(self, client):
         # Wrong HTTP method

--- a/systemtests/bin/symbolicate.py
+++ b/systemtests/bin/symbolicate.py
@@ -41,6 +41,10 @@ def request_stack(url, payload, api_version, is_debug):
     if is_debug:
         headers["Debug"] = "true"
 
+    # NOTE(willkg): this triggers the Allow-Control-* CORS headers, but maybe we want to
+    # make the origin specifiable via the command line arguments
+    headers["Origin"] = "http://example.com"
+
     resp = requests.post(url, headers=headers, json=payload, **options)
     if is_debug:
         click.echo(click.style(f"Response: {resp.status_code} {resp.reason}"))


### PR DESCRIPTION
This uses the built-in Falcon CORSMiddleware to add the access control headers. This is slightly different than what the Tecken symbolication API does where it adds the headers regardless of whether it's a preflight request or not.

However, the origin and expose-headers values are the same, so I think this will work for the affected projects.