### PR TITLE
bug 1722602: update to everett 2.0.0

### DIFF
--- a/eliot-service/eliot/libmarkus.py
+++ b/eliot-service/eliot/libmarkus.py
@@ -158,8 +158,15 @@ ELIOT_METRICS = {
 }
 
 
-def setup_metrics(app_config, logger=None):
-    """Initialize and configures the metrics system."""
+def setup_metrics(statsd_host, statsd_port, statsd_namespace, debug=False):
+    """Initialize and configures the metrics system.
+
+    :arg statsd_host: the statsd host to send metrics to
+    :arg statsd_port: the port on the host to send metrics to
+    :arg statsd_namespace: the namespace (if any) for these metrics
+    :arg debug: whether or not to additionally log metrics to the logger
+
+    """
     global _IS_MARKUS_SETUP, METRICS
     if _IS_MARKUS_SETUP:
         return
@@ -168,13 +175,13 @@ def setup_metrics(app_config, logger=None):
         {
             "class": "markus.backends.datadog.DatadogMetrics",
             "options": {
-                "statsd_host": app_config("statsd_host"),
-                "statsd_port": app_config("statsd_port"),
-                "statsd_namespace": app_config("statsd_namespace"),
+                "statsd_host": statsd_host,
+                "statsd_port": statsd_port,
+                "statsd_namespace": statsd_namespace,
             },
         }
     ]
-    if app_config("local_dev_env"):
+    if debug:
         markus_backends.append(
             {
                 "class": "markus.backends.logging.LoggingMetrics",
@@ -186,7 +193,7 @@ def setup_metrics(app_config, logger=None):
         )
     markus.configure(markus_backends)
 
-    if app_config("local_dev_env"):
+    if debug:
         # In local dev environment, we want the RegisteredMetricsFilter to
         # raise exceptions when metrics are used incorrectly.
         metrics_filter = RegisteredMetricsFilter(metrics=ELIOT_METRICS)

--- a/eliot-service/tests/conftest.py
+++ b/eliot-service/tests/conftest.py
@@ -36,9 +36,9 @@ def pytest_collection_finish(session):
     # After pytest test collection has finished, make sure we set up logging and metrics
     # to sensible default values.
     setup_logging(
-        ConfigManager.from_dict(
-            {"HOST_ID": "testnode", "LOGGING_LEVEL": "DEBUG", "LOCAL_DEV_ENV": "True"}
-        ),
+        logging_level="DEBUG",
+        debug=True,
+        host_id="testcode",
         processname="tests",
     )
     markus.configure([{"class": "markus.backends.logging.LoggingMetrics"}])

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ django-configurations==2.2
 django-redis==5.0.0
 dockerflow==2020.10.0
 encore==0.7.0
-everett==1.0.3
+everett==2.0.0
 falcon==3.0.1
 flake8==3.9.2
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -191,9 +191,9 @@ docutils==0.16 \
 encore==0.7.0 \
     --hash=sha256:da358decda1f0b22519c76a8aa7a25351359b2a09f768400fc87dacc8756eda6
     # via -r requirements.in
-everett==1.0.3 \
-    --hash=sha256:2c4cb84700a122e5bbc82b1808c22e1f0c17af0c1e0c84711e0e43cb1f7b932d \
-    --hash=sha256:6612917b7bd9c1568a63eabdf04701791f7bb05cbf302eb5dc2b6f1aeb68c61e
+everett==2.0.0 \
+    --hash=sha256:83f319300c950e5935a2399fab2f5ac07eb6b8421cafae7974d1884306b5b3e4 \
+    --hash=sha256:f4463e036f6e10ae2069a90cdcd77ab8ad5ac9242984e005dafdf146e8369b9e
     # via -r requirements.in
 falcon==3.0.1 \
     --hash=sha256:0212df91414c13c08a9cf4023488b2d47956712f712332f420bb0c7bdf39c6fa \
@@ -369,13 +369,13 @@ packaging==21.0 \
     # via
     #   pytest
     #   sphinx
-pathspec==0.8.1 \
-    --hash=sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd \
-    --hash=sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d
+pathspec==0.9.0 \
+    --hash=sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a \
+    --hash=sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1
     # via black
-pep517==0.10.0 \
-    --hash=sha256:ac59f3f6b9726a49e15a649474539442cf76e0697e39df4869d25e68e880931b \
-    --hash=sha256:eba39d201ef937584ad3343df3581069085bacc95454c80188291d5b3ac7a249
+pep517==0.11.0 \
+    --hash=sha256:3fa6b85b9def7ba4de99fb7f96fe3f02e2d630df8aa2720a5cf3b183f087a738 \
+    --hash=sha256:e1ba5dffa3a131387979a68ff3e391ac7d645be409216b961bc2efe6468ab0b2
     # via pip-tools
 pip-tools==6.0.1 \
     --hash=sha256:3b0c7b95e8d3dfb011bb42cb38f356fcf5d0630480462b59c4d0a112b8d90281 \
@@ -625,8 +625,11 @@ toml==0.10.2 \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
     # via
     #   black
-    #   pep517
     #   pytest
+tomli==1.1.0 \
+    --hash=sha256:33d7984738f8bb699c9b0a816eb646a8178a69eaa792d258486776a5d21b8ca5 \
+    --hash=sha256:f4a182048010e89cbec0ae4686b21f550a7f2903f665e34a6de58ec15424f919
+    # via pep517
 ujson==4.0.2 \
     --hash=sha256:0190d26c0e990c17ad072ec8593647218fe1c675d11089cd3d1440175b568967 \
     --hash=sha256:0ea07fe57f9157118ca689e7f6db72759395b99121c0ff038d2e38649c626fb1 \


### PR DESCRIPTION
This updates Eliot to Everett 2.0.0 and reworks component configuration.
It also fixes `setup_metrics` and `setup_logging` so they're explicit about
what argument data is being used.