### PR TITLE
bug 1702012: split out symbolic wrapper

### DIFF
--- a/eliot-service/eliot/libsymbolic.py
+++ b/eliot-service/eliot/libsymbolic.py
@@ -1,0 +1,176 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Utilities for using symbolic library.
+"""
+
+from io import BytesIO
+import logging
+import os
+import tempfile
+
+import symbolic
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def bytes_split_generator(item, sep):
+    """Takes a bytes or bytearray and returns a generator of parts split on sep
+
+    :arg item: bytes-like object
+    :arg sep: bytes-like object
+
+    :returns: generator splitting the item
+
+    """
+    index = 0
+    len_item = len(item)
+
+    while index <= len_item:
+        next_index = item.find(sep, index)
+        if next_index == -1:
+            break
+
+        yield item[index:next_index]
+        index = next_index + len(sep)
+
+
+def get_module_filename(sym_file, debug_filename):
+    """Returns the module filename
+
+    On Windows, this will be the pe_file in the INFO line:
+
+        INFO CODE_ID xxx pe_file
+
+    On other platforms, this is the debug_filename.
+
+    :arg bytes sym_file: the sym file as bytes
+    :arg str debug_filename: the debug filename
+
+    :returns: the module filename
+
+    """
+    # Iterate through the first few lines of the file until we hit FILE in which
+    # case there's no INFO for some reason or we hit the first INFO.
+    for line in bytes_split_generator(sym_file, b"\n"):
+        if line.startswith(b"INFO"):
+            parts = line.split(b" ")
+            if len(parts) == 4:
+                return parts[-1].decode("utf-8").strip()
+            else:
+                break
+
+        elif line.startswith((b"FILE", b"PUBLIC", b"FUNC")):
+            break
+
+    return debug_filename
+
+
+class BadDebugIDError(Exception):
+    pass
+
+
+class ParseSymFileError(Exception):
+    def __init__(self, reason_code):
+        super().__init__(reason_code)
+        self.reason_code = reason_code
+
+
+def convert_debug_id(debug_id):
+    """Convert a debug_id into a symbolic debug id.
+
+    :arg debug_id: a debug id string; ex: "58C99D979ADA4CD795F8740CE23C2E1F2"
+
+    :returns: debug id formatted the way symbolic likes; ex:
+        "58c99d97-9ada-4cd7-95f8-740ce23c2e1f-2"
+
+    :raises BadDebugIDError: if the debug id is invalid
+
+    """
+    try:
+        return symbolic.normalize_debug_id(debug_id)
+    except symbolic.ParseDebugIdError:
+        raise BadDebugIDError("invalid_identifier")
+
+
+def parse_sym_file(debug_filename, debug_id, data, tmpdir):
+    """Convert sym file to symcache file
+
+    :arg debug_filename: the debug filename
+    :arg debug_id: the debug id
+    :arg data: bytes
+    :arg tmpdir: the temp directory to use
+
+    :returns: symcache or None
+
+    :raises BadDebugIDError: if the debug_id is invalid
+
+    :raises ParseSymFileError: if the SYM file isn't parseable, doesn't have the debug
+        id, or some other problem
+
+    """
+    sdebug_id = convert_debug_id(debug_id)
+
+    try:
+        temp_fp = tempfile.NamedTemporaryFile(
+            mode="w+b", suffix=".sym", dir=tmpdir, delete=False
+        )
+        try:
+            temp_fp.write(data)
+            temp_fp.close()
+            LOGGER.debug(
+                f"created temp file {debug_filename} {debug_id} {temp_fp.name}"
+            )
+            archive = symbolic.Archive.open(temp_fp.name)
+            obj = archive.get_object(debug_id=sdebug_id)
+            symcache = obj.make_symcache()
+
+        except LookupError:
+            LOGGER.exception(
+                f"error looking up debug id in SYM file: {debug_filename} {debug_id}"
+            )
+            raise ParseSymFileError("sym_debug_id_lookup_error")
+
+        except (
+            symbolic.ObjectErrorUnknown,
+            symbolic.ObjectErrorUnsupportedObject,
+        ):
+            # Invalid symcache
+            LOGGER.exception(f"error with SYM file: {debug_filename} {debug_id}")
+            raise ParseSymFileError("sym_malformed")
+
+        finally:
+            os.unlink(temp_fp.name)
+
+    except OSError:
+        LOGGER.exception("error creating tmp file for SYM file")
+        raise ParseSymFileError("sym_tmp_file_error")
+
+    return symcache
+
+
+def bytes_to_symcache(data):
+    """Convert a bytes into a symcache
+
+    :arg data: the bytes data to convert
+
+    :returns: a symcache instance
+
+    """
+    return symbolic.SymCache.from_bytes(data)
+
+
+def symcache_to_bytes(symcache):
+    """Convert a symcache to bytes
+
+    :arg symcache: the symcache instance to convert
+
+    :returns: bytes
+
+    """
+    data = BytesIO()
+    symcache.dump_into(data)
+    return data.getvalue()

--- a/eliot-service/tests/test_libsymbolic.py
+++ b/eliot-service/tests/test_libsymbolic.py
@@ -1,0 +1,97 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import types
+
+import pytest
+
+from eliot.libsymbolic import (
+    BadDebugIDError,
+    bytes_split_generator,
+    convert_debug_id,
+    get_module_filename,
+    parse_sym_file,
+    ParseSymFileError,
+)
+
+
+TESTPROJ_SYM = """\
+MODULE Linux x86_64 D48F191186D67E69DF025AD71FB91E1F0 testproj
+FILE 0 /home/willkg/projects/testproj/src/main.rs
+FUNC 5380 44 0 testproj::main
+5380 9 1 0
+5389 36 2 0
+53bf 5 3 0
+"""
+
+
+def test_bytes_split_generator():
+    symfile = (
+        "MODULE windows x86_64 0185139C8F04FFC94C4C44205044422E1 xul.pdb\n"
+        "INFO CODE_ID 60533C886EFD000 xul.dll\n"
+        "FILE 0 hg:hg.mozilla.org/releases/mozilla-release:media/libjpeg/simd/etc\n"
+    )
+    symfile_bytes = symfile.encode("utf-8")
+    # This should return the same as splitlines()--the difference is that it's
+    # returning a generator
+    assert isinstance(bytes_split_generator(symfile_bytes, b"\n"), types.GeneratorType)
+    assert (
+        list(bytes_split_generator(symfile_bytes, b"\n")) == symfile_bytes.splitlines()
+    )
+
+
+def test_get_module_filename_no_info():
+    """No INFO line should return debug_filename"""
+    symfile = (
+        "MODULE Linux x86_64 D48F191186D67E69DF025AD71FB91E1F0 testproj\n"
+        "FILE 0 /home/willkg/projects/testproj/src/main.rs\n"
+        "FUNC 5380 44 0 testproj::main\n"
+    )
+    symfile_bytes = symfile.encode("utf-8")
+    assert get_module_filename(symfile_bytes, "testproj") == "testproj"
+
+
+def test_get_module_no_pe_filename():
+    symfile = (
+        "MODULE Linux x86_64 6C0CFDB91476E3E45DCB01FABB49DDA90 libxul.so\n"
+        "INFO CODE_ID B9FD0C6C7614E4E35DCB01FABB49DDA913586357\n"
+        "FILE 0 /build/firefox-ifRHdl/firefox-87.0+build3/memory/volatile/etc\n"
+    )
+    symfile_bytes = symfile.encode("utf-8")
+    assert get_module_filename(symfile_bytes, "libxul.so") == "libxul.so"
+
+
+def test_convert_debug_id():
+    assert (
+        convert_debug_id("58C99D979ADA4CD795F8740CE23C2E1F2")
+        == "58c99d97-9ada-4cd7-95f8-740ce23c2e1f-2"
+    )
+
+
+def test_convert_debug_id_bad():
+    with pytest.raises(BadDebugIDError):
+        convert_debug_id("bad_id")
+
+
+def test_parse_sym_file_malformed(tmpdir):
+    debug_filename = "testproj"
+    debug_id = "D48F191186D67E69DF025AD71FB91E1F0"
+    data = b"this is junk"
+
+    with pytest.raises(ParseSymFileError) as excinfo:
+        parse_sym_file(debug_filename, debug_id, data, tmpdir)
+
+    assert str(excinfo.value) == "sym_malformed"
+
+
+def test_parse_sym_file_lookup_error(tmpdir):
+    debug_filename = "testproj"
+    # This is the wrong debugid for that sym file
+    debug_id = "000000000000000000000000000000000"
+    data = TESTPROJ_SYM.encode("utf-8")
+
+    with pytest.raises(ParseSymFileError) as excinfo:
+        parse_sym_file(debug_filename, debug_id, data, tmpdir)
+
+    assert str(excinfo.value) == "sym_debug_id_lookup_error"


### PR DESCRIPTION
This moves a bunch of code that uses symbolic into a wrapper module that
makes it easier to isolate and test it from the rest of the code.
