### PR TITLE
bug 1701978: don't include line if there's no file

### DIFF
--- a/eliot-service/eliot/symbolicate_resource.py
+++ b/eliot-service/eliot/symbolicate_resource.py
@@ -344,7 +344,11 @@ class SymbolicateBase:
                                 )
                             elif lineinfo.filename:
                                 data["file"] = lineinfo.filename
-                            data["line"] = lineinfo.line
+
+                            # Only add a "line" if there's a file--otherwise the line
+                            # doesn't mean anything
+                            if data.get("file"):
+                                data["line"] = lineinfo.line
 
                     data["module"] = module_info.filename
 


### PR DESCRIPTION
If there's no file information for the symbol, then including a line
number doesn't make any sense. This changes the code to omit the line
number if there's no file information.