### PR TITLE
Updates 20210910 2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE(willkg): Make sure to update frontend/Dockerfile when you update this
-FROM node:16.8.0-slim@sha256:441afc10bb9f886fb6dabdf20458743273dd73e51fe9ea39db39a1b4a20124fe as frontend
+FROM node:16.9.0-slim@sha256:fca208cb6a90179412cc78ac590a81c3b802b2d3a66b202e31586a9b702e101c as frontend
 
 # these build args are turned into env vars
 # and used in bin/build_frontend.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 RUN bin/build_frontend.sh
 
 
-FROM python:3.9.7-slim@sha256:8402d0ea6e4eaeba7b390dfe522496e365334daaeb05361b24636f2407e10aae
+FROM python:3.9.7-slim@sha256:cd1045dbabff11dab74379e25f7974aa7638bc5ad46755d67d0f1f1783aee101
 
 ARG userid=10001
 ARG groupid=10001


### PR DESCRIPTION
Update dependencies. This covers:

* Bump node from 16.8.0-slim to 16.9.0-slim in /docker (from PR #2413)
* Bump python from 3.9.6-slim to 3.9.7-slim in /docker (from PR #2401)
