### PR TITLE
bug 1731412: force linux/amd64 platform for docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 ---
-version: '2'
-
+version: '2.4'
 services:
   # Base container is used for development tasks like tests, linting,
   # and building docs.
@@ -10,7 +9,7 @@ services:
       dockerfile: docker/Dockerfile
       args:
         - FRONTEND_SENTRY_PUBLIC_DSN
-    # This builds the tecken:build container
+    platform: linux/amd64
     image: tecken:build
     environment:
       - DJANGO_CONFIGURATION


### PR DESCRIPTION
This forces the use of linux/amd64 for docker images. People who are
using m1 Macs will now be forced to emulate linux/amd64. I figured I'd
try this out now since it's the easier fix.

Docker has a "known issues" here:

https://docs.docker.com/desktop/mac/apple-silicon/#known-issues

We use inotify in a couple of places. If it turns into a problem, we can
undo this change and try something different