### PR TITLE
bug 1731412: downgrade to node 14

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
 # NOTE(willkg): Make sure to update frontend/Dockerfile when you update this
-FROM node:16.9.0-slim@sha256:fca208cb6a90179412cc78ac590a81c3b802b2d3a66b202e31586a9b702e101c as frontend
+#
+# NOTE(willkg): We're using node 14 because of this issue:
+# https://github.com/docker/for-mac/issues/5831
+FROM node:14.17.6-slim@sha256:56e3ae9f6981acb5525427c37eacc73c8ad400f0fef155c4064447f220816cbc as frontend
 
 # these build args are turned into env vars
 # and used in bin/build_frontend.sh

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,10 @@
 # Note! If you make changes it in this file, to rebuild it use:
+#
 #   docker-compose build frontend
 #
 
 # This should match what we have in the Node section of the main Dockerfile.
-FROM node:15.7.0-slim@sha256:58953fedf88897d4eb39df31476e45112fa567bdc289936cddebf2357180bd30 as frontend
+FROM node:14.17.6-slim@sha256:56e3ae9f6981acb5525427c37eacc73c8ad400f0fef155c4064447f220816cbc as frontend
 
 ARG userid=10001
 ARG groupid=10001


### PR DESCRIPTION
This downgrades Tecken to using node 14. Tecken only uses node to build static assets, so as long as they're building fine, it doesn't really matter what version of node we're using.

This allows people using macs with m1 processors to build and run Tecken. Previous to this fix, they would hit this issue:

https://github.com/docker/for-mac/issues/5831

Just to clarify, this isn't a great fix, but it kicks the can down the road a bit until when we have more time to fix it more thoughtfully.