### PR TITLE
bug 1739202: rework requests wrappers to handle content errors

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 Sphinx==4.2.0
+backoff==1.11.1
 black==21.10b0
 boltons==21.0.0
 boto3==1.19.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,10 @@ babel==2.9.1 \
     --hash=sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9 \
     --hash=sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0
     # via sphinx
+backoff==1.11.1 \
+    --hash=sha256:61928f8fa48d52e4faa81875eecf308eccfb1016b018bb6bd21e05b5d90a96c5 \
+    --hash=sha256:ccb962a2378418c667b3c979b504fdeb7d9e0d29c0579e3b13b86467177728cb
+    # via -r requirements.in
 billiard==3.6.4.0 \
     --hash=sha256:299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547 \
     --hash=sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b


### PR DESCRIPTION
The `session_with_retries()` we had would create a requests `Session`
instance that used an `HTTPAdapter` that had a default timeout. It would
also create a Retry instance which would retry various error scenarios
of the HTTP request.

However, once the HTTP request is successfully sent, then a `Response`
object is created and returned. This `Response` object is now outside the
scope of all the error retry handling.

If the stream of HTTP response payload data pauses and exceeds the read
timeout, then a `ReadTimeout` error is thrown and the Eliot downloader
treats the attempt to fetch the sym file as an `ErrorFileNotFound`. It
should instead retry it.

This reworks all the requests scaffolding to keep the timeout code we
had but also cover the case where a network error when reading the HTTP
response payload data also retries the request.