### PR TITLE
upgrade django

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,8 @@ lintfix: .env .docker-build  ## | Reformat code.
 
 .PHONY: rebuildreqs
 rebuildreqs: .env .docker-build  ## | Rebuild requirements.txt file after requirements.in changes.
-	docker-compose run --rm web bash pip-compile --generate-hashes
+	docker-compose run --rm --no-deps web bash pip-compile --generate-hashes
 
 .PHONY: updatereqs
 updatereqs: .env .docker-build  ## | Update deps in requirements.txt file.
-	docker-compose run --rm web bash pip-compile --generate-hashes -U
+	docker-compose run --rm --no-deps web bash pip-compile --generate-hashes -U

--- a/requirements.in
+++ b/requirements.in
@@ -46,7 +46,7 @@ redis==3.4.1
 
 # NOTE(willkg): Django 2.2 is an LTS series so don't upgrade until the next
 # LTS.
-Django==2.2.24
+Django==2.2.25
 
 # NOTE(willkg): have to stay with 2.8.6 until we upgrade to Django 3.2;
 # https://github.com/psycopg/psycopg2/issues/1293

--- a/requirements.txt
+++ b/requirements.txt
@@ -174,9 +174,9 @@ dj-database-url==0.5.0 \
     --hash=sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163 \
     --hash=sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9
     # via -r requirements.in
-django==2.2.24 \
-    --hash=sha256:3339ff0e03dee13045aef6ae7b523edff75b6d726adf7a7a48f53d5a501f7db7 \
-    --hash=sha256:f2084ceecff86b1e631c2cd4107d435daf4e12f1efcdf11061a73bf0b5e95f92
+django==2.2.25 \
+    --hash=sha256:08bad7ef7e90286b438dbe1412c3e633fbc7b96db04735f0c7baadeed52f3fad \
+    --hash=sha256:b1e65eaf371347d4b13eb7e061b09786c973061de95390c327c85c1e2aa2349c
     # via
     #   -r requirements.in
     #   django-redis


### PR DESCRIPTION
- Fix rebuildreqs and updatereqs to not run dependent containers
- Upgrade Django to 2.2.25
