### PR TITLE
Update to Everett 3.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ testshell: .env .docker-build  ## | Open shell in test environment.
 
 .PHONY: docs
 docs: .env .docker-build  ## | Build docs.
+	docker-compose run --rm --user ${USE_UID} --no-deps test bash make -C docs/ clean
 	docker-compose run --rm --user ${USE_UID} --no-deps test bash make -C docs/ html
 
 .PHONY: docs

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -10,16 +10,21 @@ Symbols Service configuration
 
 The Symbols Service covers uploading and downloading symbols.
 
-.. envvar:: GUNICORN_TIMEOUT
+.. everett:option:: GUNICORN_TIMEOUT
+   :default: "300"
 
-   To specify the timeout value.
+   Specifies the timeout value.
 
    https://docs.gunicorn.org/en/stable/settings.html#timeout
 
+   Used in `bin/run_web.sh
+   <https://github.com/mozilla-services/tecken/blob/main/bin/run_web.sh>`_.
 
-.. envvar:: GUNICORN_WORKERS
 
-   To specify the number of gunicorn workers. The default is 4.
+.. everett:option:: GUNICORN_WORKERS
+   :default: "1"
+
+   Specifies the number of gunicorn workers.
 
    You should set it to ``(2 x $num_cores) + 1``.
 
@@ -27,23 +32,24 @@ The Symbols Service covers uploading and downloading symbols.
 
    http://docs.gunicorn.org/en/stable/design.html#how-many-workers
 
+   Used in `bin/run_web.sh
+   <https://github.com/mozilla-services/tecken/blob/main/bin/run_web.sh>`_.
+
 
 .. envvar:: DJANGO_CONFIGURATION
 
-   Determines the settings class to use.
+   Specifies the settings class to use. Defaults to "Prod".
 
-   Options:
+   This must be set as an environment variable.
+
+   Possible values:
 
    * ``Prod``: production configuration
    * ``Stage``: stage configuration
    * ``Localdev``: local development environment configuration
 
-   The Dockerfile sets this to ``Prod``, but if you use docker-compose
-   to start everything, it'll pick up ``Localdev``.
-
-   .. code-block:: shell
-
-      DJANGO_CONFIGURATION=Localdev
+   The Dockerfile sets this to ``Prod``, but if you use docker-compose to start
+   everything, it'll use ``Localdev``.
 
 
 .. envvar:: DJANGO_SECRET_KEY
@@ -65,6 +71,7 @@ The Symbols Service covers uploading and downloading symbols.
    .. code-block:: shell
 
        DJANGO_ALLOWED_HOSTS=symbols.mozilla.org
+
 
 .. envvar:: SENTRY_DSN, SENTRY_PUBLIC_DSN
 
@@ -358,40 +365,56 @@ which is run by Honcho.
 
 Gunicorn configuration:
 
-.. envvar:: ELIOT_GUNICORN_WORKERS
+.. everett:option:: ELIOT_GUNICORN_WORKERS
+   :default: "1"
 
-   Specify the number of gunicorn workers. The default is 4.
+   Specifies the number of gunicorn workers.
 
    Gunicorn docs suggest to set it to ``(2 x $num_cores) + 1``.
 
    https://docs.gunicorn.org/en/stable/settings.html#workers
 
-   http://docs.gunicorn.org/en/stable/design.html#how-many-workers
+   https://docs.gunicorn.org/en/stable/design.html#how-many-workers
+
+   Used in `bin/run_eliot_web.sh
+   <https://github.com/mozilla-services/tecken/blob/main/bin/run_eliot_web.sh>`_.
 
 
-.. envvar:: ELIOT_GUNICORN_TIMEOUT
+.. everett:option:: ELIOT_GUNICORN_TIMEOUT
+   :default: "300"
 
-   Specify the timeout value. The default is 300.
+   Specifies the timeout value.
 
    https://docs.gunicorn.org/en/stable/settings.html#timeout
 
-
-.. envvar:: ELIOT_GUNICORN_PORT
-
-   Set the port to listen to. Defaults to 8000.
+   Used in `bin/run_eliot_web.sh
+   <https://github.com/mozilla-services/tecken/blob/main/bin/run_eliot_web.sh>`_.
 
 
-.. envvar:: ELIOT_GUNICORN_CMD_PREFIX
+.. everett:option:: ELIOT_GUNICORN_PORT
+   :default: "8000"
 
-   Set any command prefix to run the gunicorn process in. Default
-   is ``""``.
+   Specifies the port to listen to.
+
+   Used in `bin/run_eliot_web.sh
+   <https://github.com/mozilla-services/tecken/blob/main/bin/run_eliot_web.sh>`_.
+
+
+.. everett:option:: ELIOT_GUNICORN_CMD_PREFIX
+   :default: ""
+
+   Specifies a command prefix to run the gunicorn process in.
+
+   Used in `bin/run_eliot_web.sh
+   <https://github.com/mozilla-services/tecken/blob/main/bin/run_eliot_web.sh>`_.
 
 
 Webapp configuration:
 
-.. autocomponent:: eliot.app.EliotApp
-   :hide-classname:
-   :namespace: eliot
+.. autocomponentconfig:: eliot.app.EliotApp
+   :show-table:
+   :hide-name:
+   :namespace: ELIOT
    :case: upper
 
 
@@ -400,7 +423,8 @@ Disk cache manager
 
 The disk cache manager is run as a single process by Honcho.
 
-.. autocomponent:: eliot.cache_manager.DiskCacheManager
-   :hide-classname:
-   :namespace: eliot
+.. autocomponentconfig:: eliot.cache_manager.DiskCacheManager
+   :show-table:
+   :hide-name:
+   :namespace: ELIOT
    :case: upper

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ django-configurations==2.3.1
 django-redis==5.2.0
 dockerflow==2021.7.0
 encore==0.7.0
-everett==2.0.1
+everett==3.0.0
 falcon==3.0.1
 flake8==4.0.1
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -206,9 +206,9 @@ docutils==0.17.1 \
 encore==0.7.0 \
     --hash=sha256:da358decda1f0b22519c76a8aa7a25351359b2a09f768400fc87dacc8756eda6
     # via -r requirements.in
-everett==2.0.1 \
-    --hash=sha256:2a08c4401ddd707f3161927e11a817cdaebabd71447f6a962612ec74b91e3898 \
-    --hash=sha256:f79bc7abc1a9f5b0db54dbfee3408eb0b3afd9f8040a4e77cc824e0347a6034d
+everett==3.0.0 \
+    --hash=sha256:43c208e09ef53adb8e8739ad96999893a2c0a27753e33f89be346e916e71efb0 \
+    --hash=sha256:80ce592168ce50643711eceff3ec94fdeec755f228de746f20b1bfc94ea20682
     # via -r requirements.in
 falcon==3.0.1 \
     --hash=sha256:0212df91414c13c08a9cf4023488b2d47956712f712332f420bb0c7bdf39c6fa \


### PR DESCRIPTION
This updates to Everett 3.0.0 and updates the configuration documentation to use Everett's new Sphinx directives.