### PR TITLE
bug 1750048: fix readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,7 @@
+---
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Tecken: Symbols at Mozilla"
-copyright = "2016-2021 Mozilla Foundation"
+copyright = "2016-2022 Mozilla Foundation"
 author = "Tecken team"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,3 +1,0 @@
-python:
-  version: 3.8
-requirements_file: requirements.txt


### PR DESCRIPTION
It's hard to tell why the docs aren't building.

This reworks the readthedocs configuration file to match version 2 of their configuration spec.