### PR TITLE
bug 1750048: change Python version to 3.9 for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 python:
   install:


### PR DESCRIPTION
We're compiling the `requirements.txt` file using Python 3.9 and
jsonschema requires importlib-resources with Python < 3.9 and RTD is
using Python 3.8. This fixes that.