### PR TITLE
bug 1751458: implement broken endpoint

### DIFF
--- a/tecken/tests/test_views.py
+++ b/tecken/tests/test_views.py
@@ -131,3 +131,8 @@ def test_heartbeat_no_warnings(client, botomock):
         response = client.get("/__heartbeat__")
         assert response.status_code == 200
         assert response.json()["status"] == "ok"
+
+
+def test_broken(client):
+    with pytest.raises(Exception):
+        client.get(reverse("broken"))

--- a/tecken/urls.py
+++ b/tecken/urls.py
@@ -31,6 +31,7 @@ register_converter(FrontendRoutesPrefixConverter, "frontendroutes")
 urlpatterns = [
     path("", views.dashboard, name="dashboard"),
     path("__auth_debug__", views.auth_debug, name="auth_debug"),
+    path("__broken__", views.broken_view, name="broken"),
     path("symbolicate/", include("tecken.symbolicate.urls", namespace="symbolicate")),
     path("oidc/", include("mozilla_django_oidc.urls")),
     path("upload/", include("tecken.upload.urls", namespace="upload")),

--- a/tecken/views.py
+++ b/tecken/views.py
@@ -121,3 +121,12 @@ def auth_debug(request):
     return http.HttpResponse(
         "\n".join([""] + out), content_type="text/plain; charset=utf-8"
     )
+
+
+def broken_view(request):
+    """Raises an unhandled exception to test Sentry.
+
+    Always have this behind some kind of basicauth.
+
+    """
+    raise Exception("Intentional exception")


### PR DESCRIPTION
This helps us verify that unhandled exceptions are sent to Sentry
in server environments.