### PR TITLE
bug 1671188: switch tecken from raven to sentry-sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ setup: .env  ## | Initialize services.
 
 .PHONY: run
 run: .env .docker-build  ## | Run the web app and services.
-	docker-compose up web eliot frontend
+	docker-compose up web eliot frontend fakesentry
 
 .PHONY: stop
 stop: .env  ## | Stop docker containers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       - docker/config/test.env
     links:
       - db
+      - fakesentry
       - redis-store
       - redis-cache
     volumes:
@@ -75,6 +76,7 @@ services:
       - docker/config/test.env
     links:
       - db
+      - fakesentry
       - redis-store
       - redis-cache
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - "8000:8000"
     links:
       - db
+      - fakesentry
       - redis-store
       - redis-cache
       - minio
@@ -136,6 +137,15 @@ services:
     # volumes:
     #   - $PWD/miniodata:/export
     command: server /export
+
+  # https://github.com/willkg/kent
+  fakesentry:
+    build:
+      context: docker/images/fakesentry
+    image: local/tecken_fakesentry
+    ports:
+      - "8090:8090"
+    command: run --host 0.0.0.0 --port 8090
 
   # https://hub.docker.com/r/mozilla/oidc-testprovider
   oidcprovider:

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -18,6 +18,8 @@ DJANGO_SECRET_KEY=DontusethisinproductionbutitneedsbelongforCI1234567890
 # NOTE(willkg): This shouldn't have a DJANGO_ prefix
 DATABASE_URL=postgresql://postgres:postgres@db/tecken
 
+SENTRY_DSN=http://public@fakesentry:8090/1
+
 # NOTE(willkg): See docker-compose.yml on how minio is set up--these are not
 # Django-configuration variables, so don't prefix them with DJANGO_
 AWS_ACCESS_KEY_ID=minio

--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -35,6 +35,8 @@ DJANGO_UPLOAD_DEFAULT_URL=https://s3.example.com/private/prefix/
 DJANGO_UPLOAD_TRY_SYMBOLS_URL=https://s3.example.com/try/prefix
 DJANGO_UPLOAD_URL_EXCEPTIONS={"*peterbe.com": "https://s3.example.com/peterbe-com"}
 
+SENTRY_DSN=http://public@fakesentry:8090/1
+
 
 # Eliot settings
 # --------------

--- a/docker/images/fakesentry/Dockerfile
+++ b/docker/images/fakesentry/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.10.1-alpine3.15@sha256:affe0faa14e7553fc570beec3864e74b5e36f8c19b2bb49ae8ba79c0e9e7236e
+
+ARG groupid=5000
+ARG userid=5000
+
+WORKDIR /app/
+
+RUN addgroup -g $groupid app && \
+    adduser --disabled-password --gecos "" --home /home/app --ingroup app --uid $userid app && \
+    chown app:app /app/
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+RUN pip install -U 'pip>=8' && \
+    pip install --no-cache-dir 'kent==0.4.0'
+
+USER app
+
+ENTRYPOINT ["/usr/local/bin/kent-server"]
+CMD ["run"]

--- a/requirements.in
+++ b/requirements.in
@@ -32,6 +32,7 @@ python-dateutil==2.8.2
 raven==6.10.0
 requests-mock==1.9.3
 requests==2.26.0
+sentry-sdk==1.5.3
 sphinx-rtd-theme==1.0.0
 sphinxcontrib-httpdomain==1.8.0
 symbolic==8.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,9 @@ celery==5.1.2 \
 certifi==2021.10.8 \
     --hash=sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872 \
     --hash=sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569
-    # via requests
+    # via
+    #   requests
+    #   sentry-sdk
 cffi==1.15.0 \
     --hash=sha256:00c878c90cb53ccfaae6b8bc18ad05d2036553e6d9d1d9dbcf323bbe83854ca3 \
     --hash=sha256:0104fb5ae2391d46a4cb082abdd5c69ea4eab79d8d44eaaf79f1b1fd806ee4c2 \
@@ -572,6 +574,10 @@ s3transfer==0.5.0 \
     --hash=sha256:50ed823e1dc5868ad40c8dc92072f757aa0e653a192845c94a3b676f4a62da4c \
     --hash=sha256:9c1dc369814391a6bda20ebbf4b70a0f34630592c9aa520856bf384916af2803
     # via boto3
+sentry-sdk==1.5.3 \
+    --hash=sha256:141da032f0fa4c56f9af6b361fda57360af1789576285bd1944561f9c274f9c0 \
+    --hash=sha256:9aeff2a47f4038460296b920bf4d269284e8454e1c67547ee002ccafd9c2442b
+    # via -r requirements.in
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
@@ -709,6 +715,7 @@ urllib3==1.26.7 \
     #   -r requirements.in
     #   botocore
     #   requests
+    #   sentry-sdk
 urlwait==1.0 \
     --hash=sha256:a9bf2da792fa6983fa93f6360108e16615066ab0f9cfb7f53e5faee5f5dffaac \
     --hash=sha256:eae2c20001efc915166cac79c04bac0088ad5787ec64b36f27afd2f359953b2b

--- a/tecken/wsgi.py
+++ b/tecken/wsgi.py
@@ -19,8 +19,3 @@ os.environ.setdefault("DJANGO_CONFIGURATION", "Localdev")
 from configurations.wsgi import get_wsgi_application  # noqa
 
 application = get_wsgi_application()
-
-if "SENTRY_DSN" in os.environ:
-    from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
-
-    application = Sentry(application)


### PR DESCRIPTION
This adds Kent as a fake Sentry service and switches the Tecken webapp over to use the sentry-sdk.

Note: This doesn't update the Tecken webapp frontend which is using raven-js. I'll do that in a separate PR.