### PR TITLE
bug 1671188: remove raven-js from Tecken webapp

### DIFF
--- a/bin/build_frontend.sh
+++ b/bin/build_frontend.sh
@@ -10,9 +10,6 @@ set -eo pipefail
 # NOTE(willkg): Since this is in the image at /app/frontend/build, it gets
 # stomped on when you mount your repo directory as /app.
 
-# Because this is what create-react-app needs as a prefix
-export REACT_APP_SENTRY_PUBLIC_DSN=$FRONTEND_SENTRY_PUBLIC_DSN
-
 # We prefer to not leave any JavaScript as inline no matter how small.
 export INLINE_RUNTIME_CHUNK=false
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,6 @@
     "font-awesome": "4.7.0",
     "mobx": "6.1.1",
     "mobx-react": "7.1.0",
-    "raven-js": "3.27.2",
     "react": "16.13.1",
     "react-copy-to-clipboard": "5.0.2",
     "react-dom": "16.13.1",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,7 +13,6 @@ import {
   Link,
 } from "react-router-dom";
 import { withRouter } from "react-router";
-import Raven from "raven-js";
 import { observer } from "mobx-react";
 import "bulma/css/bulma.css";
 
@@ -32,10 +31,6 @@ import FetchError from "./FetchError";
 import Fetch from "./Fetch";
 import DisplayAPIRequests from "./APIRequests";
 import store from "./Store";
-
-if (process.env.REACT_APP_SENTRY_PUBLIC_DSN) {
-  Raven.config(process.env.REACT_APP_SENTRY_PUBLIC_DSN).install();
-}
 
 const NavWithRouter = withRouter(Nav);
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8931,11 +8931,6 @@ range-parser@^1.2.1, range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-raven-js@3.27.2:
-  version "3.27.2"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.27.2.tgz#6c33df952026cd73820aa999122b7b7737a66775"
-  integrity sha512-mFWQcXnhRFEQe5HeFroPaEghlnqy7F5E2J3Fsab189ondqUzcjwSVi7el7F36cr6PvQYXoZ1P2F5CSF2/azeMQ==
-
 raw-body@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332"


### PR DESCRIPTION
I confirmed that it's not currently in use. Rather than switch Raven out
for `sentry/@browser`, I'm going to remove it for now and if we need it we
can implement `sentry/@browser` then.