### PR TITLE
bug 1699776: adjust how disk cache manager is run

### DIFF
--- a/bin/run_eliot_disk_manager.sh
+++ b/bin/run_eliot_disk_manager.sh
@@ -4,6 +4,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+set -euo pipefail
+
 cd /app/eliot-service/
 
-PYTHONPATH=.:$PYTHONPATH python eliot/cache_manager.py
+# Run cache manager in a loop so that if it dies (ignore exit value), the loop
+# pauses for 1 minute and then starts up again. This expects disk cache manager
+# to send errors to Sentry. The 1 minute sleep is to reduce the likelihood
+# there's a spike in error reports. The loop allows this to maybe recover
+# depending on what the error was.
+while true
+do
+    PYTHONPATH=.:$PYTHONPATH python eliot/cache_manager.py || true
+
+    echo "Sleep 1 minute..."
+    sleep 60
+done

--- a/eliot-service/eliot/cache_manager.py
+++ b/eliot-service/eliot/cache_manager.py
@@ -339,6 +339,7 @@ class DiskCacheManager:
                     # something seriously wrong and the loop should terminate
                     num_unhandled_errors += 1
                     if num_unhandled_errors >= MAX_ERRORS:
+                        LOGGER.error("Exceeded maximum number of errors.")
                         raise
 
                 if processed_events:


### PR DESCRIPTION
This adjusts the run script for the eliot disk cache manager. The
thinking is that in the case the disk cache manager hits an unhandled
exception, the process will send errors to sentry and then die. Without
a running disk cache manager, the node's cache will fill up and the
node's performance will degrade significantly and maybe die.

Maybe the errors are ephemeral? Maybe the errors are recoverable?

This adjusts the run script to run the disk cache manager process in a
loop. If the disk cache manager dies, then the loop will pause for a
minute and start the disk cache manager again. If the error was
ephemeral or recoverable, the disk cache manager will take stock of the
cache, clean it up, and continue functioning. If the error was not
ephemeral or recoverable (a code bug, perhaps), then the disk cache
manager will send errors to sentry, die again, and the loop will pause
for a minute and start it up again.

The loop allows the disk cache manager to recover. The pause reduces
flapping and overwhelming spikes in error reports.

I think this is how I want to run this for now. We can adjust going
forward as we learn more.