### PR TITLE
bug 1753051: restrict pip < 22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ help:
 
 .PHONY: build
 build: .env  ## | Build docker images.
-	docker-compose build --build-arg userid=${USE_UID} --build-arg groupid=${USE_GID} base frontend
+	docker-compose build --no-cache --build-arg userid=${USE_UID} --build-arg groupid=${USE_GID} base frontend
 	touch .docker-build
 
 .PHONY: setup

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,10 @@ RUN apt-get autoremove -y && \
 COPY requirements.txt /tmp/
 # Switch to /tmp to install dependencies outside home dir
 WORKDIR /tmp
-RUN pip install -U 'pip>=10' && \
+# Install Socorro Python requirements using pip < 22 because pip 22
+# doesn't work with pip-tools. (2022-02-01)
+# https://github.com/jazzband/pip-tools/issues/1558
+RUN pip install -U 'pip<22' && \
     pip install --no-cache-dir -r requirements.txt && \
     pip check --disable-pip-version-check
 

--- a/docker/images/fakesentry/Dockerfile
+++ b/docker/images/fakesentry/Dockerfile
@@ -12,7 +12,7 @@ RUN addgroup -g $groupid app && \
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
-RUN pip install -U 'pip>=8' && \
+RUN pip install -U 'pip>=20' && \
     pip install --no-cache-dir 'kent==0.4.0'
 
 USER app


### PR DESCRIPTION
This fixes the problem where pip-tools doesn't work with pip 22. When
there's a pip-tools update, we can update to that and drop this
restriction.