### PR TITLE
bug 1753051: update pip-tools to 6.5.0 and remove pip restriction

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,10 +48,8 @@ RUN apt-get autoremove -y && \
 COPY requirements.txt /tmp/
 # Switch to /tmp to install dependencies outside home dir
 WORKDIR /tmp
-# Install Socorro Python requirements using pip < 22 because pip 22
-# doesn't work with pip-tools. (2022-02-01)
-# https://github.com/jazzband/pip-tools/issues/1558
-RUN pip install -U 'pip<22' && \
+
+RUN pip install -U 'pip>=20' && \
     pip install --no-cache-dir -r requirements.txt && \
     pip check --disable-pip-version-check
 

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ markus[datadog]==4.0.0
 mock==4.0.3
 mozilla-django-oidc==2.0.0
 msgpack==1.0.3
-pip-tools==6.4.0
+pip-tools==6.5.0
 psycopg2==2.9.3
 pytest-django==4.5.2
 pytest-mock==3.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -269,7 +269,7 @@ iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
     # via pytest
-inotify_simple==1.3.5 \
+inotify-simple==1.3.5 \
     --hash=sha256:8440ffe49c4ae81a8df57c1ae1eb4b6bfa7acb830099bfb3e305b383005cc128
     # via -r requirements.in
 jinja2==3.0.3 \
@@ -439,9 +439,9 @@ pep517==0.12.0 \
     --hash=sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0 \
     --hash=sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161
     # via pip-tools
-pip-tools==6.4.0 \
-    --hash=sha256:65553a15b1ba34be5e43889345062e38fb9b219ffa23b084ca0d4c4039b6f53b \
-    --hash=sha256:bb2c3272bc229b4a6d25230ebe255823aba1aa466a0d698c48ab7eb5ab7efdc9
+pip-tools==6.5.0 \
+    --hash=sha256:9cf69a020e3c208a7a1bcc78cbfd436dab323efc187919df6182eca98efbe3f2 \
+    --hash=sha256:d14ea4fc2c118db2a6af65a4345a8b9b355e792aedad6bf64dd3eb97c5fc5fee
     # via -r requirements.in
 platformdirs==2.4.1 \
     --hash=sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca \


### PR DESCRIPTION
pip-tools 6.5.0 fixes the issue that required us to restrict pip to <22.
This updates pip-tools to 6.5.0 and removes the restriction.