### PR TITLE
Update dockerflow to 2022.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ dj-database-url==0.5.0
 django-cache-memoize==0.1.10
 django-configurations==2.3.1
 django-redis==5.2.0
-dockerflow==2021.7.0
+dockerflow==2022.1.0
 encore==0.7.0
 everett==3.0.0
 falcon==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -199,9 +199,9 @@ django-redis==5.2.0 \
     --hash=sha256:1d037dc02b11ad7aa11f655d26dac3fb1af32630f61ef4428860a2e29ff92026 \
     --hash=sha256:8a99e5582c79f894168f5865c52bd921213253b7fd64d16733ae4591564465de
     # via -r requirements.in
-dockerflow==2021.7.0 \
-    --hash=sha256:9f309fdf72a897290878f97cc30fd4bb3609b13cf74bfce4268f5e368e466070 \
-    --hash=sha256:e47bbca06c261a5c3d97e5e0990aa71dafed41b723d0e0009c32e1d2f9b92db4
+dockerflow==2022.1.0 \
+    --hash=sha256:ec723cedb853043a0c7cada32f46f8f7eadfaf6bd7dee718e9a373b6b577d249 \
+    --hash=sha256:f40bad2d465533b1949261e5cd3ffa23fd1dd0c12f32f4e4608040ec6ad502a5
     # via -r requirements.in
 docutils==0.17.1 \
     --hash=sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125 \

--- a/tecken/pytest.ini
+++ b/tecken/pytest.ini
@@ -15,6 +15,3 @@ filterwarnings =
     # dockerflow defines default_app_config in dockerflow.django.__init__ and
     # shouldn't anymore
     ignore:.*default_app_config:django.utils.deprecation.RemovedInDjango41Warning
-    # dockerflow passes providing_args as an argument to Signal which it shouldn't
-    # do anymore
-    ignore:.*providing_args:django.utils.deprecation.RemovedInDjango40Warning


### PR DESCRIPTION
This updates dockerflow to 2022.1.0 which fixes one of the warnings we
were ignoring in the pytest configuration.