### PR TITLE
bug 1758712: migrate to cimg/base:2022.02 for ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,28 @@ jobs:
             docker-compose run --rm --no-deps test-ci bash ./bin/run_lint.sh
             docker-compose run --rm --no-deps frontend-ci lint
 
+  testeliot:
+    docker: *docker
+    steps:
+      - checkout
+
+      - *setup_remote_docker
+
+      - attach_workspace:
+          at: workspace
+
+      - run:
+          name: Load from workspace
+          command: |
+            docker load -i workspace/tecken_app.tar.gz
+
+      - run:
+          name: Run tests
+          command: |
+            make .env
+            docker-compose up -d db redis-cache minio statsd oidcprovider
+            docker-compose run --rm test-ci bash ./bin/run_test.sh eliot
+
   testtecken:
     docker: *docker
     steps:
@@ -120,7 +142,7 @@ jobs:
           command: |
             make .env
             docker-compose up -d db redis-cache minio statsd oidcprovider
-            docker-compose run --rm test-ci bash ./bin/run_test.sh
+            docker-compose run --rm test-ci bash ./bin/run_test.sh tecken
 
   testdocs:
     docker: *docker
@@ -177,6 +199,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - testeliot:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
       - testtecken:
           requires:
             - build
@@ -193,6 +221,7 @@ workflows:
           requires:
             - build
             - lint
+            - testeliot
             - testtecken
             - testdocs
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,46 +160,8 @@ jobs:
 
       - run:
           name: Push to Dockerhub
-          # yamllint disable rule:line-length
           command: |
-            function retry {
-                set +e
-                local n=0
-                local max=3
-                while true; do
-                "$@" && break || {
-                  if [[ $n -lt $max ]]; then
-                    ((n++))
-                    echo "Command failed. Attempt $n/$max:"
-                  else
-                    echo "Failed after $n attempts."
-                    exit 1
-                  fi
-                }
-                done
-                set -e
-            }
-
-            export LOCAL_IMAGE="tecken:build"
-
-            if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
-              echo "Skipping Login to Dockerhub, credentials not available."
-            else
-              echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
-
-              if [ "${CIRCLE_BRANCH}" == "main" ]; then
-                # deploy latest on main branch updates
-                docker tag "${LOCAL_IMAGE}" "${DOCKERHUB_REPO}:latest"
-                retry docker push "${DOCKERHUB_REPO}:latest"
-              elif  [ ! -z "${CIRCLE_TAG}" ]; then
-                # deploy a release tag
-                echo "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
-                docker tag "${LOCAL_IMAGE}" "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
-                docker images
-                retry docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
-              fi
-            fi
-          # yamllint enable rule:line-length
+            bin/circleci_push.sh "tecken:build"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@
 # DOCKER_PASS
 version: 2.1
 jobs:
-  build_test_publish:
-    docker:
+  build:
+    docker: &docker
       - image: cimg/base:2022.02
         auth:
           username: $DOCKER_USER
@@ -16,7 +16,8 @@ jobs:
     steps:
       - checkout
 
-      - setup_remote_docker:
+      - &setup_remote_docker
+        setup_remote_docker:
           docker_layer_caching: true
           version: 20.10.11
 
@@ -66,19 +67,96 @@ jobs:
           # yamllint enable rule:line-length
 
       - run:
+          name: Save image
+          command: |
+            mkdir -p workspace
+            docker save -o workspace/tecken_app.tar tecken:build
+            gzip --fast workspace/tecken_app.tar
+
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - tecken_app.tar.gz
+
+  lint:
+    docker: *docker
+    steps:
+      - checkout
+
+      - *setup_remote_docker
+
+      - attach_workspace:
+          at: workspace
+
+      - run:
+          name: Load from workspace
+          command: |
+            docker load -i workspace/tecken_app.tar.gz
+
+      - run:
           name: Run lint check
           command: |
-            make lintci
+            make .env
+            docker-compose run --rm --no-deps test-ci bash ./bin/run_lint.sh
+            docker-compose run --rm --no-deps frontend-ci lint
+
+  testtecken:
+    docker: *docker
+    steps:
+      - checkout
+
+      - *setup_remote_docker
+
+      - attach_workspace:
+          at: workspace
+
+      - run:
+          name: Load from workspace
+          command: |
+            docker load -i workspace/tecken_app.tar.gz
 
       - run:
           name: Run tests
           command: |
-            make testci
+            make .env
+            docker-compose up -d db redis-cache minio statsd oidcprovider
+            docker-compose run --rm test-ci bash ./bin/run_test.sh
+
+  testdocs:
+    docker: *docker
+    steps:
+      - checkout
+
+      - *setup_remote_docker
+
+      - attach_workspace:
+          at: workspace
+
+      - run:
+          name: Load from workspace
+          command: |
+            docker load -i workspace/tecken_app.tar.gz
 
       - run:
           name: Build docs
           command: |
-            make docsci
+            make .env
+            docker-compose run --rm --no-deps test-ci bash make -C docs/ html
+
+  push:
+    docker: *docker
+    steps:
+      - checkout
+
+      - *setup_remote_docker
+
+      - attach_workspace:
+          at: workspace
+
+      - run:
+          name: Load from workspace
+          command: |
+            docker load -i workspace/tecken_app.tar.gz
 
       - run:
           name: Push to Dockerhub
@@ -125,9 +203,36 @@ jobs:
 
 workflows:
   version: 2
-  main:
+  build-test-push:
     jobs:
-      - build_test_publish:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - lint:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+      - testtecken:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+      - testdocs:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+      - push:
+          requires:
+            - build
+            - lint
+            - testtecken
+            - testdocs
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,10 @@ version: 2.1
 jobs:
   build_test_publish:
     docker:
-      - image: mozilla/cidockerbases:docker-latest
+      - image: cimg/base:2022.02
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
-    working_directory: ~/tecken
 
     steps:
       - run:
@@ -23,7 +22,7 @@ jobs:
 
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 19.03.13
+          version: 20.10.11
 
       - run:
           name: Login to Dockerhub
@@ -36,7 +35,6 @@ jobs:
 
       - run:
           name: Create version.json
-          working_directory: ~/tecken
           command: |
             # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
             printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
@@ -75,7 +73,6 @@ jobs:
 
       - run:
           name: Push to Dockerhub
-          working_directory: ~/tecken
           command: |
             function retry {
                 set +e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,6 @@ jobs:
           password: $DOCKER_PASS
 
     steps:
-      - run:
-          name: Host info
-          command: uname -v
-
       - checkout
 
       - setup_remote_docker:
@@ -25,46 +21,59 @@ jobs:
           version: 20.10.11
 
       - run:
+          name: Get info
+          command: |
+            uname -v
+            docker info
+            docker-compose --version
+
+      - run:
           name: Login to Dockerhub
+          # yamllint disable rule:line-length
           command: |
             if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
               echo "Skipping Login to Dockerhub, credentials not available."
             else
               echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
             fi
+          # yamllint enable rule:line-length
 
       - run:
           name: Create version.json
+          # yamllint disable rule:line-length
           command: |
-            # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
+            # create a version.json per
+            # https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
             printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
             "$CIRCLE_SHA1" \
             "$CIRCLE_TAG" \
             "$CIRCLE_PROJECT_USERNAME" \
             "$CIRCLE_PROJECT_REPONAME" \
             "$CIRCLE_BUILD_URL" > version.json
+          # yamllint enable rule:line-length
 
       - run:
           name: Build Docker images
           command: |
-            docker info
             # build tecken containers
             make build
 
       - run:
           name: Verify requirements.txt contains correct dependencies
+          # yamllint disable rule:line-length
           command: |
             docker-compose run --rm --no-deps test-ci bash ./bin/run_verify_reqs.sh
-
-      - run:
-          name: Run tests
-          command: |
-            make testci
+          # yamllint enable rule:line-length
 
       - run:
           name: Run lint check
           command: |
             make lintci
+
+      - run:
+          name: Run tests
+          command: |
+            make testci
 
       - run:
           name: Build docs
@@ -73,6 +82,7 @@ jobs:
 
       - run:
           name: Push to Dockerhub
+          # yamllint disable rule:line-length
           command: |
             function retry {
                 set +e
@@ -111,6 +121,7 @@ jobs:
                 retry docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
               fi
             fi
+          # yamllint enable rule:line-length
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,6 @@ test: .env .docker-build  ## | Run Python unit test suite.
 	docker-compose up -d db redis-cache minio statsd oidcprovider
 	docker-compose run --rm test bash ./bin/run_test.sh
 
-.PHONY: testci
-testci: .env .docker-build  ## | Run Python unit test suite in test-ci container.
-	docker-compose up -d db redis-cache minio statsd oidcprovider
-	docker-compose run --rm test-ci bash ./bin/run_test.sh
-
 .PHONY: testshell
 testshell: .env .docker-build  ## | Open shell in test environment.
 	docker-compose up -d db redis-cache minio statsd oidcprovider
@@ -94,19 +89,10 @@ docs: .env .docker-build  ## | Build docs.
 	docker-compose run --rm --user ${USE_UID} --no-deps test bash make -C docs/ clean
 	docker-compose run --rm --user ${USE_UID} --no-deps test bash make -C docs/ html
 
-.PHONY: docs
-docsci: .env .docker-build  ## | Build docs in test-ci container
-	docker-compose run --rm --user ${USE_UID} --no-deps test-ci bash make -C docs/ html
-
 .PHONY: lint
 lint: .env .docker-build  ## | Lint code.
 	docker-compose run --rm --no-deps test bash ./bin/run_lint.sh
 	docker-compose run --rm frontend lint
-
-.PHONY: lintci
-lintci: .env .docker-build  ## | Lint code in test-ci container.
-	docker-compose run --rm --no-deps test-ci bash ./bin/run_lint.sh
-	docker-compose run --rm frontend-ci lint
 
 .PHONY: lintfix
 lintfix: .env .docker-build  ## | Reformat code.

--- a/bin/circleci_push.sh
+++ b/bin/circleci_push.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Usage: bin/circleci-push.sh [LOCALIMAGE]
+#
+# Note: Don't use this--it's only used in CI.
+#
+# Environment variables used:
+#
+# DOCKER_USER/DOCKER_PASS: dockerhub credentials
+# DOCKER_REPO: name of the repo on dockerhub to use
+# CIRCLE_BRANCH/CIRCLE_TAG: CircleCI generated environment variables
+
+set -euo pipefail
+
+function retry {
+    set +e
+    local n=0
+    local max=3
+    while true; do
+    "$@" && break || {
+        if [[ $n -lt $max ]]; then
+            ((n++))
+            echo "Command failed. Attempt $n/$max:"
+        else
+            echo "Failed after $n attempts."
+            exit 1
+        fi
+    }
+    done
+    set -e
+}
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: bin/circleci_push.sh [LOCALIMAGE]"
+    exit 1
+fi
+
+LOCAL_IMAGE="$1"
+DOCKER_USER="${DOCKER_USER:-}"
+DOCKER_PASS="${DOCKER_PASS:-}"
+
+if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
+    echo "Skipping Login to Dockerhub, credentials not available."
+    exit
+fi
+
+
+echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
+
+if [ "${CIRCLE_BRANCH}" == "main" ]; then
+    # deploy main latest
+    docker tag "${LOCAL_IMAGE}" "${DOCKERHUB_REPO}:latest"
+    retry docker push "${DOCKERHUB_REPO}:latest"
+elif  [ ! -z "${CIRCLE_TAG}" ]; then
+    # deploy a release tag
+    echo "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+    docker tag "${LOCAL_IMAGE}" "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+    docker images
+    retry docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+fi

--- a/bin/run_test.sh
+++ b/bin/run_test.sh
@@ -13,14 +13,23 @@ set -eo pipefail
 export DEVELOPMENT=1
 export DJANGO_CONFIGURATION=Test
 
-if [ "$1" = "--shell" ]; then
+if [ "$1" = "--shell" ]
+then
     bash
-else
+fi
+
+TESTSUITE="${1:-}"
+
+if [[ "$TESTSUITE" == "" ]] || [[ "$TESTSUITE" == "tecken" ]]
+then
     # Run tecken tests
     pushd tecken
     pytest
     popd
+fi
 
+if [[ "$TESTSUITE" == "" ]] || [[ "$TESTSUITE" == "eliot" ]]
+then
     # Run eliot-service tests
     pushd eliot-service
     pytest


### PR DESCRIPTION
This swaps out the deprecated ci-docker-bases image for cimg/base:2022.02 image for running CI environment.

This also:

* updates circleci configuration
* fixes yamllint issues and removes some duplicate yaml
* parallelizes the jobs