### PR TITLE
bug 1671188: remove SENTRY_PUBLIC_DSN bits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile
-      args:
-        - FRONTEND_SENTRY_PUBLIC_DSN
     platform: linux/amd64
     image: tecken:build
     environment:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,11 +4,6 @@
 # https://github.com/docker/for-mac/issues/5831
 FROM node:16.10.0-slim@sha256:9bec98898848c3e3a1346bc74ab04c2072da9d0149d8be1ea0485dbf39fd658f as frontend
 
-# these build args are turned into env vars
-# and used in bin/build_frontend.sh
-ARG FRONTEND_SENTRY_PUBLIC_DSN=UNSET_DSN
-ENV FRONTEND_SENTRY_PUBLIC_DSN=${FRONTEND_SENTRY_PUBLIC_DSN}
-
 COPY . /app
 WORKDIR /app
 RUN bin/build_frontend.sh

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -73,16 +73,15 @@ The Symbols Service covers uploading and downloading symbols.
        DJANGO_ALLOWED_HOSTS=symbols.mozilla.org
 
 
-.. envvar:: SENTRY_DSN, SENTRY_PUBLIC_DSN
+.. envvar:: SENTRY_DSN
 
-   This sets the Sentry DSN for the Python code and the JS code.
+   This sets the Sentry DSN for the Python code.
 
    For example:
 
    .. code-block:: shell
 
       SENTRY_DSN=https://bb4e266xxx:d1c1eyyy@sentry.prod.mozaws.net/001
-      SENTRY_PUBLIC_DSN=https://bb4e266xxx@sentry.prod.mozaws.net/001
 
 
 .. envvar:: DJANGO_SYMBOL_URLS


### PR DESCRIPTION
This variable was used to add the sentry dsn to the js code. We don't do
that anymore so we can remove it.