### PR TITLE
bug 1667211: move tecken test config up a level

### DIFF
--- a/bin/run_test.sh
+++ b/bin/run_test.sh
@@ -23,9 +23,7 @@ TESTSUITE="${1:-}"
 if [[ "$TESTSUITE" == "" ]] || [[ "$TESTSUITE" == "tecken" ]]
 then
     # Run tecken tests
-    pushd tecken
     pytest
-    popd
 fi
 
 if [[ "$TESTSUITE" == "" ]] || [[ "$TESTSUITE" == "eliot" ]]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 norecursedirs = .cache __pycache__
-testpaths = tests/
+testpaths = tecken/tests/
 addopts = -rsxX --showlocals --tb=native --no-migrations -p no:cacheprovider
 
 DJANGO_SETTINGS_MODULE = tecken.settings


### PR DESCRIPTION
The tecken pytest.ini needs to be up a level so it's not embedded in the
tecken code.

With eliot, we did this differently where eliot-service/ is a top-level
for all the service bits, but is not itself a python module.