### PR TITLE
bug 1667211: fix OIDC_RP_CLIENT_ID configuration parsing

### DIFF
--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -314,7 +314,7 @@ SILENCED_SYSTEM_CHECKS = [
 ]
 
 # OIDC setup
-OIDC_RP_CLIENT_ID = _config("OIDC_RP_CLIENT_ID", parser=int, doc="OIDC RP client id.")
+OIDC_RP_CLIENT_ID = _config("OIDC_RP_CLIENT_ID", doc="OIDC RP client id.")
 OIDC_RP_CLIENT_SECRET = _config("OIDC_RP_CLIENT_SECRET", doc="OIDC RP client secret.")
 
 OIDC_OP_AUTHORIZATION_ENDPOINT = _config(


### PR DESCRIPTION
The id is a str--not an int. This fixes that.

Previously, this configuration item was a SecretValue for server environments and an IntValue in the local dev environment:

https://github.com/mozilla-services/tecken/blame/eb55264be41e7315858adc8120949d95ed267db5/tecken/settings.py#L641