### PR TITLE
bug 1760308: create docs container and fix configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ testshell: .env .docker-build  ## | Open shell in test environment.
 
 .PHONY: docs
 docs: .env .docker-build  ## | Build docs.
-	docker-compose run --rm --user ${USE_UID} --no-deps test bash make -C docs/ clean
-	docker-compose run --rm --user ${USE_UID} --no-deps test bash make -C docs/ html
+	docker-compose run --rm --user ${USE_UID} --no-deps docs bash make -C docs/ clean
+	docker-compose run --rm --user ${USE_UID} --no-deps docs bash make -C docs/ html
 
 .PHONY: lint
 lint: .env .docker-build  ## | Lint code.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,16 @@ services:
       - fakesentry
       - redis-cache
 
+  docs:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    platform: linux/amd64
+    env_file:
+      - .env
+    volumes:
+      - $PWD:/app
+
   # Web container is a prod-like fully-functioning container.
   gunicorn:
     extends:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,14 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import os
 import sys
 from pathlib import Path
+
+
+# Set TOOL_ENV to true to pick up fake settings so configuration doesn't fail.
+os.environ["TOOL_ENV"] = "true"
+
 
 BASEDIR = Path(__file__).parent.parent
 # Insert repo base dir which will pick up Tecken webapp things


### PR DESCRIPTION
This fixes ReadTheDocs building in a couple of ways:

1. it creates a docs container that more accurately reflects the
   environment ReadTheDocs is building Tecken docs in
2. it sets TOOL_ENV=true so building the docs happens with fake values
   for required settings