### PR TITLE
fix bug 1762056: update kent to 0.4.1 for compatibility w/ new flask 2.1.0

### DIFF
--- a/docker/images/fakesentry/Dockerfile
+++ b/docker/images/fakesentry/Dockerfile
@@ -13,7 +13,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 RUN pip install -U 'pip>=20' && \
-    pip install --no-cache-dir 'kent==0.4.0'
+    pip install --no-cache-dir 'kent==0.4.1'
 
 USER app
 


### PR DESCRIPTION
fix bug [1762056](https://bugzilla.mozilla.org/show_bug.cgi?id=1762056) 

Kent 0.4.0 became incompatible with Flask's yesterday release 2.1.0, breaking fakesentry docker image build. This fixes fakesentry image build by updating Kent to 0.4.1. 

Tests:
`make test`, `make build` and `make run` from a fresh clone