### PR TITLE
bug 1668371: Async fetch Files and Aggregates

### DIFF
--- a/frontend/src/Common.js
+++ b/frontend/src/Common.js
@@ -106,6 +106,7 @@ export const Pagination = ({
   batchSize,
   currentPage,
   updateFilter,
+  hasNext,
 }) => {
   if (!currentPage) {
     currentPage = 1;
@@ -126,7 +127,11 @@ export const Pagination = ({
 
   const isOverflow = (page) => {
     // return true if doesn't make sense to go to this page
-    return page < 1 || (page - 1) * batchSize >= total;
+    if (hasNext !== undefined) {
+      return page < 1 || !hasNext
+    } else {
+      return page < 1 || (page - 1) * batchSize >= total;
+    }
   };
 
   return (
@@ -151,18 +156,27 @@ export const Pagination = ({
   );
 };
 
-export const TableSubTitle = ({ total, page, batchSize }) => {
-  if (total === null) {
+export const TableSubTitle = ({
+  total,
+  page,
+  batchSize,
+  calculating = false,
+}) => {
+  if (total === null && !calculating) {
     return null;
   }
   page = page || 1;
   const totalPages = Math.ceil(total / batchSize);
-  return (
-    <h2 className="subtitle">
-      {thousandFormat(total)} Found (Page {thousandFormat(page)} of{" "}
-      {thousandFormat(totalPages)})
-    </h2>
-  );
+  if (calculating) {
+    return <h2 className="subtitle">Calculating ...</h2>;
+  } else {
+    return (
+      <h2 className="subtitle">
+        {thousandFormat(total)} Found (Page {thousandFormat(page)} of{" "}
+        {thousandFormat(totalPages)})
+      </h2>
+    );
+  }
 };
 
 export const pluralize = (number, singular, plural) => {

--- a/frontend/src/Common.js
+++ b/frontend/src/Common.js
@@ -128,7 +128,7 @@ export const Pagination = ({
   const isOverflow = (page) => {
     // return true if doesn't make sense to go to this page
     if (hasNext !== undefined) {
-      return page < 1 || !hasNext
+      return page < 1 || !hasNext;
     } else {
       return page < 1 || (page - 1) * batchSize >= total;
     }

--- a/frontend/src/Common.js
+++ b/frontend/src/Common.js
@@ -125,12 +125,20 @@ export const Pagination = ({
     updateFilter({ page });
   };
 
-  const isOverflow = (page) => {
-    // return true if doesn't make sense to go to this page
-    if (hasNext !== undefined) {
-      return page < 1 || !hasNext;
+  const hasPrevPage = (currPage) => {
+    // in /uploads/files 'total' is loaded async so there's no guarantee it'll be present
+    if (total !== undefined) {
+      return currPage - 1 >= 1 && (currPage - 2) * batchSize < total;
     } else {
-      return page < 1 || (page - 1) * batchSize >= total;
+      return currPage - 1 >= 1;
+    }
+  };
+
+  const hasNextPage = (currPage) => {
+    if (hasNext !== undefined) {
+      return hasNext;
+    } else {
+      return currPage + 1 >= 1 && currPage * batchSize < total;
     }
   };
 
@@ -139,16 +147,16 @@ export const Pagination = ({
       <Link
         className="pagination-previous"
         to={nextPageUrl(currentPage - 1)}
-        onClick={(e) => goTo(e, currentPage - 1)}
-        disabled={isOverflow(currentPage - 1)}
+        onClick={(e) => hasPrevPage(currentPage) && goTo(e, currentPage - 1)}
+        disabled={!hasPrevPage(currentPage)}
       >
         Previous
       </Link>
       <Link
         to={nextPageUrl(currentPage + 1)}
         className="pagination-next"
-        onClick={(e) => goTo(e, currentPage + 1)}
-        disabled={isOverflow(currentPage + 1)}
+        onClick={(e) => hasNextPage(currentPage) && goTo(e, currentPage + 1)}
+        disabled={!hasNextPage(currentPage)}
       >
         Next page
       </Link>

--- a/frontend/src/Files.js
+++ b/frontend/src/Files.js
@@ -59,7 +59,7 @@ class Files extends React.PureComponent {
     }
   }
 
-  _fetch = (url, callback, updateHistory = true) => {
+  _fetch = (url, callback, errorCallback, updateHistory = true) => {
     const qs = filterToQueryString(this.state.filter);
 
     if (qs) {
@@ -85,6 +85,9 @@ class Files extends React.PureComponent {
         return r.json().then((response) => callback(response));
       } else {
         store.fetchError = r;
+        if (errorCallback) {
+          errorCallback();
+        }
       }
     });
   };
@@ -103,8 +106,16 @@ class Files extends React.PureComponent {
       });
       this.setState({ loadingFiles: false });
     };
+    var errorCallback = () => {
+      this.setState({ loadingFiles: false });
+    };
     this.setState({ loadingFiles: true });
-    this._fetch("/api/uploads/files/content", callback, updateHistory);
+    this._fetch(
+      "/api/uploads/files/content",
+      callback,
+      errorCallback,
+      updateHistory
+    );
   };
 
   _fetchAggregates = () => {
@@ -115,8 +126,11 @@ class Files extends React.PureComponent {
       });
       this.setState({ loadingAggregates: false });
     };
+    var errorCallback = () => {
+      this.setState({ loadingAggregates: false });
+    };
     this.setState({ loadingAggregates: true });
-    this._fetch("/api/uploads/files/aggregates", callback);
+    this._fetch("/api/uploads/files/aggregates", callback, errorCallback);
   };
 
   filterOnAll = (event) => {
@@ -161,12 +175,14 @@ class Files extends React.PureComponent {
         {this.state.loadingFiles ? (
           <Loading />
         ) : (
-          <TableSubTitle
-            total={this.state.total}
-            page={this.state.filter.page}
-            batchSize={this.state.batchSize}
-            calculating={this.state.loadingAggregates}
-          />
+          this.state.files && (
+            <TableSubTitle
+              total={this.state.total}
+              page={this.state.filter.page}
+              batchSize={this.state.batchSize}
+              calculating={this.state.loadingAggregates}
+            />
+          )
         )}
 
         {!this.state.loadingFiles && this.state.files && (
@@ -185,7 +201,7 @@ class Files extends React.PureComponent {
           <Loading />
         )}
 
-        {!this.state.loadingAggregates && (
+        {!this.state.loadingAggregates && this.state.files && (
           <DisplayFilesAggregates
             aggregates={this.state.aggregates}
             total={this.state.total}

--- a/frontend/src/Files.js
+++ b/frontend/src/Files.js
@@ -59,13 +59,11 @@ class Files extends React.PureComponent {
     }
   }
 
-  _fetch = (selector, callback, updateHistory = true) => {
+  _fetch = (url, callback, updateHistory = true) => {
     const qs = filterToQueryString(this.state.filter);
-    const qSelector = selector ? "selector=" + selector : "";
 
-    var url = "/api/uploads/files?" + qSelector;
     if (qs) {
-      url += "&" + qs;
+      url += "?" + qs;
     }
     this.props.history.push({ search: qs });
 
@@ -106,7 +104,7 @@ class Files extends React.PureComponent {
       this.setState({ loadingFiles: false });
     };
     this.setState({ loadingFiles: true });
-    this._fetch("files", callback, updateHistory);
+    this._fetch("/api/uploads/files/content", callback, updateHistory);
   };
 
   _fetchAggregates = () => {
@@ -118,7 +116,7 @@ class Files extends React.PureComponent {
       this.setState({ loadingAggregates: false });
     };
     this.setState({ loadingAggregates: true });
-    this._fetch("aggregates", callback);
+    this._fetch("/api/uploads/files/aggregates", callback);
   };
 
   filterOnAll = (event) => {
@@ -188,11 +186,11 @@ class Files extends React.PureComponent {
         )}
 
         {!this.state.loadingAggregates && (
-            <DisplayFilesAggregates
-              aggregates={this.state.aggregates}
-              total={this.state.total}
-            />
-          )}
+          <DisplayFilesAggregates
+            aggregates={this.state.aggregates}
+            total={this.state.total}
+          />
+        )}
       </div>
     );
   }

--- a/frontend/src/Files.js
+++ b/frontend/src/Files.js
@@ -30,8 +30,10 @@ class Files extends React.PureComponent {
     super(props);
     this.pageTitle = "All Files";
     this.state = {
-      loading: true, // undone by componentDidMount
+      loadingFiles: true, // undone by componentDidMount
+      loadingAggregates: true,
       files: null,
+      hasNextPage: false,
       total: null,
       batchSize: null,
       apiUrl: null,
@@ -49,23 +51,21 @@ class Files extends React.PureComponent {
       this.setState(
         { filter: parseQueryString(this.props.location.search) },
         () => {
-          this._fetchFiles(false);
+          this._fetchFilesAndAggregatesAsync(false);
         }
       );
     } else {
-      this._fetchFiles(false);
+      this._fetchFilesAndAggregatesAsync(false);
     }
   }
 
-  _fetchFiles = (updateHistory = true) => {
-    // delay the loading animation in case it loads really fast
-    this.setLoadingTimer = window.setTimeout(() => {
-      this.setState({ loading: true });
-    }, 500);
-    let url = "/api/uploads/files/";
+  _fetch = (selector, callback, updateHistory = true) => {
     const qs = filterToQueryString(this.state.filter);
+    const qSelector = selector ? "selector=" + selector : "";
+
+    var url = "/api/uploads/files?" + qSelector;
     if (qs) {
-      url += "?" + qs;
+      url += "&" + qs;
     }
     this.props.history.push({ search: qs });
 
@@ -80,23 +80,45 @@ class Files extends React.PureComponent {
         );
         return;
       }
-      this.setState({ loading: false });
       if (r.status === 200) {
         if (store.fetchError) {
           store.fetchError = null;
         }
-        return r.json().then((response) => {
-          this.setState({
-            files: response.files,
-            aggregates: response.aggregates,
-            total: response.total,
-            batchSize: response.batch_size,
-          });
-        });
+        return r.json().then((response) => callback(response));
       } else {
         store.fetchError = r;
       }
     });
+  };
+
+  _fetchFilesAndAggregatesAsync = (updateHistory = true) => {
+    this._fetchFiles(updateHistory);
+    this._fetchAggregates();
+  };
+
+  _fetchFiles = (updateHistory = true) => {
+    var callback = (response) => {
+      this.setState({
+        files: response.files,
+        hasNextPage: response.has_next,
+        batchSize: response.batch_size,
+      });
+      this.setState({ loadingFiles: false });
+    };
+    this.setState({ loadingFiles: true });
+    this._fetch("files", callback, updateHistory);
+  };
+
+  _fetchAggregates = () => {
+    var callback = (response) => {
+      this.setState({
+        aggregates: response.aggregates,
+        total: response.total,
+      });
+      this.setState({ loadingAggregates: false });
+    };
+    this.setState({ loadingAggregates: true });
+    this._fetch("aggregates", callback);
   };
 
   filterOnAll = (event) => {
@@ -107,7 +129,7 @@ class Files extends React.PureComponent {
     filter.page = 1;
     filter.key = "";
     filter.size = "";
-    this.setState({ filter: filter }, this._fetchFiles);
+    this.setState({ filter: filter }, this._fetchFilesAndAggregatesAsync);
   };
 
   updateFilter = (newFilters) => {
@@ -115,7 +137,7 @@ class Files extends React.PureComponent {
       {
         filter: Object.assign({}, this.state.filter, newFilters),
       },
-      this._fetchFiles
+      this._fetchFilesAndAggregatesAsync
     );
   };
 
@@ -138,28 +160,39 @@ class Files extends React.PureComponent {
         ) : null}
         <h1 className="title">{this.pageTitle}</h1>
 
-        {this.state.loading ? (
+        {this.state.loadingFiles ? (
           <Loading />
         ) : (
           <TableSubTitle
             total={this.state.total}
             page={this.state.filter.page}
             batchSize={this.state.batchSize}
+            calculating={this.state.loadingAggregates}
           />
         )}
 
-        {this.state.files && (
+        {!this.state.loadingFiles && this.state.files && (
           <DisplayFiles
-            loading={this.state.loading}
+            loading={this.state.loadingFiles}
             files={this.state.files}
-            aggregates={this.state.aggregates}
-            total={this.state.total}
             batchSize={this.state.batchSize}
             location={this.props.location}
             filter={this.state.filter}
             updateFilter={this.updateFilter}
+            hasNextPage={this.state.hasNextPage}
           />
         )}
+
+        {this.state.loadingAggregates && !this.state.loadingFiles && (
+          <Loading />
+        )}
+
+        {!this.state.loadingAggregates && (
+            <DisplayFilesAggregates
+              aggregates={this.state.aggregates}
+              total={this.state.total}
+            />
+          )}
       </div>
     );
   }
@@ -200,7 +233,7 @@ class DisplayFiles extends React.PureComponent {
     this.submitForm(event);
   };
   render() {
-    const { loading, files, aggregates } = this.props;
+    const { loading, files } = this.props;
 
     return (
       <form onSubmit={this.submitForm}>
@@ -332,67 +365,71 @@ class DisplayFiles extends React.PureComponent {
             batchSize={this.props.batchSize}
             updateFilter={this.props.updateFilter}
             currentPage={this.props.filter.page}
+            hasNext={this.props.hasNextPage}
           />
         )}
-
-        {!loading && <ShowAggregates aggregates={aggregates} />}
       </form>
     );
   }
 }
 
-const ShowAggregates = ({ aggregates }) => {
-  return (
-    <nav className="level" style={{ marginTop: 60 }}>
-      <div className="level-item has-text-centered">
-        <div>
-          <p className="heading">Files</p>
-          <p className="title">
-            {aggregates.files.count
-              ? thousandFormat(aggregates.files.count)
-              : "n/a"}
-          </p>
+class DisplayFilesAggregates extends React.PureComponent {
+  render() {
+    const { aggregates } = this.props;
+    return (
+      <nav className="level" style={{ marginTop: 60 }}>
+        <div className="level-item has-text-centered">
+          <div>
+            <p className="heading">Files</p>
+            <p className="title">
+              {aggregates.files.count
+                ? thousandFormat(aggregates.files.count)
+                : "n/a"}
+            </p>
+          </div>
         </div>
-      </div>
-      <div className="level-item has-text-centered">
-        <div title="Files that got started upload but never finished for some reason">
-          <p className="heading">Incomplete Files</p>
-          <p className="title">{thousandFormat(aggregates.files.incomplete)}</p>
+        <div className="level-item has-text-centered">
+          <div title="Files that got started upload but never finished for some reason">
+            <p className="heading">Incomplete Files</p>
+            <p className="title">
+              {thousandFormat(aggregates.files.incomplete)}
+            </p>
+          </div>
         </div>
-      </div>
-      <div className="level-item has-text-centered">
-        <div>
-          <p className="heading">File Sizes Sum</p>
-          <p className="title">
-            {aggregates.files.size.sum
-              ? formatFileSize(aggregates.files.size.sum)
-              : "n/a"}
-          </p>
+        <div className="level-item has-text-centered">
+          <div>
+            <p className="heading">File Sizes Sum</p>
+            <p className="title">
+              {aggregates.files.size.sum
+                ? formatFileSize(aggregates.files.size.sum)
+                : "n/a"}
+            </p>
+          </div>
         </div>
-      </div>
-      <div className="level-item has-text-centered">
-        <div>
-          <p className="heading">File Sizes Avg</p>
-          <p className="title">
-            {aggregates.files.size.average
-              ? formatFileSize(aggregates.files.size.average)
-              : "n/a"}
-          </p>
+        <div className="level-item has-text-centered">
+          <div>
+            <p className="heading">File Sizes Avg</p>
+            <p className="title">
+              {aggregates.files.size.average
+                ? formatFileSize(aggregates.files.size.average)
+                : "n/a"}
+            </p>
+          </div>
         </div>
-      </div>
-      <div
-        className="level-item has-text-centered"
-        title="Average time to complete upload of completed files"
-      >
-        <div>
-          <p className="heading">Upload Time Avg</p>
-          <p className="title">
-            {aggregates.files.time.average
-              ? formatSeconds(aggregates.files.time.average)
-              : "n/a"}
-          </p>
+        <div
+          className="level-item has-text-centered"
+          title="Average time to complete upload of completed files"
+        >
+          <div>
+            <p className="heading">Upload Time Avg</p>
+            <p className="title">
+              {aggregates.files.time.average
+                ? formatSeconds(aggregates.files.time.average)
+                : "n/a"}
+            </p>
+          </div>
         </div>
-      </div>
-    </nav>
-  );
-};
+      </nav>
+    );
+  }
+}

--- a/frontend/src/Files.js
+++ b/frontend/src/Files.js
@@ -111,7 +111,7 @@ class Files extends React.PureComponent {
     };
     this.setState({ loadingFiles: true });
     this._fetch(
-      "/api/uploads/files/content",
+      "/api/uploads/files/content/",
       callback,
       errorCallback,
       updateHistory
@@ -130,7 +130,7 @@ class Files extends React.PureComponent {
       this.setState({ loadingAggregates: false });
     };
     this.setState({ loadingAggregates: true });
-    this._fetch("/api/uploads/files/aggregates", callback, errorCallback);
+    this._fetch("/api/uploads/files/aggregates/", callback, errorCallback);
   };
 
   filterOnAll = (event) => {

--- a/tecken/api/forms.py
+++ b/tecken/api/forms.py
@@ -257,6 +257,7 @@ class FileUploadsForm(UploadsForm):
     update = forms.BooleanField(required=False)
     compressed = forms.BooleanField(required=False)
     bucket_name = forms.CharField(required=False)
+    selector = forms.MultipleChoiceField(required=False, choices=(('aggregates','aggregates'),('files','files')))
 
     def clean_key(self):
         values = self.cleaned_data["key"]
@@ -278,6 +279,12 @@ class FileUploadsForm(UploadsForm):
                     operator = "="
                 cleaned.append((operator, value))
         return cleaned
+
+    def clean_selector(self):
+        values = self.cleaned_data["selector"]
+        if not values:
+            return {'files', 'aggregates'}
+        return values
 
 
 COUNT_RE = re.compile(

--- a/tecken/api/forms.py
+++ b/tecken/api/forms.py
@@ -257,7 +257,6 @@ class FileUploadsForm(UploadsForm):
     update = forms.BooleanField(required=False)
     compressed = forms.BooleanField(required=False)
     bucket_name = forms.CharField(required=False)
-    selector = forms.MultipleChoiceField(required=False, choices=(('aggregates','aggregates'),('files','files')))
 
     def clean_key(self):
         values = self.cleaned_data["key"]
@@ -279,12 +278,6 @@ class FileUploadsForm(UploadsForm):
                     operator = "="
                 cleaned.append((operator, value))
         return cleaned
-
-    def clean_selector(self):
-        values = self.cleaned_data["selector"]
-        if not values:
-            return {'files', 'aggregates'}
-        return values
 
 
 COUNT_RE = re.compile(

--- a/tecken/api/urls.py
+++ b/tecken/api/urls.py
@@ -37,10 +37,12 @@ urlpatterns = [
     ),
     path("uploads/files/", views.upload_files, name="upload_files"),
     path(
-        "uploads/files/content", views.upload_files_content, name="upload_files_content"
+        "uploads/files/content/",
+        views.upload_files_content,
+        name="upload_files_content",
     ),
     path(
-        "uploads/files/aggregates",
+        "uploads/files/aggregates/",
         views.upload_files_aggregates,
         name="upload_files_aggregates",
     ),

--- a/tecken/api/urls.py
+++ b/tecken/api/urls.py
@@ -36,6 +36,14 @@ urlpatterns = [
         name="uploads_created_backfilled",
     ),
     path("uploads/files/", views.upload_files, name="upload_files"),
+    path(
+        "uploads/files/content", views.upload_files_content, name="upload_files_content"
+    ),
+    path(
+        "uploads/files/aggregates",
+        views.upload_files_aggregates,
+        name="upload_files_aggregates",
+    ),
     path("uploads/files/file/<int:id>", views.upload_file, name="upload_file"),
     path("uploads/upload/<int:id>", views.upload, name="upload"),
     path("downloads/missing/", views.downloads_missing, name="downloads_missing"),

--- a/tecken/api/views.py
+++ b/tecken/api/views.py
@@ -14,7 +14,7 @@ from django.contrib.auth.models import Permission, User
 from django.db.models import Aggregate, Count, Q, Sum, Avg, F, Min
 from django.utils import timezone
 from django.shortcuts import get_object_or_404
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, BadRequest
 from django.core.cache import cache
 
 from tecken.api import forms
@@ -558,10 +558,7 @@ def uploads_created_backfilled(request):
     return http.JsonResponse(context)
 
 
-@metrics.timer_decorator("api", tags=["endpoint:upload_files"])
-@api_login_required
-@api_permission_required("upload.view_all_uploads")
-def upload_files(request):
+def _upload_files_build_qs(request):
     form = forms.FileUploadsForm(request.GET)
     if not form.is_valid():
         return http.JsonResponse({"errors": form.errors}, status=400)
@@ -583,49 +580,15 @@ def upload_files(request):
             include_bucket_names.append(bucket_name)
     if include_bucket_names:
         qs = qs.filter(bucket_name__in=include_bucket_names)
-
-    selector = form.cleaned_data["selector"]
-
-    context = {}
-    if "files" in selector:
-        pagination_form = PaginationForm(request.GET)
-        if not pagination_form.is_valid():
-            return http.JsonResponse({"errors": pagination_form.errors}, status=400)
-        page = pagination_form.cleaned_data["page"]
-        context = _upload_files_content(page, qs)
-
-    if "aggregates" in selector:
-        aggregates = _upload_files_aggregates(qs)
-        context["aggregates"] = aggregates
-        context["total"] = aggregates["files"]["count"]
-
-    return http.JsonResponse(context)
+    return qs
 
 
-def _upload_files_aggregates(qs):
-    aggregates_numbers = qs.aggregate(
-        count=Count("id"), size_avg=Avg("size"), size_sum=Sum("size")
-    )
-    time_avg = qs.filter(completed_at__isnull=False).aggregate(
-        time_avg=Avg(F("completed_at") - F("created_at"))
-    )["time_avg"]
-    if time_avg is not None:
-        time_avg = time_avg.total_seconds()
-    aggregates = {
-        "files": {
-            "count": aggregates_numbers["count"],
-            "incomplete": qs.filter(completed_at__isnull=True).count(),
-            "size": {
-                "average": aggregates_numbers["size_avg"],
-                "sum": aggregates_numbers["size_sum"],
-            },
-            "time": {"average": time_avg},
-        }
-    }
-    return aggregates
+def _upload_files_content(request, qs):
+    pagination_form = PaginationForm(request.GET)
+    if not pagination_form.is_valid():
+        raise BadRequest(pagination_form.errors)
+    page = pagination_form.cleaned_data["page"]
 
-
-def _upload_files_content(page, qs):
     files = []
     batch_size = settings.API_FILES_BATCH_SIZE
     start = (page - 1) * batch_size
@@ -634,9 +597,11 @@ def _upload_files_content(page, qs):
 
     upload_ids = set()
     file_uploads = qs.order_by("-created_at")[start:end]
-    if len(file_uploads) == batch_size + 1:
-        has_next = True
-    for file_upload in file_uploads[:batch_size]:
+    for i, file_upload in enumerate(file_uploads):
+        if i == batch_size:
+            has_next = True
+            continue
+
         files.append(
             {
                 "id": file_upload.id,
@@ -681,6 +646,67 @@ def _upload_files_content(page, qs):
     }
 
     return content
+
+
+def _upload_files_aggregates(qs):
+    aggregates_numbers = qs.aggregate(
+        count=Count("id"), size_avg=Avg("size"), size_sum=Sum("size")
+    )
+    time_avg = qs.filter(completed_at__isnull=False).aggregate(
+        time_avg=Avg(F("completed_at") - F("created_at"))
+    )["time_avg"]
+    if time_avg is not None:
+        time_avg = time_avg.total_seconds()
+    aggregates = {
+        "files": {
+            "count": aggregates_numbers["count"],
+            "incomplete": qs.filter(completed_at__isnull=True).count(),
+            "size": {
+                "average": aggregates_numbers["size_avg"],
+                "sum": aggregates_numbers["size_sum"],
+            },
+            "time": {"average": time_avg},
+        }
+    }
+
+    return {"aggregates": aggregates, "total": aggregates["files"]["count"]}
+
+
+@metrics.timer_decorator("api", tags=["endpoint:upload_files"])
+@api_login_required
+@api_permission_required("upload.view_all_uploads")
+def upload_files(request):
+    qs = _upload_files_build_qs(request)
+    try:
+        context = _upload_files_content(request, qs)
+    except BadRequest as e:
+        return http.JsonResponse({"errors": str(e)}, status=400)
+    aggregates = _upload_files_aggregates(qs)
+    context.update(aggregates)
+    context["total"] = aggregates["aggregates"]["files"]["count"]
+
+    return http.JsonResponse(context)
+
+
+@metrics.timer_decorator("api", tags=["endpoint:upload_files_content"])
+@api_login_required
+@api_permission_required("upload.view_all_uploads")
+def upload_files_content(request):
+    qs = _upload_files_build_qs(request)
+    try:
+        content = _upload_files_content(request, qs)
+    except BadRequest as e:
+        return http.JsonResponse({"errors": str(e)}, status=400)
+    return http.JsonResponse(content)
+
+
+@metrics.timer_decorator("api", tags=["endpoint:upload_files_content_aggregates"])
+@api_login_required
+@api_permission_required("upload.view_all_uploads")
+def upload_files_aggregates(request):
+    qs = _upload_files_build_qs(request)
+    aggregates = _upload_files_aggregates(qs)
+    return http.JsonResponse(aggregates)
 
 
 @metrics.timer_decorator("api", tags=["endpoint:upload_file"])

--- a/tecken/api/views.py
+++ b/tecken/api/views.py
@@ -586,7 +586,7 @@ def _upload_files_build_qs(request):
 def _upload_files_content(request, qs):
     pagination_form = PaginationForm(request.GET)
     if not pagination_form.is_valid():
-        raise BadRequest(pagination_form.errors)
+        raise BadRequest("formerrors", pagination_form.errors)
     page = pagination_form.cleaned_data["page"]
 
     files = []
@@ -680,7 +680,7 @@ def upload_files(request):
     try:
         context = _upload_files_content(request, qs)
     except BadRequest as e:
-        return http.JsonResponse({"errors": str(e)}, status=400)
+        return http.JsonResponse({"errors": e.args[1]}, status=400)
     aggregates = _upload_files_aggregates(qs)
     context.update(aggregates)
     context["total"] = aggregates["aggregates"]["files"]["count"]
@@ -696,7 +696,7 @@ def upload_files_content(request):
     try:
         content = _upload_files_content(request, qs)
     except BadRequest as e:
-        return http.JsonResponse({"errors": str(e)}, status=400)
+        return http.JsonResponse({"errors": e.args[1]}, status=400)
     return http.JsonResponse(content)
 
 

--- a/tecken/tests/test_api.py
+++ b/tecken/tests/test_api.py
@@ -868,6 +868,39 @@ def test_upload_files(client, settings):
     assert aggregates["files"]["incomplete"] == 2
     assert aggregates["files"]["size"]["sum"] == 1234 + 100
 
+    # When filtering by different selectors, must return data for that selector only
+    response = client.get(
+        url,
+        {
+            "selector": "files",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["files"]
+    assert data["batch_size"] == settings.API_FILES_BATCH_SIZE
+    assert data["has_next"] == False
+    assert "aggregates" not in data
+    assert "total" not in data
+
+
+    response = client.get(
+        url,
+        {
+            "selector": "aggregates",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["aggregates"]
+    assert "files" not in data
+    aggregates = data["aggregates"]
+    assert data["total"] == 2
+    assert aggregates["files"]["count"] == 2
+    assert aggregates["files"]["incomplete"] == 2
+    assert aggregates["files"]["size"]["sum"] == 1234 + 100
+
+
     # Filter by created_at and completed_at
     response = client.get(
         url,

--- a/tecken/tests/test_api.py
+++ b/tecken/tests/test_api.py
@@ -822,8 +822,10 @@ def test_upload_files(client, settings):
     assert data["files"] == []
 
     # Don't mess with the 'page' key
+    error_body = {"errors": {"page": ["Not a number 'notanumber'"]}}
     response = client.get(url, {"page": "notanumber"})
     assert response.status_code == 400
+    assert response.json() == error_body
 
     # Let's pretend there's an upload belonging to someone else
     upload = Upload.objects.create(

--- a/tecken/tests/test_api.py
+++ b/tecken/tests/test_api.py
@@ -868,28 +868,20 @@ def test_upload_files(client, settings):
     assert aggregates["files"]["incomplete"] == 2
     assert aggregates["files"]["size"]["sum"] == 1234 + 100
 
-    # When filtering by different selectors, must return data for that selector only
-    response = client.get(
-        url,
-        {
-            "selector": "files",
-        },
-    )
+    url_content = reverse("api:upload_files_content")
+    # Must return only "content" data
+    response = client.get(url_content)
     assert response.status_code == 200
     data = response.json()
     assert data["files"]
     assert data["batch_size"] == settings.API_FILES_BATCH_SIZE
-    assert data["has_next"] == False
+    assert data["has_next"] is False
     assert "aggregates" not in data
     assert "total" not in data
 
-
-    response = client.get(
-        url,
-        {
-            "selector": "aggregates",
-        },
-    )
+    url_aggregates = reverse("api:upload_files_aggregates")
+    # Must return only "aggregates" data
+    response = client.get(url_aggregates)
     assert response.status_code == 200
     data = response.json()
     assert data["aggregates"]
@@ -899,7 +891,6 @@ def test_upload_files(client, settings):
     assert aggregates["files"]["count"] == 2
     assert aggregates["files"]["incomplete"] == 2
     assert aggregates["files"]["size"]["sum"] == 1234 + 100
-
 
     # Filter by created_at and completed_at
     response = client.get(


### PR DESCRIPTION
Related to bug 1668371 (doesn't fix it)

This change addresses the slowness on the File Uploads page by splitting that page into two different components that will load asynchronously (note the UI doesn't change, only how the components load): 
* "Files", which populates a table with a list of files and 
* "FilesAggregates", which provides total count, avg size and avg upload time. 

Local tests have indicated usability will increase since users will be able to visualize the list of files quicker while the Aggregates part, slower to fetch, loads in parallel.

This change was also done to make further work on optimizing performance of that page easier, by allowing us to tweak the distinct components individually.