### PR TITLE
Bug 1668371 async fetch uploads

### DIFF
--- a/tecken/api/urls.py
+++ b/tecken/api/urls.py
@@ -31,7 +31,6 @@ urlpatterns = [
     path("uploads/", views.uploads, name="uploads"),
     path("uploads/content/", views.uploads_content, name="uploads_content"),
     path("uploads/aggregates/", views.uploads_aggregates, name="uploads_aggregates"),
-
     path("uploads/created/", views.uploads_created, name="uploads_created"),
     path(
         "uploads/created/backfilled/",

--- a/tecken/api/urls.py
+++ b/tecken/api/urls.py
@@ -29,6 +29,9 @@ urlpatterns = [
         name="possible_upload_urls",
     ),
     path("uploads/", views.uploads, name="uploads"),
+    path("uploads/content/", views.uploads_content, name="uploads_content"),
+    path("uploads/aggregates/", views.uploads_aggregates, name="uploads_aggregates"),
+
     path("uploads/created/", views.uploads_created, name="uploads_created"),
     path(
         "uploads/created/backfilled/",

--- a/tecken/api/views.py
+++ b/tecken/api/views.py
@@ -299,6 +299,7 @@ def _uploads_content(form, pagination_form, qs, can_view_all):
     content["has_next"] = has_next
     return content
 
+
 def _uploads_aggregates(form, qs, can_view_all):
     context = {}
     if can_view_all and not any(form.cleaned_data.values()):

--- a/tecken/api/views.py
+++ b/tecken/api/views.py
@@ -246,7 +246,7 @@ def _uploads_content(form, pagination_form, qs, can_view_all):
     for i, upload in enumerate(uploads):
         if i == batch_size:
             has_next = True
-            continue
+            break
 
         rows.append(
             {
@@ -640,7 +640,7 @@ def _upload_files_content(request, qs):
     for i, file_upload in enumerate(file_uploads):
         if i == batch_size:
             has_next = True
-            continue
+            break
 
         files.append(
             {


### PR DESCRIPTION
Related to bug 1668371 (greatly alleviates its symptoms but doesn't quite fix it)

This change addresses the slowness on the Uploads page by splitting that page into two different components that will load asynchronously (the UI doesn't change, only how the components load): 

- "Uploads", which populates a table with a list of uploads 
- "Aggregates", which provides the aggregated metrics on the bottom of the page

I tested the different functionalities of the page such as page navigation, filters (including "Your Uploads") and the "New Uploads" button that refreshes the page when clicked.
