### PR TITLE
bug 1758566: fix cache invalidation for try symbols

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -17,6 +17,8 @@ SECRET_KEY=DontusethisinproductionbutitneedsbelongforCI1234567890
 
 DATABASE_URL=postgresql://postgres:postgres@db/tecken
 
+REDIS_URL=redis://redis-cache:6379/0
+
 SENTRY_DSN=http://public@fakesentry:8090/1
 
 # NOTE(willkg): See docker-compose.yml on how localstack is set up.

--- a/tecken/base/symboldownloader.py
+++ b/tecken/base/symboldownloader.py
@@ -108,7 +108,10 @@ def exists_in_source(source, key):
 @metrics.timer_decorator("symboldownloader_public_exists")
 def check_url_head(url):
     session = session_with_retries()
-    return session.head(url).status_code == 200
+    resp = session.head(url)
+    if resp.status_code not in (200, 404):
+        logger.error(f"check_url_head: {url} status code is {resp.status_code}")
+    return resp.status_code == 200
 
 
 class SymbolDownloader:

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -68,6 +68,7 @@ if TOOL_ENV:
         ("OIDC_OP_TOKEN_ENDPOINT", "http://example.com/"),
         ("OIDC_OP_USER_ENDPOINT", "http://example.com/"),
         ("DATABASE_URL", "postgresql://postgres:postgres@db/tecken"),
+        ("REDIS_URL", "redis://redis-cache:6379/0"),
         ("SYMBOL_URLS", "https://example.com/"),
         ("UPLOAD_DEFAULT_URL", "https://example.com/"),
         ("UPLOAD_TRY_SYMBOLS_URL", "https://example.com/try/"),
@@ -383,9 +384,7 @@ TOKENS_DEFAULT_EXPIRATION_DAYS = _config(
     doc="Default expiration in days for tokens.",
 )
 
-REDIS_URL = _config(
-    "REDIS_URL", default="redis://redis-cache:6379/0", doc="URL for Redis."
-)
+REDIS_URL = _config("REDIS_URL", doc="URL for Redis.")
 
 REDIS_SOCKET_CONNECT_TIMEOUT = _config(
     "REDIS_SOCKET_CONNECT_TIMEOUT",

--- a/tecken/upload/utils.py
+++ b/tecken/upload/utils.py
@@ -25,7 +25,9 @@ from tecken.base.symboldownloader import SymbolDownloader
 logger = logging.getLogger("tecken")
 metrics = markus.get_metrics("tecken")
 
-downloader = SymbolDownloader(settings.SYMBOL_URLS)
+# FIXME(willkg): This downloader needs to point to all the things that can be downloaded
+# from so it can correctly invalidate the cache
+downloader = SymbolDownloader(settings.SYMBOL_URLS + [settings.UPLOAD_TRY_SYMBOLS_URL])
 
 
 class UnrecognizedArchiveFileExtension(ValueError):


### PR DESCRIPTION
When try symbols get uploaded, the "does this exist in s3?" cache wasn't
getting invalidated, so symbol download could continue to kick up 404s.

This fixes that specific issue by adding the try symbols source to the
downloader hard-coded in the upload code. There's another bug to rewrite
how all this works and we can fix it in a more resilient way then.

To test:

1. log in and create an API token with "upload try symbols files" permission
2. create a zip file to upload
3. `curl --head http://localhost:8000/try/<debugfilename>/<debugid>/<filename>.sym`

   This should return a 404 because the symbol doesn't exist.
5. upload the zip file and make sure the file got uploaded
6. `curl --head http://localhost:8000/try/<debugfilename>/<debugid>/<filename>.sym`

   This should return a 200 now because the symbol does exist and the cache was invalidated.

If you don't have a symbol zip file, you can create a zip to upload using the systemtests script `systemtests/bin/make-symbols-zip.py`. When generating the file, it'll spit out output like this:

```
app@9ad507c4c348:/app/systemtests$ ./bin/make-symbols-zip.py --auth-token 23c38b3b02c948ed86264350200a79d1 --max-size=5000000 data/zip-files/
Generating ZIP file data/zip-files/symbols_20220526_180657.zip ...
Adding v1/libxul.so/8D4A6289D19D5094AE3A169FFE398C6C0/libxul.so.sym (22408377) ...
size: 22745935, max_size: 5000000
Completed data/zip-files/symbols_20220526_180657.zip (22745935)!
app@9ad507c4c348:/app/systemtests$
```

The debugfilename for that symbol is "libxul.so" and the debug id is "8D4A6289D19D5094AE3A169FFE398C6C0" so the curl line would be:

```
curl --head http://localhost:8000/try/libxul.so/8D4A6289D19D5094AE3A169FFE398C6C0/libxul.so.sym
```
```