### PR TITLE
bug 1764569: change error capture to be explicit

### DIFF
--- a/eliot-service/eliot/app.py
+++ b/eliot-service/eliot/app.py
@@ -9,6 +9,7 @@ Holds the EliotApp code. EliotApp is a WSGI app implemented using Falcon.
 import logging
 import logging.config
 from pathlib import Path
+import sys
 
 from everett.manager import (
     ConfigManager,
@@ -21,6 +22,7 @@ import falcon
 from falcon.errors import HTTPInternalServerError
 from fillmore.libsentry import set_up_sentry
 from fillmore.scrubber import Scrubber, Rule, SCRUB_RULES_DEFAULT
+import sentry_sdk
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
 from eliot.cache import DiskCache
@@ -233,8 +235,8 @@ class EliotApp(falcon.App):
         code for the HTTP response.
 
         """
-        # We're still in an exception context, so sys.exc_info() still has the details.
-        LOGGER.exception("Unhandled exception")
+        sentry_sdk.capture_exception(ex)
+        LOGGER.error("Unhandled exception", exc_info=sys.exc_info())
         self._compose_error_response(req, resp, HTTPInternalServerError())
 
     def verify(self):

--- a/eliot-service/tests/test_sentry.py
+++ b/eliot-service/tests/test_sentry.py
@@ -45,7 +45,7 @@ BROKEN_EVENT = {
     "exception": {
         "values": [
             {
-                "mechanism": {"handled": True, "type": "logging"},
+                "mechanism": None,
                 "module": None,
                 "stacktrace": {
                     "frames": [
@@ -62,7 +62,7 @@ BROKEN_EVENT = {
                             "vars": {
                                 "__builtins__": "<module 'builtins' (built-in)>",
                                 "__doc__": "'Falcon App class.'",
-                                "__file__": "'/usr/local/lib/python3.9/site-packages/falcon/app.cpython-39-x86_64-linux-gnu.so'",
+                                "__file__": ANY,
                                 "__loader__": ANY,
                                 "__name__": "'falcon.app'",
                                 "__package__": "'falcon'",
@@ -95,15 +95,8 @@ BROKEN_EVENT = {
             }
         ]
     },
-    "extra": {
-        "asctime": ANY,
-        "host_id": "testcode",
-        "processname": "tests",
-        "sys.argv": ANY,
-    },
+    "extra": {"sys.argv": ANY},
     "level": "error",
-    "logentry": {"message": "Unhandled exception", "params": []},
-    "logger": "eliot.app",
     "modules": ANY,
     "platform": "python",
     "release": ANY,


### PR DESCRIPTION
This fixes Eliot so that Sentry is capturing errors from
sentry_sdk.capture_exception() rather than from the LoggingIntegration
listening to LOGGER.exception.