### PR TITLE
bug 1764569: fix transaction name for Eliot Sentry events

### DIFF
--- a/eliot-service/tests/test_sentry.py
+++ b/eliot-service/tests/test_sentry.py
@@ -45,7 +45,7 @@ BROKEN_EVENT = {
     "exception": {
         "values": [
             {
-                "mechanism": None,
+                "mechanism": {"handled": True, "type": "eliot"},
                 "module": None,
                 "stacktrace": {
                     "frames": [
@@ -128,7 +128,7 @@ BROKEN_EVENT = {
     },
     "server_name": "testnode",
     "timestamp": ANY,
-    "transaction": "generic WSGI request",
+    "transaction": "/__broken__",
     "transaction_info": {},
 }
 


### PR DESCRIPTION
Eliot uses SentryWsgiMiddleware which assigns "generic WSGI request" as
the transaction name which is unbelievably unhelpful in the Sentry
interface.

This fixes the transaction name to be the req.path which is what other
web framework integrations do.