### PR TITLE
bug 1743854: remove platform setting from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile
-    platform: linux/amd64
     image: tecken:build
     env_file:
       - docker/config/local_dev.env


### PR DESCRIPTION
I'm pretty sure we don't need this anymore since symbolic provides
wheels suitable for m1 macs now.