### PR TITLE
bug 1790808: increase gunicorn timeout to 600

### DIFF
--- a/bin/run_web.sh
+++ b/bin/run_web.sh
@@ -2,12 +2,12 @@
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# default variables
+# Default variables
 : "${PORT:=8000}"
 : "${GUNICORN_WORKERS:=4}"
-: "${GUNICORN_TIMEOUT:=300}"
+: "${GUNICORN_TIMEOUT:=600}"
 
 if [ "$1" == "--dev" ]; then
     python manage.py migrate --noinput


### PR DESCRIPTION
This doubles the gunicorn worker timeout to 600 so that it's less likely to kill a symbol upload request while it's being processed leaving files on disk.