### PR TITLE
bug 1796579: simplify the uploads page

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 .git
 .bash_history
 frontend/node_modules/
+
+# Places where I put data I'm debugging / working on
+systemtests/data/
+myanalysis/

--- a/frontend/src/Common.js
+++ b/frontend/src/Common.js
@@ -18,6 +18,10 @@ import {
 } from "date-fns";
 import parseISO from "date-fns/parseISO";
 
+// Big number signifying we don't know what the count is. This needs to match
+// the BIG_NUMBER API total value.
+const BIG_NUMBER = 1000000;
+
 export function parseISODate(input) {
   return toDate(parseISO(input));
 }
@@ -152,7 +156,7 @@ export const Pagination = ({
       >
         Previous
       </Link>
-      <ul class="pagination-list">
+      <ul className="pagination-list">
         <li>Page {currentPage}</li>
       </ul>
       <Link
@@ -177,14 +181,21 @@ export const TableSubTitle = ({
     return null;
   }
   page = page || 1;
-  const totalPages = Math.ceil(total / batchSize);
+  var totalText = "";
+  var totalPagesText = "";
+  if (total === BIG_NUMBER) {
+    totalText = "Lots";
+    totalPagesText = "many";
+  } else {
+    totalText = thousandFormat(total);
+    totalPagesText = thousandFormat(Math.ceil(total / batchSize));
+  }
   if (calculating) {
     return <h2 className="subtitle">Calculating ...</h2>;
   } else {
     return (
       <h2 className="subtitle">
-        {thousandFormat(total)} Found (Page {thousandFormat(page)} of{" "}
-        {thousandFormat(totalPages)})
+        {totalText} Found (Page {thousandFormat(page)} of {totalPagesText})
       </h2>
     );
   }

--- a/frontend/src/Common.js
+++ b/frontend/src/Common.js
@@ -143,7 +143,7 @@ export const Pagination = ({
   };
 
   return (
-    <nav className="pagination is-right">
+    <nav className="pagination is-centered">
       <Link
         className="pagination-previous"
         to={nextPageUrl(currentPage - 1)}
@@ -152,6 +152,9 @@ export const Pagination = ({
       >
         Previous
       </Link>
+      <ul class="pagination-list">
+        <li>Page {currentPage}</li>
+      </ul>
       <Link
         to={nextPageUrl(currentPage + 1)}
         className="pagination-next"

--- a/frontend/src/Uploads.js
+++ b/frontend/src/Uploads.js
@@ -84,7 +84,8 @@ class Uploads extends React.PureComponent {
       return response.json().then((response) => {
         this.setState(
           {
-            loadingUploads: false,
+            loading: false,
+            total: response.total,
             uploads: response.uploads,
             canViewAll: response.can_view_all,
             batchSize: response.batch_size,
@@ -106,15 +107,15 @@ class Uploads extends React.PureComponent {
       if (r.status === 400) {
         return r.json().then((data) => {
           this.setState({
-            loadingUploads: false,
+            loading: false,
             refreshing: false,
             validationErrors: data.errors,
           });
         });
       }
     };
-    this.setState({ loadingUploads: true });
-    this._fetch("/api/uploads/content/", callback, errorCallback);
+    this.setState({ loading: true });
+    this._fetch("/api/uploads/", callback, errorCallback);
   };
 
   _fetch = (endpoint, callback, errorCallback) => {
@@ -153,7 +154,7 @@ class Uploads extends React.PureComponent {
   };
 
   _fetchAbsoluteLatestUpload = () => {
-    const url = "/api/uploads/content/";
+    const url = "/api/uploads/";
     return fetch(url).then((r) => {
       if (r.status === 200) {
         return r.json().then((response) => {
@@ -307,7 +308,7 @@ class Uploads extends React.PureComponent {
           refresh={this._refreshUploads}
         />
         <h1 className="title">{this.state.pageTitle}</h1>
-        {this.state.loadingUploads ? (
+        {this.state.loading ? (
           <Loading />
         ) : (
           this.state.uploads && (
@@ -315,7 +316,7 @@ class Uploads extends React.PureComponent {
               total={this.state.total}
               page={this.state.filter.page}
               batchSize={this.state.batchSize}
-              calculating={this.state.loadingUploads}
+              calculating={this.state.loading}
             />
           )
         )}
@@ -325,9 +326,9 @@ class Uploads extends React.PureComponent {
             resetAndReload={this.resetAndReload}
           />
         )}
-        {!this.state.loadingUploads && this.state.uploads && (
+        {!this.state.loading && this.state.uploads && (
           <DisplayUploads
-            loading={this.state.loadingUploads}
+            loading={this.state.loading}
             uploads={this.state.uploads}
             canViewAll={this.state.canViewAll}
             batchSize={this.state.batchSize}
@@ -512,7 +513,7 @@ class DisplayUploads extends React.PureComponent {
               </td>
             </tr>
             <tr>
-              <td colspan="4"></td>
+              <td colSpan="4"></td>
               <td className="buttons">
                 <button type="submit" className="button is-primary">
                   Filter Uploads

--- a/systemtests/bin/make-symbols-zip.py
+++ b/systemtests/bin/make-symbols-zip.py
@@ -143,12 +143,12 @@ def make_symbols_zip(ctx, auth_token, start_page, max_size, outputdir):
     zip_filename = datetime.datetime.now().strftime("symbols_%Y%m%d_%H%M%S.zip")
     zip_path = os.path.join(outputdir, zip_filename)
 
-    click.echo("Generating ZIP file %s ..." % zip_path)
+    click.echo(f"Generating ZIP file {zip_path} ...")
     with tempfile.TemporaryDirectory(prefix="symbols") as tmpdirname:
         sym_dir = os.path.join(tmpdirname, "syms")
         tmp_zip_path = os.path.join(tmpdirname, zip_filename)
 
-        sym_files_url = urljoin(SYMBOLS_URL, "/api/uploads/files/")
+        sym_files_url = urljoin(SYMBOLS_URL, "/api/uploads/files/content/")
         sym_files_generator = get_sym_files(auth_token, sym_files_url, start_page)
         for sym_filename, sym_size in sym_files_generator:
             if sym_filename.endswith(".0"):
@@ -160,7 +160,7 @@ def make_symbols_zip(ctx, auth_token, start_page, max_size, outputdir):
             if os.path.exists(tmp_zip_path):
                 # See if the new zip file is too big; if it is, we're done!
                 zip_size = os.stat(tmp_zip_path).st_size
-                click.echo("size: %s, max_size: %s" % (zip_size, max_size))
+                click.echo(f"size: {zip_size:,}, max_size: {max_size:,}")
                 if zip_size > max_size:
                     # Handle weird case where the first zip file we built was
                     # too big--just use that.
@@ -172,9 +172,7 @@ def make_symbols_zip(ctx, auth_token, start_page, max_size, outputdir):
                 shutil.copy(tmp_zip_path, zip_path)
 
             click.echo(
-                click.style(
-                    "Adding %s (%s) ..." % (sym_filename, sym_size), fg="yellow"
-                )
+                click.style(f"Adding {sym_filename} ({sym_size:,}) ...", fg="yellow")
             )
 
             # Download SYM file into temporary directory
@@ -195,7 +193,7 @@ def make_symbols_zip(ctx, auth_token, start_page, max_size, outputdir):
             build_zip_file(tmp_zip_path, sym_dir)
 
     zip_size = os.stat(zip_path).st_size
-    click.echo("Completed %s (%s)!" % (zip_path, zip_size))
+    click.echo(f"Completed {zip_path} ({zip_size:,})!")
 
 
 if __name__ == "__main__":

--- a/tecken/api/urls.py
+++ b/tecken/api/urls.py
@@ -29,8 +29,6 @@ urlpatterns = [
         name="possible_upload_urls",
     ),
     path("uploads/", views.uploads, name="uploads"),
-    path("uploads/content/", views.uploads_content, name="uploads_content"),
-    path("uploads/aggregates/", views.uploads_aggregates, name="uploads_aggregates"),
     path("uploads/created/", views.uploads_created, name="uploads_created"),
     path(
         "uploads/created/backfilled/",


### PR DESCRIPTION
This does a few things to simplify the uploads page:

1. cleans up and clarify the filter form so I can remember how to use the damn thing
2. removes aggregates summary (total uploads, total upload size, average size, etc) and all the code used to generate it
3. merge the `/api/uploads/*` apis back into a single endpoint
4. change the way "total" is calculated--if there are no filters, it returns 1,000,000 a "magic big number" which is handled in the front end as "lots"; if there are filters, then it calculates the count
5. removes the 5-second check loop for new uploads and the code to support that