### PR TITLE
bug 1796633: remove aggregates from "upload files" pages

### DIFF
--- a/frontend/src/Files.js
+++ b/frontend/src/Files.js
@@ -94,22 +94,18 @@ class Files extends React.PureComponent {
   _fetchFiles = (updateHistory = true) => {
     var callback = (response) => {
       this.setState({
+        loadingFiles: false,
+        total: response.total,
         files: response.files,
         hasNextPage: response.has_next,
         batchSize: response.batch_size,
       });
-      this.setState({ loadingFiles: false });
     };
     var errorCallback = () => {
       this.setState({ loadingFiles: false });
     };
     this.setState({ loadingFiles: true });
-    this._fetch(
-      "/api/uploads/files/content/",
-      callback,
-      errorCallback,
-      updateHistory
-    );
+    this._fetch("/api/uploads/files/", callback, errorCallback, updateHistory);
   };
 
   filterOnAll = (event) => {

--- a/systemtests/bin/make-symbols-zip.py
+++ b/systemtests/bin/make-symbols-zip.py
@@ -148,7 +148,7 @@ def make_symbols_zip(ctx, auth_token, start_page, max_size, outputdir):
         sym_dir = os.path.join(tmpdirname, "syms")
         tmp_zip_path = os.path.join(tmpdirname, zip_filename)
 
-        sym_files_url = urljoin(SYMBOLS_URL, "/api/uploads/files/content/")
+        sym_files_url = urljoin(SYMBOLS_URL, "/api/uploads/files/")
         sym_files_generator = get_sym_files(auth_token, sym_files_url, start_page)
         for sym_filename, sym_size in sym_files_generator:
             if sym_filename.endswith(".0"):

--- a/tecken/api/urls.py
+++ b/tecken/api/urls.py
@@ -9,12 +9,9 @@ from . import views
 
 app_name = "api"
 
-"""
-Note!
-The endpoints that start with a '_' are basically only relevant
-for the sake of the frontend. Meaning, it doesn't make sense to use
-them in your curl script, for example.
-"""
+# NOTE(peterbe): The endpoints that start with a '_' are basically only relevant for the
+# sake of the frontend. Meaning, it doesn't make sense to use them in your curl script,
+# for example.
 
 urlpatterns = [
     path("_auth/", views.auth, name="auth"),
@@ -36,16 +33,6 @@ urlpatterns = [
         name="uploads_created_backfilled",
     ),
     path("uploads/files/", views.upload_files, name="upload_files"),
-    path(
-        "uploads/files/content/",
-        views.upload_files_content,
-        name="upload_files_content",
-    ),
-    path(
-        "uploads/files/aggregates/",
-        views.upload_files_aggregates,
-        name="upload_files_aggregates",
-    ),
     path("uploads/files/file/<int:id>", views.upload_file, name="upload_file"),
     path("uploads/upload/<int:id>", views.upload, name="upload"),
     path("downloads/missing/", views.downloads_missing, name="downloads_missing"),


### PR DESCRIPTION
This removes the aggregates summary (count, average size, etc) from the uploads files page.

This cleans up the filter form so I can remember how to use it.

This merges all the /api/uploads/files/* back into a single view.

This changes how "total" is handled. If there are no filters, then it doesn't calculate a total and instead uses 1,000,000 which is a magic number the frontend understands as "many". If there are filters, then it'll calculate the total.