### PR TITLE
bug 1793984: clean up symbolication code

### DIFF
--- a/eliot-service/eliot/cache_manager.py
+++ b/eliot-service/eliot/cache_manager.py
@@ -66,7 +66,7 @@ class LastUpdatedOrderedDict(OrderedDict):
         """Update last-updated for key"""
         self.move_to_end(key, last=True)
 
-    def popoldest(self):
+    def pop_oldest(self):
         """Pop the oldest item"""
         return self.popitem(last=False)
 
@@ -236,7 +236,7 @@ class DiskCacheManager:
         removed = 0
 
         while self.lru and total_size > self.max_size:
-            rm_path, rm_size = self.lru.popoldest()
+            rm_path, rm_size = self.lru.pop_oldest()
             total_size -= rm_size
             removed += rm_size
             os.remove(rm_path)

--- a/eliot-service/eliot/libmarkus.py
+++ b/eliot-service/eliot/libmarkus.py
@@ -164,7 +164,8 @@ ELIOT_METRICS = {
         description="Counter for disk cache evictions.",
     ),
     "eliot.diskcache.usage": Metric(
-        stat_type="gauge", description="Gauge for how much of the cache is in use."
+        stat_type="gauge",
+        description="Gauge for how much of the cache is in use.",
     ),
     "eliot.sentry_scrub_error": Metric(
         stat_type="incr",

--- a/eliot-service/tests/test_cache_manager.py
+++ b/eliot-service/tests/test_cache_manager.py
@@ -43,7 +43,7 @@ class TestLastUpdatedOrderedDict:
         lru["key1"] = 1
         lru["key2"] = 2
 
-        oldest = lru.popoldest()
+        oldest = lru.pop_oldest()
         assert oldest == ("key1", 1)
         assert list(lru.items()) == [("key2", 2)]
 

--- a/eliot-service/tests/test_symbolicate_resource.py
+++ b/eliot-service/tests/test_symbolicate_resource.py
@@ -418,7 +418,10 @@ class TestSymbolicateBase:
         modules = [["testproj", "D48F191186D67E69DF025AD71FB91E1F0"]]
         debug_stats = DebugStats()
 
-        assert base.symbolicate(stacks, modules, debug_stats) == {
+        jobs = [{"stacks": stacks, "memoryMap": modules}]
+        result = base.symbolicate(jobs, debug_stats)[0]
+
+        assert result == {
             "found_modules": {"testproj/D48F191186D67E69DF025AD71FB91E1F0": True},
             "stacks": [
                 [
@@ -481,7 +484,10 @@ class TestSymbolicateBase:
         modules = [["xul.pdb", "0185139C8F04FFC94C4C44205044422E1"]]
         debug_stats = DebugStats()
 
-        assert base.symbolicate(stacks, modules, debug_stats) == {
+        jobs = [{"stacks": stacks, "memoryMap": modules}]
+        result = base.symbolicate(jobs, debug_stats)[0]
+
+        assert result == {
             "found_modules": {"xul.pdb/0185139C8F04FFC94C4C44205044422E1": True},
             "stacks": [
                 [
@@ -560,7 +566,7 @@ class TestSymbolicateV4:
         assert result.headers["Content-Type"].startswith("application/json")
         assert (
             result.content
-            == b'{"title": "job has invalid stacks: no stacks specified"}'
+            == b'{"title": "job 0 has invalid stacks: no stacks specified"}'
         )
 
         # No stacks specified
@@ -571,7 +577,7 @@ class TestSymbolicateV4:
         assert result.headers["Content-Type"].startswith("application/json")
         assert (
             result.content
-            == b'{"title": "job has invalid stacks: no stacks specified"}'
+            == b'{"title": "job 0 has invalid stacks: no stacks specified"}'
         )
 
     def test_symbolication_module_missing_and_not_checked(self, requestsmock, client):

--- a/systemtests/bin/list-firefox-symbols-zips.py
+++ b/systemtests/bin/list-firefox-symbols-zips.py
@@ -4,8 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# List recently generated symbols ZIP files in taskcluster. You can
-# use these to do "upload by download url".
+# List recently generated symbols ZIP files in taskcluster. You can use these to do
+# "upload by download url".
 #
 # Usage: ./bin/list-firefox-symbols-zips.py
 

--- a/systemtests/bin/make-stacks.py
+++ b/systemtests/bin/make-stacks.py
@@ -50,11 +50,11 @@ def build_stack(data):
     :returns: Symbolicate API payload
 
     """
-    json_dump = data.get("json_dump", {})
+    json_dump = data.get("json_dump") or {}
     if not json_dump:
         return {}
 
-    crashing_thread = json_dump.get("crashing_thread", {})
+    crashing_thread = json_dump.get("crashing_thread") or {}
     if not crashing_thread:
         return {}
 
@@ -67,7 +67,7 @@ def build_stack(data):
         # Add the module information to the map
         modules.append((debug_file, debug_id))
         # Keep track of which modules are at which index
-        modules_list.append(module["filename"])
+        modules_list.append(module.get("filename") or "unknown")
 
     stack = []
     for frame in crashing_thread.get("frames") or []:
@@ -76,7 +76,7 @@ def build_stack(data):
         else:
             # -1 indicates the module is unknown
             module_index = -1
-        if "module_offset" in frame:
+        if frame.get("module_offset"):
             module_offset = int(frame["module_offset"], base=16)
         else:
             # -1 indicates the module_offset is unknown

--- a/systemtests/bin/make-stacks.py
+++ b/systemtests/bin/make-stacks.py
@@ -60,9 +60,9 @@ def build_stack(data):
 
     modules = []
     modules_list = []
-    for module in json_dump.get("modules", []):
-        debug_file = module.get("debug_file", "")
-        debug_id = module.get("debug_id", "")
+    for module in json_dump.get("modules") or []:
+        debug_file = module.get("debug_file") or ""
+        debug_id = module.get("debug_id") or ""
 
         # Add the module information to the map
         modules.append((debug_file, debug_id))
@@ -70,8 +70,8 @@ def build_stack(data):
         modules_list.append(module["filename"])
 
     stack = []
-    for frame in crashing_thread.get("frames", []):
-        if "module" in frame:
+    for frame in crashing_thread.get("frames") or []:
+        if frame.get("module"):
             module_index = modules_list.index(frame["module"])
         else:
             # -1 indicates the module is unknown


### PR DESCRIPTION
This moves some symbolication code around to reduce duplication between the v4 and v5 views and also to change the work of the `symbolicate` method so it's operating on a list of jobs rather than a single job. This sets us up to rewrite `symbolicate` for more efficient processing.

We switched stackwalkers at the end of 2021 and the new one emits nulls rather than omitting the field altogether. This updates `make-stacks.py` to account for nulls better.
