### PR TITLE
bug 1800479: fix ParseSymFileError to be more helpful

### DIFF
--- a/eliot-service/eliot/symbolicate_resource.py
+++ b/eliot-service/eliot/symbolicate_resource.py
@@ -283,13 +283,13 @@ class SymbolicateBase:
         except BadDebugIDError:
             # If the debug id isn't valid, then there's nothing to parse, so
             # log something, emit a metric, and move on
-            LOGGER.error(f"debug_id parse error: {debug_id!r}")
+            LOGGER.exception(f"debug_id parse error: {debug_id!r}")
             METRICS.incr(
                 "eliot.symbolicate.parse_sym_file.error", tags=["reason:bad_debug_id"]
             )
 
         except ParseSymFileError as psfe:
-            LOGGER.error(f"sym file parse error: {debug_filename} {debug_id!r}")
+            LOGGER.exception(f"sym file parse error: {debug_filename} {debug_id!r}")
             METRICS.incr(
                 "eliot.symbolicate.parse_sym_file.error",
                 tags=[f"reason:{psfe.reason_code}"],

--- a/eliot-service/tests/test_libsymbolic.py
+++ b/eliot-service/tests/test_libsymbolic.py
@@ -82,7 +82,7 @@ def test_parse_sym_file_malformed(tmpdir):
     with pytest.raises(ParseSymFileError) as excinfo:
         parse_sym_file(debug_filename, debug_id, data, tmpdir)
 
-    assert str(excinfo.value) == "sym_malformed"
+    assert excinfo.value.reason_code == "sym_malformed"
 
 
 def test_parse_sym_file_lookup_error(tmpdir):
@@ -94,4 +94,4 @@ def test_parse_sym_file_lookup_error(tmpdir):
     with pytest.raises(ParseSymFileError) as excinfo:
         parse_sym_file(debug_filename, debug_id, data, tmpdir)
 
-    assert str(excinfo.value) == "sym_debug_id_lookup_error"
+    assert excinfo.value.reason_code == "sym_debug_id_lookup_error"


### PR DESCRIPTION
Previously, ParseSymFileError didn't include an exception message so debugging these was tricky because you knew there was an error, but it didn't include enough detail as to why.

This also fixes the handling cade to use logger.exception rather than logger.error so we get a traceback which helps debug issues.