### PR TITLE
Update Kent to 1.0.0

### DIFF
--- a/docker/images/fakesentry/Dockerfile
+++ b/docker/images/fakesentry/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.5-alpine3.16@sha256:52ce18e9d7a2556a3632d093f8f77700307735b7e7049dce3339c9bf9221ae7f
+FROM python:3.10.8-alpine3.16@sha256:d17cfece24cb5d0432b37c138f307a19dd461b88aded1fc6981ef5c997c74de1
 
 ARG groupid=5000
 ARG userid=5000
@@ -9,13 +9,15 @@ RUN addgroup -g $groupid app && \
     adduser --disabled-password --gecos "" --home /home/app --ingroup app --uid $userid app && \
     chown app:app /app/
 
+RUN apk add --no-cache tini
+
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 RUN pip install -U 'pip>=20' && \
-    pip install --no-cache-dir 'kent==0.5.0'
+    pip install --no-cache-dir 'kent==1.0.0'
 
 USER app
 
-ENTRYPOINT ["/usr/local/bin/kent-server"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/kent-server"]
 CMD ["run"]


### PR DESCRIPTION
This updates Kent to 1.0.0 and also fixes the Dockerfile to run Kent with tini.