### PR TITLE
bug 1793984: reorder frames to symbolicate

### DIFF
--- a/eliot-service/tests/test_libsymbolic.py
+++ b/eliot-service/tests/test_libsymbolic.py
@@ -74,24 +74,24 @@ def test_convert_debug_id_bad():
         convert_debug_id("bad_id")
 
 
-def test_parse_sym_file_malformed(tmpdir):
+def test_parse_sym_file_malformed():
     debug_filename = "testproj"
     debug_id = "D48F191186D67E69DF025AD71FB91E1F0"
     data = b"this is junk"
 
     with pytest.raises(ParseSymFileError) as excinfo:
-        parse_sym_file(debug_filename, debug_id, data, tmpdir)
+        parse_sym_file(debug_filename, debug_id, data)
 
     assert excinfo.value.reason_code == "sym_malformed"
 
 
-def test_parse_sym_file_lookup_error(tmpdir):
+def test_parse_sym_file_lookup_error():
     debug_filename = "testproj"
     # This is the wrong debugid for that sym file
     debug_id = "000000000000000000000000000000000"
     data = TESTPROJ_SYM.encode("utf-8")
 
     with pytest.raises(ParseSymFileError) as excinfo:
-        parse_sym_file(debug_filename, debug_id, data, tmpdir)
+        parse_sym_file(debug_filename, debug_id, data)
 
     assert excinfo.value.reason_code == "sym_debug_id_lookup_error"


### PR DESCRIPTION
This reworks symbolication to reorder all the frames to symbolicate by module so that as we're symbolicating frames, we only need one module in memory at a time.

This also removes the need for using a temporary directory to store a symbol file that was just downloaded in order to parse it with symbolic. Now we parse it straight from bytes.

I tested this in a few ways:

1. updated unit tests
2. run system tests
3. pull down crash reports to build stacks to symbolicate and then compare the results from prod with the results of my local dev environment
4. run a "memory test" where I measure the memory usage of the container running the disk cache manager, gunicorn, and a single eliot gunicorn worker symbolicating multiple different requests

It looks ok.
