### PR TITLE
bug 1819191: use tini for services

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,11 +30,15 @@ RUN groupadd --gid $groupid app && \
 # install a few essentials and clean apt caches afterwards
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    apt-transport-https build-essential curl git libpq-dev \
-    gettext libffi-dev
-
-# Clean up apt
-RUN apt-get autoremove -y && \
+        apt-transport-https \
+        build-essential \
+        curl \
+        git \
+        libpq-dev \
+        gettext \
+        libffi-dev \
+        tini && \
+    apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -63,6 +67,6 @@ USER app
 # Using /bin/bash as the entrypoint works around some volume mount issues on Windows
 # where volume-mounted files do not have execute bits set.
 # https://github.com/docker/compose/issues/2301#issuecomment-154450785 has additional background.
-ENTRYPOINT ["/bin/bash", "/app/bin/entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "/bin/bash", "/app/bin/entrypoint.sh"]
 
 CMD ["web"]

--- a/docker/images/oidcprovider/Dockerfile
+++ b/docker/images/oidcprovider/Dockerfile
@@ -1,4 +1,10 @@
-FROM mozilla/oidc-testprovider:oidc_testprovider-v0.10.1@sha256:5799e811ce48a00660d5c1401135d0d967111e7fec2e829756be8b292f4d70ab
+FROM mozilla/oidc-testprovider:oidc_testprovider-v0.10.7@sha256:cff948eeb665cd48a6bd343af585f4970d2788a7745ea8c84410bf80800e0ef9
+
+RUN apt-get update && \
+    apt install tini && \
+    rm -rf /var/lib/apt/lists/*
 
 # Modify redirect_urls specified in "fixtures.json" to fit our needs.
 COPY fixtures.json /code/fixtures.json
+
+CMD ["/usr/bin/tini", "--", "./bin/run.sh"]


### PR DESCRIPTION
This fixes the web and oidcprovider services.

The frontend service uses node-14.17.6-slim which is based on stretch and doesn't have tini available. We'll have to wait to fix that until we update node. :cry: 