### PR TITLE
bug 1821063: fix temporary directory usage

### DIFF
--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -32,6 +32,8 @@ OIDC_OP_USER_ENDPOINT=https://auth.example.com/authorize
 
 SYMBOL_FILE_PREFIX=v0
 
+UPLOAD_TEMPDIR=/tmp/test/uploads
+
 
 # Eliot settings
 # --------------

--- a/tecken/base/decorators.py
+++ b/tecken/base/decorators.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import logging
-from tempfile import TemporaryDirectory
 from functools import wraps
 
 from django import http
@@ -174,30 +173,6 @@ def set_cors_headers(origin="*", methods="GET", allow_headers=DEFAULT_ALLOW_HEAD
             response["Access-Control-Allow-Methods"] = ",".join(methods)
             response["Access-Control-Allow-Headers"] = ",".join(allow_headers)
             return response
-
-        return inner
-
-    return decorator
-
-
-def make_tempdir(prefix=None, suffix=None):
-    """Decorator that adds a last argument that is the path to a temporary
-    directory that gets deleted after the function has finished.
-
-    Usage::
-
-        @make_tempdir()
-        def some_function(arg1, arg2, tempdir, kwargs1='one'):
-            assert os.path.isdir(tempdir)
-            ...
-    """
-
-    def decorator(func):
-        @wraps(func)
-        def inner(*args, **kwargs):
-            with TemporaryDirectory(prefix=prefix, suffix=suffix) as f:
-                args = args + (f,)
-                return func(*args, **kwargs)
 
         return inner
 

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -537,10 +537,10 @@ ENABLE_STORE_MISSING_SYMBOLS = _config(
     ),
 )
 
-UPLOAD_TEMPDIR_PREFIX = _config(
-    "UPLOAD_TEMPDIR_PREFIX",
-    default="raw-uploads",
-    doc="The prefix used when generating directories in the temp directory.",
+UPLOAD_TEMPDIR = _config(
+    "UPLOAD_TEMPDIR",
+    default="/tmp/uploads",
+    doc="The directory to use as a workspace for handling symbol uploads.",
 )
 
 ALLOW_UPLOAD_BY_ANY_DOMAIN = _config(

--- a/tecken/tests/test_decorators.py
+++ b/tecken/tests/test_decorators.py
@@ -2,10 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import os
-
-import pytest
-
 from django import http
 from django.test import RequestFactory
 
@@ -49,27 +45,3 @@ def test_set_cors_headers(rf):
     response = view_function(request)
     assert response["Access-Control-Allow-Origin"] == "example.com"
     assert response["Access-Control-Allow-Methods"] == "HEAD,GET"
-
-
-def test_make_tempdir():
-    mutable = []
-
-    @decorators.make_tempdir(prefix="PREFIX", suffix="SUFFIX")
-    def view_function(request, tmpdir, foo=None):
-        assert os.path.isdir(tmpdir)
-        basename = os.path.basename(tmpdir)
-        assert "PREFIX" in basename
-        assert "SUFFIX" in basename
-        mutable.append(tmpdir)
-
-        if foo == "ERROR":
-            raise NameError("anything")
-
-    view_function("somerequest", foo="bar")
-    assert not os.path.isdir(mutable[0])
-
-    # Let it fail this time
-    with pytest.raises(NameError):
-        view_function("somerequest", foo="ERROR")
-
-    assert not os.path.isdir(mutable[1])


### PR DESCRIPTION
This drops `UPLOAD_TEMPDIR_PREFIX` for `UPLOAD_TEMPDIR` which is an absolute path to a directory to use for building temporary workspaces for handling symbol uploads.

While doing this, I moved the `make_tempdir` decorator closer to the only place it's used in the codebase.

This requires a configuration change in the infrastructure code before landing.