### PR TITLE
bug 1817902: redo remove_orphaned_files output; fix logging issues

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -28,10 +28,10 @@ shift
 
 case ${SERVICE} in
 web)  ## Run Tecken web service
-    exec honcho -f /app//Procfile start
+    exec honcho -f /app//Procfile --no-prefix start
     ;;
 eliot)  ## Run Eliot service
-    exec honcho -f /app/eliot-service/Procfile start
+    exec honcho -f /app/eliot-service/Procfile --no-prefix start
     ;;
 worker)  ## Run Celery worker
     # FIXME(willkg): 1728210: remove this after we remove the celery infra

--- a/bin/run_web.sh
+++ b/bin/run_web.sh
@@ -9,6 +9,8 @@
 : "${GUNICORN_WORKERS:=4}"
 : "${GUNICORN_TIMEOUT:=600}"
 
+export PROCESS_NAME=webapp
+
 if [ "$1" == "--dev" ]; then
     python manage.py migrate --noinput
     python manage.py runserver 0.0.0.0:${PORT}

--- a/bin/run_web_disk_manager.sh
+++ b/bin/run_web_disk_manager.sh
@@ -12,6 +12,8 @@ set -euo pipefail
 
 cd /app/
 
+export PROCESS_NAME=disk_manager
+
 # Run disk manager in a loop so that if it dies (ignore exit value), the loop
 # pauses for 1 minute and then starts up again. This expects the disk manager
 # to send errors to Sentry. The 1 minute sleep is to reduce the likelihood

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -52,7 +52,7 @@ ENABLE_AUTH0_BLOCKED_CHECK=false
 # -----
 
 # Local development flag
-ELIOT_LOCAL_DEV_ENV=True
+ELIOT_LOCAL_DEV_ENV=true
 
 # Logging
 ELIOT_LOGGING_LEVEL=INFO

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -89,79 +89,83 @@ LOGGING_DEFAULT_LEVEL = _config(
     default="INFO",
     doc="Default level for logging. Should be one of INFO, DEBUG, WARNING, ERROR.",
 )
+
+
+class AddProcessName(logging.Filter):
+    process_name = os.environ.get("PROCESS_NAME", "main")
+
+    def filter(self, record):
+        record.processname = self.process_name
+        return True
+
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        "add_processname": {"()": AddProcessName},
+    },
     "formatters": {
         "json": {
             "()": "dockerflow.logging.JsonLogFormatter",
             "logger_name": "tecken",
         },
-        "human": {"format": "%(levelname)s %(asctime)s %(name)s %(message)s"},
+        "human": {
+            "format": "%(levelname)s %(asctime)s - %(processname)s - %(name)s %(message)s",
+        },
     },
     "handlers": {
         "console": {
             "level": LOGGING_DEFAULT_LEVEL,
             "class": "logging.StreamHandler",
             "formatter": "json",
+            "filters": ["add_processname"],
         },
         "null": {"class": "logging.NullHandler"},
     },
-    "root": {"level": "INFO", "handlers": ["console"]},
     "loggers": {
         "celery.task": {
             "level": logging.DEBUG,
             "handlers": ["console"],
-            "propagate": False,
         },
         "django": {
             "level": logging.INFO,
             "handlers": ["console"],
-            "propagate": False,
         },
         "django.db.backends": {
             "level": logging.ERROR,
             "handlers": ["console"],
-            "propagate": False,
         },
         "django_redis.cache": {
             "level": logging.INFO,
             "handlers": ["console"],
-            "propagate": False,
         },
         "django.request": {
             "level": logging.INFO,
             "handlers": ["console"],
-            "propagate": False,
         },
         "django.security.DisallowedHost": {
             "handlers": ["null"],
-            "propagate": False,
         },
         "fillmore": {
             "level": logging.ERROR,
             "handlers": ["console"],
-            "propagate": False,
         },
         "markus": {
             "level": logging.INFO,
             "handlers": ["console"],
-            "propagate": False,
         },
         "mozilla_django_oidc": {
             "level": logging.DEBUG,
             "handlers": ["console"],
-            "propagate": False,
         },
         "request.summary": {
             "handlers": ["console"],
             "level": logging.INFO,
-            "propagate": False,
         },
         "tecken": {
             "level": logging.DEBUG,
             "handlers": ["console"],
-            "propagate": False,
         },
     },
 }


### PR DESCRIPTION
This redoes the output for remove_orphaned_files so it's logged rather than written to stdout/stderr. In order to test that, I had to fix how logging was configured in tecken so that it all went through the root--that way I can use caplog in the tests.

While doing that, I fixed honcho to not prepend prefixes to log lines and I added the "processname" (as set by the run scripts) to the log metadata.