### PR TITLE
Update dependencies

### DIFF
--- a/eliot-service/tests/test_sentry.py
+++ b/eliot-service/tests/test_sentry.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import json
 from unittest.mock import ANY
 
+from fillmore.test import diff_event
 from markus.testing import MetricsMock
 from werkzeug.test import Client
 
@@ -172,11 +172,8 @@ def test_sentry_scrubbing(sentry_helper):
         # Drop the "_meta" bit because we don't want to compare that.
         del event["_meta"]
 
-        # If this test fails, this will print out the new event that you can copy and
-        # paste and then edit above
-        print(json.dumps(event, indent=4, sort_keys=True))
-
-        assert event == BROKEN_EVENT
+        differences = diff_event(event, BROKEN_EVENT)
+        assert differences == []
 
 
 def test_count_sentry_scrub_error():

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ dockerflow==2022.8.0
 encore==0.8.0
 everett==3.2.0
 falcon==3.1.1
-fillmore==1.0.0
+fillmore==1.1.0
 gunicorn==20.1.0
 honcho==1.1.0
 inotify_simple==1.3.5
@@ -31,7 +31,7 @@ python-dateutil==2.8.2
 requests-mock==1.10.0
 requests==2.28.2
 ruff==0.0.260
-sentry-sdk==1.16.0
+sentry-sdk==1.19.1
 Sphinx==5.1.1
 sphinx-rtd-theme==1.2.0
 sphinxcontrib-httpdomain==1.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -281,9 +281,9 @@ falcon==3.1.1 \
     --hash=sha256:fd1eaf1a5d9d936f29f9aca3f268cf375621d1ffcbf27a6e14c187b489bf5f26 \
     --hash=sha256:ff2eaf9807ea357ced1cc60e1d2871f55aa6ea29162386efb95fb4e5a730e6de
     # via -r requirements.in
-fillmore==1.0.0 \
-    --hash=sha256:6829367ad75f10711a9b97144cb3f9a925d0c06af9c460ea28ab51f8a6d5cd80 \
-    --hash=sha256:9a7f5e3f559ee19307110e8ef094e3063cae666e698a7fe679b959e3c5eaebd4
+fillmore==1.1.0 \
+    --hash=sha256:68b2aa27340725026d7be1e4e96c3ec3ef954f66410e1cb65d0d85a692f0fdc1 \
+    --hash=sha256:8afe5fa0f59d99bc10f2996d23755860dd8b8f1aebe96c34fd5d0e5e1c2e0771
     # via -r requirements.in
 gunicorn==20.1.0 \
     --hash=sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e \
@@ -604,9 +604,9 @@ s3transfer==0.6.0 \
     --hash=sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd \
     --hash=sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947
     # via boto3
-sentry-sdk==1.16.0 \
-    --hash=sha256:633edefead34d976ff22e7edc367cdf57768e24bc714615ccae746d9d91795ae \
-    --hash=sha256:a900845bd78c263d49695d48ce78a4bce1030bbd917e0b6cc021fc000c901113
+sentry-sdk==1.19.1 \
+    --hash=sha256:7ae78bd921981a5010ab540d6bdf3b793659a4db8cccf7f16180702d48a80d84 \
+    --hash=sha256:885a11c69df23e53eb281d003b9ff15a5bdfa43d8a2a53589be52104a1b4582f
     # via
     #   -r requirements.in
     #   fillmore

--- a/tecken/tests/test_sentry.py
+++ b/tecken/tests/test_sentry.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import json
 from unittest.mock import ANY
 
+from fillmore.test import diff_event
 from markus.testing import MetricsMock
 from werkzeug.test import Client
 
@@ -219,11 +219,8 @@ def test_sentry_scrubbing(sentry_helper, transactional_db):
         # Drop the "_meta" bit because we don't want to compare that.
         del event["_meta"]
 
-        # If this test fails, this will print out the new event that you can copy and
-        # paste and then edit above
-        print(json.dumps(event, indent=4, sort_keys=True))
-
-        assert event == BROKEN_EVENT
+        differences = diff_event(event, BROKEN_EVENT)
+        assert differences == []
 
 
 def test_count_sentry_scrub_error():


### PR DESCRIPTION
* fillmore: 1.0.0 -> 1.1.0
* sentry-sdk: 1.16.0 -> 1.19.1

This also redoes how we check Sentry events to use fillmore.test.diff_event which is easier to discern changes with.