### PR TITLE
Change sleep to 15; improve docs

### DIFF
--- a/systemtests/README.rst
+++ b/systemtests/README.rst
@@ -26,7 +26,15 @@ That creates files in directories under ``data/``.
 Running tests
 =============
 
-To run::
+First, make sure you have a valid, unexpired API token for the environment you're testing.
+
+To set auth tokens, add these to your .env file:
+
+* `LOCAL_AUTH_TOKEN`
+* `STAGE_AUTH_TOKEN`
+* `PROD_AUTH_TOKEN`
+
+To run the systemtests, do::
 
    $ make shell
    root@f09b3cdf8570:/app# cd systemtests/

--- a/systemtests/bin/upload-symbols.py
+++ b/systemtests/bin/upload-symbols.py
@@ -25,7 +25,7 @@ MAX_ATTEMPTS = 5
 CONNECTION_TIMEOUT = 60
 
 # Number of seconds to sleep between tries to account for rate limiting
-SLEEP_TIMEOUT = 10
+SLEEP_TIMEOUT = 15
 
 
 class StdoutMetrics(BackendBase):


### PR DESCRIPTION
This increases the sleep after hitting rate-limiting from 10 to 15. That makes the test run longer, but it decreases the number of 429s hit and decreases the likelihood you hit 5 in a row causing the test to exit.

This improves the system test docs by adding information about api tokens.