### PR TITLE
Add additional tables and timings to site_status admin page

### DIFF
--- a/tecken/base/admin.py
+++ b/tecken/base/admin.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import json
+import time
 from urllib.parse import urlparse, urlunparse
 
 from dockerflow.version import get_version as dockerflow_get_version
@@ -143,18 +144,29 @@ def site_status(request):
 
     # Get some table counts
     tables = [
+        "auth_user",
+        "django_session",
         "download_missingsymbol",
-        "upload_upload",
+        "tokens_token",
         "upload_fileupload",
+        "upload_upload",
         "upload_uploadscreated",
     ]
     context["table_counts"] = []
     for table_name in tables:
+        start_time = time.time()
         with connection.cursor() as cursor:
             cursor.execute("select count(*) from %s" % table_name)
             row = cursor.fetchone()
             (value,) = row
-        context["table_counts"].append({"key": table_name, "value": value})
+        timing = time.time() - start_time
+        context["table_counts"].append(
+            {
+                "key": table_name,
+                "value": f"{value:,}",
+                "timing": f"{timing:,.2}",
+            }
+        )
 
     # Get migration status
     try:

--- a/tecken/base/templates/admin/site_status.html
+++ b/tecken/base/templates/admin/site_status.html
@@ -35,8 +35,9 @@
     <table>
       <thead>
         <tr>
-          <th>key</th>
-          <th>value</th>
+          <th>table</th>
+          <th>number of rows</th>
+          <th>time to count rows (s)</th>
         </tr>
       </thead>
       <tbody>
@@ -44,6 +45,7 @@
           <tr>
             <td>{{ item.key }}</td>
             <td>{{ item.value }}</td>
+            <td>{{ item.timing }}</td>
           </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
This adds some additional tables to the row counts listing so we can see growth in those tables over time. Also, since it takes a while to count rows, this keeps track of how long it took to do a count for each table.