### PR TITLE
bug 1832823: fix list-firefox-symbols-zips

### DIFF
--- a/systemtests/bin/list-firefox-symbols-zips.py
+++ b/systemtests/bin/list-firefox-symbols-zips.py
@@ -9,6 +9,8 @@
 #
 # Usage: ./bin/list-firefox-symbols-zips.py
 
+import datetime
+
 import click
 import requests
 
@@ -23,17 +25,23 @@ HTTP_HEADERS = {"User-Agent": "tecken-systemtests"}
 
 
 def index_namespaces(namespace, limit=1000):
+    # Skip any tasks that were created more than 3 months ago--this makes it more likely
+    # we hit a task that has valid symbols zip file that hasn't been deleted
+    cutoff = (datetime.date.today() + datetime.timedelta(days=270)).strftime("%Y-%m-%d")
+
     url = INDEX + "namespaces/" + namespace
     resp = requests.post(url, headers=HTTP_HEADERS, json={"limit": limit})
     for namespace in resp.json()["namespaces"]:
+        if namespace["expires"][0:8] < cutoff:
+            continue
         yield namespace["namespace"]
 
 
 def index_tasks(namespace, limit=1000):
     url = INDEX + "tasks/" + namespace
     r = requests.post(url, headers=HTTP_HEADERS, json={"limit": limit})
-    for t in r.json()["tasks"]:
-        yield t["taskId"]
+    for task in r.json()["tasks"]:
+        yield task["taskId"]
 
 
 def tasks_by_changeset(revisions_limit):
@@ -44,17 +52,23 @@ def tasks_by_changeset(revisions_limit):
 
 
 def list_artifacts(taskid):
+    # Skip any artifacts that have expired
+    cutoff = datetime.date.today().strftime("%Y-%m-%d")
+
     url = QUEUE + f"task/{taskid}/artifacts"
     resp = requests.get(url, headers=HTTP_HEADERS)
-    if resp.status_code != 200:
-        return []
-    data = resp.json()
-    return [artifact["name"] for artifact in data["artifacts"]]
+    if resp.status_code == 200:
+        data = resp.json()
+        for artifact in data["artifacts"]:
+            if artifact["expires"][0:8] < cutoff:
+                continue
+
+            yield artifact["name"]
 
 
 def get_symbols_urls():
     for taskid in tasks_by_changeset(10):
-        artifacts = list_artifacts(taskid)
+        artifacts = list(list_artifacts(taskid))
         full_zip = [a for a in artifacts if a.endswith(SYMBOLS_FULL_ZIP_SUFFIX)]
         if full_zip:
             yield QUEUE + f"task/{taskid}/artifacts/{full_zip[0]}"
@@ -71,10 +85,13 @@ def get_content_length(url):
 
     :returns: content length as an int
 
+    :raises requests.exceptions.HTTPError: if the request is forbidden or something
+
     """
     response = requests.head(url, headers=HTTP_HEADERS)
     if response.status_code > 300 and response.status_code < 400:
         return get_content_length(response.headers["location"])
+    response.raise_for_status()
     return int(response.headers["content-length"])
 
 
@@ -98,7 +115,11 @@ def run(number, max_size):
 
         # Get the size and see if it's lower than our max size and also
         # sensible--a 22 byte zip file is just the header
-        size = get_content_length(url)
+        try:
+            size = get_content_length(url)
+        except requests.exceptions.HTTPError:
+            continue
+
         if 1_000 > size > max_size:
             continue
 


### PR DESCRIPTION
This fixes the list-firefox-symbols-zips script to handle changes they made in firefox ci where they purged a bunch of symbols zip files, but didn't update the expiry in the artifact records.

This skips tasks that are more than 3 months old (1 year - 9 months) and adds skipping for artifacts that have expired as well.