### PR TITLE
bug 1739449: remove get_symbol_stream

### DIFF
--- a/tecken/base/symboldownloader.py
+++ b/tecken/base/symboldownloader.py
@@ -3,15 +3,11 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import time
-from io import BytesIO
-from gzip import GzipFile
 from functools import wraps
 
-from botocore.exceptions import ClientError
 from cache_memoize import cache_memoize
 import logging
 import markus
-import requests
 
 from django.conf import settings
 
@@ -119,7 +115,6 @@ class SymbolDownloader:
 
     1. Do you have this particular symbol?
     2. Give me the presigned URL for this particular symbol.
-    3. Give me a stream for this particular symbol.
 
     This class takes a list of URLs. If the URL contains ``access=public``
     in the query string part, this class will use ``requests.get`` or
@@ -127,40 +122,6 @@ class SymbolDownloader:
     If the URL does NOT contain ``access=public`` it will use a
     ``boto3`` S3 client to do the check or download.
 
-    So, with the 3 tasks listed above, there are 6 different things
-    this class can do.
-
-    When you use ``self.get_symbol_stream()`` it will return a generator
-    whose field value is always a URL or a tuple. The tuple is going to be
-    ``('name-of-the-bucket', 'full-path-to-the-object-key')``. This
-    is useful when you need to parse the stream and get extra information
-    about where the symbol stream came from. For example::
-
-        >>> d = SymbolDownloader(['https://s3-us-we...1/?access=public'])
-        >>> stream = d.get_symbol_stream(
-        ...    'nss3.pdb', '9354378E7F4E4322A83EA57C483671962', 'nss3.sym')
-        >>> next(stream)
-        'https://s3-us-we...s3.pdb/9354378E7F4E4322A83EA57C483671962/nss3.sym'
-        >>> for line in stream:
-        ...    line
-        ...    break
-        ...
-        'MODULE windows x86 9354378E7F4E4322A83EA57C483671962 nss3.pdb'
-
-    Or, if using a non-public URL::
-
-        >>> # Same as above but without '?access=public' ending
-        >>> d = SymbolDownloader(['https://s3-us-we...1/'])
-        >>> stream = d.get_symbol_stream(
-        ...    'nss3.pdb', '9354378E7F4E4322A83EA57C483671962', 'nss3.sym')
-        >>> pprint(next(stream))
-        ('org.mozilla.crash-stats.symbols-public',
-         'v1/nss3.pdb/9354378E7F4E4322A83EA57C483671962/nss3.sym')
-        >>> for line in stream:
-        ...    line
-        ...    break
-        ...
-        'MODULE windows x86 9354378E7F4E4322A83EA57C483671962 nss3.pdb'
     """
 
     def __init__(self, urls, file_prefix=settings.SYMBOL_FILE_PREFIX):
@@ -248,112 +209,6 @@ class SymbolDownloader:
                 if check_url_head(file_url, _refresh=refresh_cache):
                     return {"url": file_url, "source": source}
 
-    def _get_stream(self, symbol, debugid, filename):
-        session = session_with_retries()
-        for source in self.sources:
-            prefix = source.prefix
-            assert prefix
-
-            if source.private:
-                # If it's a private bucket we use boto3
-
-                key = "{}/{}/{}/{}".format(
-                    prefix,
-                    symbol,
-                    # The are some legacy use case where the debug ID might
-                    # not already be uppercased. If so, we override it.
-                    # Every debug ID is always in uppercase.
-                    debugid.upper(),
-                    filename,
-                )
-                logger.debug(f"Looking for symbol file {key!r} in bucket {source.name}")
-
-                try:
-                    with metrics.timer("symboldownloader_get_object"):
-                        response = source.client.get_object(Bucket=source.name, Key=key)
-                    stream = response["Body"]
-                    # But if the content encoding is gzip we have
-                    # re-wrap the stream.
-                    if response.get("ContentEncoding") == "gzip":
-                        with metrics.timer("symboldownloader_get_object_read"):
-                            body = response["Body"].read()
-                        metrics.incr(
-                            "symboldownloader_download_bytes",
-                            len(body),
-                            tags=["encoding:gzip"],
-                        )
-                        bytestream = BytesIO(body)
-                        stream = GzipFile(None, "rb", fileobj=bytestream)
-                    yield (source.name, key)
-                    try:
-                        for line in iter_lines(stream):
-                            yield line.decode("utf-8")
-                        return
-                    except OSError as exception:
-                        if "Not a gzipped file" in str(exception):
-                            logger.warning(
-                                "OSError ({!r}) when downloading {}/{}"
-                                "".format(str(exception), source.name, key)
-                            )
-                            continue
-                        # Who knows what other OSErrors might happen when
-                        # it's not a problem of being a gzip content?!
-                        raise  # pragma: no cover
-
-                except ClientError as exception:
-                    if exception.response["Error"]["Code"] == "NoSuchKey":
-                        # basically, a convuluted way of saying 404
-                        continue
-                    # Any other errors we're not yet aware of, proceeed
-                    raise
-
-            else:
-                # If it's not a private bucket, we can use requests
-                # to download via HTTP.
-
-                # We'll put together the URL manually
-                file_url = "{}/{}/{}/{}/{}".format(
-                    source.base_url, prefix, symbol, debugid.upper(), filename
-                )
-                logger.debug(f"Looking for symbol file by URL {file_url!r}")
-                response = session.get(file_url, stream=True)
-                if response.status_code == 404:
-                    # logger.warning('{} 404 Not Found'.format(file_url))
-                    continue
-                elif response.status_code == 200:
-                    # Files downloaded from S3 should be UTF-8 but it's
-                    # unlikely that S3 exposes this in a header.
-                    # If the Content-Type in 'text/plain' requests will
-                    # assume the ISO-8859-1 encoding (this is according
-                    # to RFC 2616).
-                    # But if the content type is 'binary/octet-stream' it
-                    # can't assume any encoding so it will be returned
-                    # as a bytestring.
-                    if not response.encoding:
-                        response.encoding = "utf-8"
-                    yield file_url
-                    try:
-                        for line in response.iter_lines():
-                            # filter out keep-alive newlines
-                            if line:
-                                line = line.decode("utf-8")
-                                yield line
-                        # Stop the iterator
-                        return
-                    except requests.exceptions.ContentDecodingError as exc:
-                        logger.warning(f"{exc!r} when downloading {source}")
-                        continue
-                else:
-                    logger.warning(
-                        "{} {} ({})".format(
-                            source, response.status_code, response.content
-                        )
-                    )
-                    raise SymbolDownloadError(response.status_code, str(source))
-
-        # All URLs exhausted
-        raise SymbolNotFound(symbol, debugid, filename)
-
     @set_time_took
     def has_symbol(self, symbol, debugid, filename, refresh_cache=False):
         """return True if the symbol can be found, False if not
@@ -381,10 +236,3 @@ class SymbolDownloader:
                 # Left commented-in to remind us of what the default is
                 # ExpiresIn=3600
             )
-
-    def get_symbol_stream(self, symbol, debugid, filename):
-        """return a body stream for download if the file can be found.
-        The object is a regular Python generator.
-        The first item in the generator is always the URL or the
-        (bucketname, objectkey) tuple if found."""
-        return self._get_stream(symbol, debugid, filename)


### PR DESCRIPTION
get_symbol_stream is from the old symbolication API code and we don't need it any more.