### PR TITLE
bug 1814436: default uploads and files pages to last 30 days

### DIFF
--- a/frontend/src/Common.js
+++ b/frontend/src/Common.js
@@ -201,6 +201,17 @@ export const TableSubTitle = ({
   }
 };
 
+export const FilterSummary = ({ filter }) => {
+  const filterParts = [];
+  for (const [key, value] of Object.entries(filter)) {
+    if (key != "page" && value != "") {
+      filterParts.push(`${key}: ${value}`);
+    }
+  }
+  const filterValue = filterParts.join(", ");
+  return <span>{filterValue}</span>;
+};
+
 export const pluralize = (number, singular, plural) => {
   if (number === 1) {
     return `1 ${singular}`;

--- a/frontend/src/Files.js
+++ b/frontend/src/Files.js
@@ -14,6 +14,7 @@ import {
   Pagination,
   BooleanIcon,
   TableSubTitle,
+  FilterSummary,
   thousandFormat,
   formatSeconds,
   DisplayDateDifference,
@@ -37,8 +38,17 @@ class Files extends React.PureComponent {
       total: null,
       batchSize: null,
       apiUrl: null,
-      filter: {},
+      filter: {
+        // We want the filter for created_at to default to the last 30 days
+        created_at: this.getThirtyDaysFilterValue(),
+      },
     };
+  }
+
+  getThirtyDaysFilterValue() {
+    var thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    return ">=" + format(thirtyDaysAgo, "yyyy-MM-dd");
   }
 
   componentWillMount() {
@@ -162,6 +172,8 @@ class Files extends React.PureComponent {
             />
           )
         )}
+
+        <FilterSummary filter={this.state.filter} />
 
         {!this.state.loadingFiles && this.state.files && (
           <DisplayFiles

--- a/frontend/src/Uploads.js
+++ b/frontend/src/Uploads.js
@@ -14,6 +14,7 @@ import {
   formatFileSize,
   Pagination,
   TableSubTitle,
+  FilterSummary,
   thousandFormat,
   pluralize,
   DisplayFilesSummary,
@@ -37,12 +38,21 @@ class Uploads extends React.PureComponent {
       total: null,
       batchSize: null,
       apiUrl: null,
-      filter: {},
+      filter: {
+        // We want the filter for created_at to default to the last 30 days
+        created_at: this.getThirtyDaysFilterValue(),
+      },
       validationErrors: null,
       latestUpload: null,
       orderBy: null,
       hasNextPage: false,
     };
+  }
+
+  getThirtyDaysFilterValue() {
+    var thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    return ">=" + format(thirtyDaysAgo, "yyyy-MM-dd");
   }
 
   componentWillMount() {
@@ -260,6 +270,9 @@ class Uploads extends React.PureComponent {
             />
           )
         )}
+
+        <FilterSummary filter={this.state.filter} />
+
         {this.state.validationErrors && (
           <ShowValidationErrors
             errors={this.state.validationErrors}

--- a/tecken/api/views.py
+++ b/tecken/api/views.py
@@ -522,6 +522,8 @@ def _upload_files_content(request, qs):
 @api_permission_required("upload.view_all_uploads")
 def upload_files(request):
     qs = _upload_files_build_qs(request)
+    if isinstance(qs, http.JsonResponse):
+        return qs
     try:
         context = _upload_files_content(request, qs)
     except BadRequest as e:


### PR DESCRIPTION
This changes the uploads and files pages to default to looking at only the last 30 days. This radically reduces how much time it takes to render the pages and gets us around the "omg--it's so slow" problem.