### PR TITLE
bug 1840655: reduce home page stats

### DIFF
--- a/bin/run_test.sh
+++ b/bin/run_test.sh
@@ -15,7 +15,7 @@ export DEVELOPMENT=1
 if [ "$1" = "--shell" ]
 then
     bash
+else
+    # Run tecken tests
+    pytest
 fi
-
-# Run tecken tests
-pytest

--- a/frontend/src/Home.js
+++ b/frontend/src/Home.js
@@ -71,27 +71,21 @@ class SignedInTiles extends React.PureComponent {
     return (
       <div>
         <div className="tile is-ancestor">
-          <div
-            className={user.is_superuser ? "tile is-parent" : "tile is-parent"}
-          >
+          <div className="tile is-parent is-6">
             {store.hasPermission("upload.upload_symbols") ? (
               <UploadsStatsTile loading={loading} stats={stats} />
             ) : (
               <AboutUploadsPermissionTile />
             )}
           </div>
-          <div className="tile is-parent">
-            <DownloadsStatsTile loading={loading} stats={stats} />
+          <div className="tile is-parent is-6">
+            <LinksTile />
           </div>
         </div>
 
         <div className="tile is-ancestor">
-          <div className="tile is-parent is-6">
-            <YouTile user={user} />
-          </div>
-
           <div className="tile is-parent">
-            <LinksTile />
+            <YouTile user={user} />
           </div>
         </div>
       </div>
@@ -210,31 +204,14 @@ const UploadsStatsTile = ({ loading, stats }) => (
             <th>
               <Link to="/uploads">Uploads Size</Link>
             </th>
-            <th>
-              <Link
-                to="/uploads/files"
-                title="Files from .zip uploads we actually uploaded"
-              >
-                Uploaded Files
-              </Link>
-            </th>
           </tr>
         </thead>
         <tbody>
-          <UploadsRow
-            title="Today"
-            uploads={stats.uploads.today}
-            files={stats.files.today}
-          />
-          <UploadsRow
-            title="Yesterday"
-            uploads={stats.uploads.yesterday}
-            files={stats.files.yesterday}
-          />
+          <UploadsRow title="Today" uploads={stats.uploads.today} />
+          <UploadsRow title="Yesterday" uploads={stats.uploads.yesterday} />
           <UploadsRow
             title="Last 30 days"
             uploads={stats.uploads.last_30_days}
-            files={stats.files.last_30_days}
           />
         </tbody>
       </table>
@@ -242,52 +219,15 @@ const UploadsStatsTile = ({ loading, stats }) => (
   </article>
 );
 
-const UploadsRow = ({ title, uploads, files }) => {
+const UploadsRow = ({ title, uploads }) => {
   return (
     <tr>
       <th>{title}</th>
       <td>{thousandFormat(uploads.count)}</td>
       <td>{formatFileSize(uploads.total_size)}</td>
-      <td>{thousandFormat(files.count)}</td>
     </tr>
   );
 };
-
-const DownloadsStatsTile = ({ loading, stats }) => (
-  <article className="tile is-child box">
-    <p className="title">Downloads</p>
-    {loading || !stats ? (
-      <Loading />
-    ) : (
-      <table className="table is-fullwidth">
-        <thead>
-          <tr>
-            <th />
-            <th>
-              <Link to="/downloads/missing/">Recorded Missing</Link>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th>Today</th>
-            <TableCountCell count={stats.downloads.missing.today.count} />
-          </tr>
-          <tr>
-            <th>Yesterday</th>
-            <TableCountCell count={stats.downloads.missing.yesterday.count} />
-          </tr>
-          <tr>
-            <th>Last 30 days</th>
-            <TableCountCell
-              count={stats.downloads.missing.last_30_days.count}
-            />
-          </tr>
-        </tbody>
-      </table>
-    )}
-  </article>
-);
 
 const TableCountCell = ({ count }) => {
   return <td>{thousandFormat(count)}</td>;

--- a/tecken/tests/test_api.py
+++ b/tecken/tests/test_api.py
@@ -965,20 +965,6 @@ def test_stats(client):
             "yesterday": {"count": 0, "total_size": 0},
             "last_30_days": {"count": 0, "total_size": 0},
         },
-        "files": {
-            "today": {"count": 0},
-            "yesterday": {"count": 0},
-            "last_30_days": {"count": 0},
-        },
-        "downloads": {
-            "missing": {
-                "today": {"count": 0},
-                "yesterday": {"count": 0},
-                "last_30_days": {"count": 0},
-            }
-        },
-        "tokens": {"total": 0, "expired": 0},
-        # NOTE: no "users" section
     }
 
     user.is_superuser = True
@@ -995,50 +981,7 @@ def test_stats(client):
             "yesterday": {"count": 0, "total_size": 0},
             "last_30_days": {"count": 0, "total_size": 0},
         },
-        "files": {
-            "today": {"count": 0},
-            "yesterday": {"count": 0},
-            "last_30_days": {"count": 0},
-        },
-        "downloads": {
-            "missing": {
-                "today": {"count": 0},
-                "yesterday": {"count": 0},
-                "last_30_days": {"count": 0},
-            }
-        },
-        "tokens": {"total": 0, "expired": 0},
-        "users": {"total": 1, "superusers": 1, "active": 1, "not_active": 0},
     }
-
-
-@pytest.mark.django_db
-def test_stats_missing_symbols_count(client):
-    url = reverse("api:stats")
-    response = client.get(url)
-    user = User.objects.create(username="peterbe", email="peterbe@example.com")
-    user.set_password("secret")
-    user.save()
-    assert client.login(username="peterbe", password="secret")
-
-    response = client.get(url)
-    assert response.status_code == 200
-    data = response.json()
-    missing = data["stats"]["downloads"]["missing"]
-    assert missing["today"]["count"] == 0
-    assert missing["yesterday"]["count"] == 0
-    assert missing["last_30_days"]["count"] == 0
-
-    MissingSymbol.objects.create(
-        hash="x1", symbol="foo.pdb", debugid="ADEF12345", filename="foo.sym", count=1
-    )
-    response = client.get(url)
-    assert response.status_code == 200
-    data = response.json()
-    missing = data["stats"]["downloads"]["missing"]
-    assert missing["today"]["count"] == 1
-    assert missing["yesterday"]["count"] == 0
-    assert missing["last_30_days"]["count"] == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This does a few things to reduce the work done by the stats view which is called by the home page:

1. removes the "missing symbols" stats--we're removing missing symbols bookkeeping, so we can remove this now
2. removes the uploaded files counts--I'm not sure this really means anything and comparing two uploaded files counts numbers doesn't really tell us anything
3. removes some other things that were generated by the stats view but weren't used in the frontend--this was extra work being done with no value