### PR TITLE
bug 1843356, 1834626: remove support for private buckets

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -46,20 +46,3 @@ OIDC_OP_USER_ENDPOINT=http://oidcprovider:8080/openid/userinfo
 OIDC_VERIFY_SSL=false
 # Disable NotBlockedInAuth0Middleware
 ENABLE_AUTH0_BLOCKED_CHECK=false
-
-
-# Eliot
-# -----
-
-# Local development flag
-ELIOT_LOCAL_DEV_ENV=true
-
-# Logging
-ELIOT_LOGGING_LEVEL=INFO
-
-# Statsd things
-ELIOT_STATSD_HOST=statsd
-ELIOT_STATSD_NAMESPACE=mcboatface
-ELIOT_STATSD_PORT=8125
-ELIOT_SYMBOLS_CACHE_MAX_SIZE=400000000
-ELIOT_SECRET_SENTRY_DSN=http://public@fakesentry:8090/1

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -28,9 +28,9 @@ AWS_ENDPOINT_URL=http://localstack:4566/
 
 DEBUG=true
 LOCAL_DEV_ENV=true
-SYMBOL_URLS=http://localstack:4566/publicbucket/?access=public
-UPLOAD_DEFAULT_URL=http://localstack:4566/publicbucket/?access=public
-UPLOAD_TRY_SYMBOLS_URL=http://localstack:4566/publicbucket/try/?access=public
+SYMBOL_URLS=http://localstack:4566/publicbucket/
+UPLOAD_DEFAULT_URL=http://localstack:4566/publicbucket/
+UPLOAD_TRY_SYMBOLS_URL=http://localstack:4566/publicbucket/try/
 
 # Default to the test oidcprovider container for Open ID Connect
 #

--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -33,14 +33,3 @@ OIDC_OP_USER_ENDPOINT=https://auth.example.com/authorize
 SYMBOL_FILE_PREFIX=v0
 
 UPLOAD_TEMPDIR=/tmp/test/uploads
-
-
-# Eliot settings
-# --------------
-
-ELIOT_HOST_ID=testnode
-
-ELIOT_SYMBOLS_URLS=http://symbols.example.com/
-ELIOT_TMP_DIR=/tmp/test/junk/
-ELIOT_SYMBOLS_CACHE_DIR=/tmp/test/cache/
-ELIOT_SECRET_SENTRY_DSN=http://public@fakesentry:8090/1

--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -30,6 +30,4 @@ OIDC_RP_CLIENT_SECRET=abcdef
 # This makes sure this is never a real valid URL.
 OIDC_OP_USER_ENDPOINT=https://auth.example.com/authorize
 
-SYMBOL_FILE_PREFIX=v0
-
 UPLOAD_TEMPDIR=/tmp/test/uploads

--- a/docs/upload.rst
+++ b/docs/upload.rst
@@ -330,20 +330,9 @@ Records of the upload and what files were in it are available on the website.
 Which S3 Bucket
 ===============
 
-The S3 bucket that gets used for upload is based on a "default" and a map of
-exceptions for certain users.
-
-The default is configured as ``DJANGO_UPLOAD_DEFAULT_URL``. For example:
-``https://s3-us-west-2.amazonaws.com/org-mozilla-symbols-public``.  From the
-URL the bucket name is deduced and that's the default S3 bucket used.
-
-The overriding is based on the **uploader's email address**. The default
-configuration is to make no exceptions. But you can set
-``DJANGO_UPLOAD_URL_EXCEPTIONS`` as a Python dict like this:
-
-.. code-block:: shell
-
-    $ export DJANGO_UPLOAD_URL_EXCEPTIONS={'*@adobe.com': 'https://s3.amazonaws.com/private-bucket'}
+The S3 bucket for symbols is configured by ``DJANGO_UPLOAD_DEFAULT_URL``. For
+example: ``https://s3-us-west-2.amazonaws.com/org-mozilla-symbols-public``.
+From the URL the bucket name is deduced and that's the default S3 bucket used.
 
 
 Checks and Validations

--- a/frontend/src/UploadNow.js
+++ b/frontend/src/UploadNow.js
@@ -448,7 +448,6 @@ function PossibleUploadUrlsField({ possibleUploadUrls, preferredBucketName }) {
               return (
                 <option value={item.bucket_name} key={item.url}>
                   {item.bucket_name}
-                  {item.private ? " (private)" : ""}
                 </option>
               );
             })}

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,5 @@ filterwarnings =
     # sentry requires urllib3 version that deprecated urllib3.contrib.pyopenssl which
     # botocore still uses, https://github.com/boto/botocore/issues/2744
     ignore:'urllib3.contrib.pyopenssl':DeprecationWarning
+    # boto3 kicks up ResourceWarning: unclosed socket, https://github.com/boto/boto3/issues/454
+    ignore:unclosed:ResourceWarning

--- a/systemtests/data/sym_files_to_download.csv
+++ b/systemtests/data/sym_files_to_download.csv
@@ -17,8 +17,3 @@ libmozglue.dylib/11FB836EE6723C07BFF775900077457B0/libmozglue.dylib.sym,200
 # These were from tecken-loadtests and have expired so they're 404.
 libEGL.so/8787CB75CD6E976D87477CA9AC1EB98D0/libEGL.so.sym,404
 libvlc.dll/3BDB3BCF29000/libvlc.dl_,404
-
-# These are in the private bucket which isn't accessible via the
-# downloading API, so these return a 404.
-libc.so/8B654FF16EA5103DF06284EDA4EE8C730/libc.so.sym,404
-libsqlite.so/2D932347B05044E333C97A1915A08ADA0/libsqlite.so.sym,404

--- a/tecken/api/views.py
+++ b/tecken/api/views.py
@@ -27,7 +27,7 @@ from tecken.download.models import MissingSymbol
 from tecken.storage import StorageBucket
 from tecken.tokens.models import Token
 from tecken.upload.models import Upload, FileUpload
-from tecken.upload.views import get_possible_bucket_urls
+from tecken.upload.views import get_upload_bucket_urls
 
 logger = logging.getLogger("tecken")
 metrics = markus.get_metrics("tecken")
@@ -100,7 +100,7 @@ def auth(request):
 def possible_upload_urls(request):
     context = {"urls": []}
     seen = set()
-    for url, private_or_public in get_possible_bucket_urls(request.user):
+    for url in get_upload_bucket_urls():
         bucket_info = StorageBucket(url)
 
         if bucket_info.name in seen:
@@ -110,7 +110,6 @@ def possible_upload_urls(request):
             {
                 "url": url,
                 "bucket_name": bucket_info.name,
-                "private": private_or_public == "private",
                 "default": url == settings.UPLOAD_DEFAULT_URL,
             }
         )

--- a/tecken/base/admin.py
+++ b/tecken/base/admin.py
@@ -134,14 +134,6 @@ def site_status(request):
             "value": json.dumps([clean_url(x) for x in settings.SYMBOL_URLS]),
         }
     )
-    context["settings"].append(
-        {
-            "key": "UPLOAD_URL_EXCEPTIONS",
-            "value": json.dumps(
-                {k: clean_url(v) for k, v in settings.UPLOAD_URL_EXCEPTIONS.items()}
-            ),
-        }
-    )
     context["settings"].sort(key=lambda x: x["key"])
 
     # Get some table counts

--- a/tecken/base/symboldownloader.py
+++ b/tecken/base/symboldownloader.py
@@ -18,8 +18,6 @@ from tecken.storage import StorageBucket
 logger = logging.getLogger("tecken")
 metrics = markus.get_metrics("tecken")
 
-ITER_CHUNK_SIZE = 512
-
 
 class SymbolNotFound(Exception):
     """Happens when you try to download a symbols file that doesn't exist"""
@@ -29,33 +27,6 @@ class SymbolDownloadError(Exception):
     def __init__(self, status_code, url):
         self.status_code = status_code
         self.url = url
-
-
-def iter_lines(stream, chunk_size=ITER_CHUNK_SIZE):
-    """Iterates over the response data, one line at a time.  When
-    stream=True is set on the request, this avoids reading the
-    content at once into memory for large responses.
-
-    .. note:: This method is not reentrant safe.
-    """
-
-    pending = None
-
-    for chunk in iter(lambda: stream.read(chunk_size), b""):
-        if pending is not None:
-            chunk = pending + chunk
-
-        lines = chunk.splitlines()
-
-        if lines and lines[-1] and chunk and lines[-1][-1] == chunk[-1]:
-            pending = lines.pop()
-        else:
-            pending = None
-
-        yield from lines
-
-    if pending is not None:
-        yield pending
 
 
 def set_time_took(method):
@@ -116,11 +87,7 @@ class SymbolDownloader:
     1. Do you have this particular symbol?
     2. Give me the presigned URL for this particular symbol.
 
-    This class takes a list of URLs. If the URL contains ``access=public``
-    in the query string part, this class will use ``requests.get`` or
-    ``requests.head`` depending on the task.
-    If the URL does NOT contain ``access=public`` it will use a
-    ``boto3`` S3 client to do the check or download.
+    This class takes a list of URLs.
 
     """
 
@@ -152,19 +119,10 @@ class SymbolDownloader:
         for source in self.sources:
             prefix = source.prefix
             assert prefix
-            if source.private:
-                # At some point we ran
-                # exists_in_source(source, key)
-                # But that function is wrapped and now has an extra
-                # function to "undoing" it.
-                exists_in_source.invalidate(
-                    source, self._make_key(prefix, symbol, debugid, filename)
-                )
-            else:
-                file_url = "{}/{}".format(
-                    source.base_url, self._make_key(prefix, symbol, debugid, filename)
-                )
-                check_url_head.invalidate(file_url)
+            file_url = "{}/{}".format(
+                source.base_url, self._make_key(prefix, symbol, debugid, filename)
+            )
+            check_url_head.invalidate(file_url)
 
     @staticmethod
     def _make_key(prefix, symbol, debugid, filename):
@@ -179,35 +137,25 @@ class SymbolDownloader:
         )
 
     def _get(self, symbol, debugid, filename, refresh_cache=False):
-        """Return a dict if the symbol can be found. The dict will
-        either be `{'url': ...}` or `{'buckey_name': ..., 'key': ...}`
-        depending on if the symbol was found a public bucket or a
-        private bucket.
+        """Return a dict if the symbol can be found.
+
+        Dict includes a "url" key.
+
         Consumers of this method can use the fact that anything truish
-        was returned as an indication that the symbol actually exists."""
+        was returned as an indication that the symbol actually exists.
+
+        """
         for source in self.sources:
             prefix = source.prefix
             assert prefix
 
-            if source.private:
-                # If it's a private bucket we use boto3
-                key = self._make_key(prefix, symbol, debugid, filename)
-                logger.debug(f"Looking for symbol file {key!r} in bucket {source.name}")
-
-                if not exists_in_source(source, key, _refresh=refresh_cache):
-                    continue
-
-                # It exists if we're still here.
-                return {"bucket_name": source.name, "key": key, "source": source}
-
-            else:
-                # We'll put together the URL manually
-                file_url = "{}/{}".format(
-                    source.base_url, self._make_key(prefix, symbol, debugid, filename)
-                )
-                logger.debug(f"Looking for symbol file by URL {file_url!r}")
-                if check_url_head(file_url, _refresh=refresh_cache):
-                    return {"url": file_url, "source": source}
+            # We'll put together the URL manually
+            file_url = "{}/{}".format(
+                source.base_url, self._make_key(prefix, symbol, debugid, filename)
+            )
+            logger.debug(f"Looking for symbol file by URL {file_url!r}")
+            if check_url_head(file_url, _refresh=refresh_cache):
+                return {"url": file_url, "source": source}
 
     @set_time_took
     def has_symbol(self, symbol, debugid, filename, refresh_cache=False):
@@ -217,22 +165,11 @@ class SymbolDownloader:
 
     @set_time_took
     def get_symbol_url(self, symbol, debugid, filename, refresh_cache=False):
-        """return the redirect URL or None. If we return None
-        it means we can't find the object in any of the URLs provided."""
+        """Return the redirect URL or None.
+
+        If we return None it means we can't find the object in any of the URLs provided.
+
+        """
         found = self._get(symbol, debugid, filename, refresh_cache=refresh_cache)
         if found:
-            if "url" in found:
-                return found["url"]
-
-            # If a URL wasn't returned, the bucket it was found in
-            # was not public.
-            bucket_name = found["bucket_name"]
-            key = found["key"]
-            # generate_presigned_url() actually works for both private
-            # and public buckets.
-            return found["source"].client.generate_presigned_url(
-                "get_object",
-                Params={"Bucket": bucket_name, "Key": key},
-                # Left commented-in to remind us of what the default is
-                # ExpiresIn=3600
-            )
+            return found["url"]

--- a/tecken/libdockerflow.py
+++ b/tecken/libdockerflow.py
@@ -19,8 +19,6 @@ def check_storage_urls(app_configs, **kwargs):
         if url in checked:
             return
         bucket = StorageBucket(url)
-        if not bucket.private:
-            return
         try:
             if not bucket.exists():
                 errors.append(

--- a/tecken/libdockerflow.py
+++ b/tecken/libdockerflow.py
@@ -43,8 +43,6 @@ def check_storage_urls(app_configs, **kwargs):
 
     for url in settings.SYMBOL_URLS:
         check_url(url, "SYMBOL_URLS")
-    for url in settings.UPLOAD_URL_EXCEPTIONS.values():
-        check_url(url, "UPLOAD_URL_EXCEPTIONS")
 
     return errors
 

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -612,26 +612,20 @@ DOCKERFLOW_CHECKS = [
 ]
 
 
-#
 SYMBOL_URLS = _config(
     "SYMBOL_URLS",
     parser=ListOf(str),
     doc=(
-        "Comma-separated list of urls for symbol lookups.\n\n"
-        "The order here matters. Symbol download goes through these one at a time. "
-        "Ideally you want the one most commonly hit first unless there's a "
-        "cascading reason you want other buckets first.\n\n"
-        "By default, each URL is assumed to be private!\n\n"
-        "If there's a bucket you want to include that should be accessed "
-        "by HTTP only, add '?access=public' to the URL."
+        "Comma-separated list of urls for symbol downloads.\n\n"
+        "Lookups are performed in list order."
     ),
 )
 
 UPLOAD_DEFAULT_URL = _config(
     "UPLOAD_DEFAULT_URL",
     doc=(
-        "The default url to use for symbols. This must be a public bucket and "
-        "one of the items in SYMBOL_URLS."
+        "The default url to use for symbol uploads. This must be an item in "
+        "SYMBOL_URLS."
     ),
 )
 

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -656,21 +656,6 @@ if UPLOAD_DEFAULT_URL not in SYMBOL_URLS:
         f"in SYMBOL_URLS ({SYMBOL_URLS!r})"
     )
 
-UPLOAD_URL_EXCEPTIONS = _config(
-    "UPLOAD_URL_EXCEPTIONS",
-    default="{}",
-    parser=dict_parser,
-    doc=(
-        "This is a config that, typed as a Python dictionary, specifies "
-        "specific email addresses or patterns to custom URLs.\n\n"
-        "For example::\n\n"
-        '    UPLOAD_URL_EXCEPTIONS={"peter@example.com":"https://s3.amazonaws.com/bucket"}\n\n'
-        "    or\n\n"
-        '    UPLOAD_URL_EXCEPTIONS={"*@example.com": "https://s3.amazonaws.com/bucket"}\n\n'
-        "anybody uploading with an ``@example.com`` email address."
-    ),
-)
-
 # The default prefix for locating all symbols
 SYMBOL_FILE_PREFIX = _config(
     "SYMBOL_FILE_PREFIX",

--- a/tecken/storage.py
+++ b/tecken/storage.py
@@ -36,14 +36,12 @@ class StorageBucket:
     Usage::
 
         >>> s = StorageBucket(
-        ...    'https://s3-us-west-2.amazonaws.com/bucky/prfx?access=public'
+        ...    'https://s3-us-west-2.amazonaws.com/bucky/prfx'
         )
         >>> s.netloc
         's3-us-west-2.amazonaws.com'
         >>> s.name
         'bucky'
-        >>> s.private  # note, private is usually default
-        False
         >>> s.prefix
         'prfx'
         >>> s.client.list_objects_v2(Bucket=s.name, Prefix='some/key.ext')
@@ -91,7 +89,6 @@ class StorageBucket:
             else:
                 prefix = file_prefix
         self.prefix = prefix
-        self.private = "access=public" not in parsed.query
         self.try_symbols = try_symbols
         self.endpoint_url = None
         self.region = None

--- a/tecken/tests/test_api.py
+++ b/tecken/tests/test_api.py
@@ -776,7 +776,7 @@ def test_upload_files(client, settings):
     file_upload1 = FileUpload.objects.create(
         upload=upload,
         size=1234,
-        bucket_name="symbols-private",
+        bucket_name="other-public",
         key="v0/bar.dll/A4FC12EFA5/foo.sym",
     )
     file_upload2 = FileUpload.objects.create(
@@ -867,7 +867,7 @@ def test_upload_files_count(client):
     file_upload_1 = FileUpload.objects.create(
         upload=upload,
         size=1234,
-        bucket_name="symbols-private",
+        bucket_name="symbols-public",
         key="v0/bar.dll/A4FC12EFA5/foo.sym",
     )
     file_upload_2 = FileUpload.objects.create(
@@ -899,7 +899,7 @@ def test_upload_files_count(client):
             "update": False,
             "compressed": False,
             "size": 1234,
-            "bucket_name": "symbols-private",
+            "bucket_name": "symbols-public",
             "completed_at": None,
             "created_at": ANY,
             "upload": {
@@ -921,7 +921,7 @@ def test_upload_files_count(client):
     data = response.json()
     assert data["files"] == [
         {
-            "bucket_name": "symbols-private",
+            "bucket_name": "symbols-public",
             "completed_at": None,
             "compressed": False,
             "created_at": ANY,

--- a/tecken/tests/test_libdockerflow.py
+++ b/tecken/tests/test_libdockerflow.py
@@ -19,13 +19,13 @@ def test_check_storage_urls_happy_path():
 def test_check_storage_urls_missing(settings):
     settings.SYMBOL_URLS = [
         "http://s3.example.com/public",
-        "http://s3.example.com/private",
+        "http://s3.example.com/other-bucket",
     ]
     with patch("tecken.storage.StorageBucket.exists", return_value=False):
         errors = libdockerflow.check_storage_urls(None)
     assert len(errors) == 2
     assert "public" in errors[0].msg
-    assert "private" in errors[1].msg
+    assert "other-bucket" in errors[1].msg
     for error in errors:
         assert "bucket not found" in error.msg
         assert error.id == "tecken.health.E001"
@@ -41,7 +41,7 @@ def test_check_storage_urls_missing(settings):
 def test_check_storage_urls_storageerror(exception, settings):
     settings.SYMBOL_URLS = [
         "http://s3.example.com/public",
-        "http://s3.example.com/private",
+        "http://s3.example.com/other-bucket",
     ]
     fake_bucket = StorageBucket(url=settings.SYMBOL_URLS[0])
     error = StorageError(bucket=fake_bucket, backend_error=exception)
@@ -56,7 +56,7 @@ def test_check_storage_urls_storageerror(exception, settings):
 def test_check_storage_urls_other_error(settings):
     settings.SYMBOL_URLS = [
         "http://s3.example.com/public",
-        "http://s3.example.com/private",
+        "http://s3.example.com/other-bucket",
     ]
     exception = RuntimeError("A different error")
     with patch(

--- a/tecken/tests/test_symboldownloader.py
+++ b/tecken/tests/test_symboldownloader.py
@@ -2,84 +2,45 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import pytest
-from botocore.exceptions import ClientError
+import os
 
-from tecken.storage import StorageBucket
 from tecken.base.symboldownloader import (
     SymbolDownloader,
-    iter_lines,
     exists_in_source,
 )
+from tecken.storage import StorageBucket
 
 
-def test_exists_in_source(botomock, settings):
-    mock_api_calls = []
+def test_exists_in_source(s3_helper, settings):
+    module = "xul.pdb"
+    debugid = "44E4EC8C2F41492B9369D6B9A059577C2"
+    debugfn = "xul.sym"
 
-    def mock_api_call(self, operation_name, api_params):
-        mock_api_calls.append(api_params)
-        assert operation_name == "ListObjectsV2"
-        if api_params["Prefix"].endswith("xxx.sym"):
-            return {}
-        return {"Contents": [{"Key": api_params["Prefix"]}]}
-
-    bucket = StorageBucket("https://s3.example.com/private")
-    with botomock(mock_api_call):
-        assert not exists_in_source(bucket, "xxx.sym")
-        assert exists_in_source(bucket, "xul.sym")
-        assert len(mock_api_calls) == 2
-
-        # again
-        assert not exists_in_source(bucket, "xxx.sym")
-        assert exists_in_source(bucket, "xul.sym")
-        assert len(mock_api_calls) == 2
-
-
-def test_iter_lines():
-    class Stream:
-        def __init__(self, content):
-            self.left = content
-
-        def read(self, size):
-            if not self.left:
-                raise StopIteration
-            chunk = self.left[:size]
-            self.left = self.left[size:]
-            return chunk
-
-    lines = "Line 1\n" "Line 2\n" "Line 3\n"
-    stream = Stream(lines)
-    output = list(iter_lines(stream))
-    assert output == ["Line 1", "Line 2", "Line 3"]
-
-    # Create it again because our little stream mock doesn't rewind
-    stream = Stream(lines)
-    output = list(iter_lines(stream, chunk_size=5))
-    assert output == ["Line 1", "Line 2", "Line 3"]
-
-    stream = Stream(lines.strip())  # no trailing linebreak
-    output = list(iter_lines(stream))
-    assert output == ["Line 1", "Line 2", "Line 3"]
-
-    stream = Stream(lines.strip())  # no trailing linebreak
-    output = list(iter_lines(stream, chunk_size=3))
-    assert output == ["Line 1", "Line 2", "Line 3"]
-
-
-def test_has_public(requestsmock):
-    requestsmock.head(
-        "https://s3.example.com/public/prefix/v0/xul.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xul.sym",
-        text="",
+    # Upload a file into the regular bucket
+    s3_helper.create_bucket("publicbucket")
+    s3_helper.upload_fileobj(
+        bucket_name="publicbucket",
+        key=f"v1/{module}/{debugid}/{debugfn}",
+        data=b"abc123",
     )
-    requestsmock.head(
-        "https://s3.example.com/public/prefix/v0/xxx.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xxx.sym",
-        text="Page Not Found",
-        status_code=404,
+
+    good_key = f"v1/{module}/{debugid}/{debugfn}"
+    bad_key = "v1/XUL/4C4C445955553144A1984A09D6A8D6930/XUL.sym"
+
+    bucket = StorageBucket(os.environ["UPLOAD_DEFAULT_URL"])
+    assert exists_in_source(bucket, good_key)
+    assert not exists_in_source(bucket, bad_key)
+
+
+def test_has_symbol(s3_helper):
+    s3_helper.create_bucket("publicbucket")
+    s3_helper.upload_fileobj(
+        bucket_name="publicbucket",
+        key="v1/xul.pdb/44E4EC8C2F41492B9369D6B9A059577C2/xul.sym",
+        data=b"abc123",
     )
-    urls = ("https://s3.example.com/public/prefix/?access=public",)
-    downloader = SymbolDownloader(urls, file_prefix="v0")
+    urls = ("http://localstack:4566/publicbucket/",)
+    downloader = SymbolDownloader(urls, file_prefix="v1")
     assert downloader.has_symbol(
         "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
     )
@@ -88,153 +49,21 @@ def test_has_public(requestsmock):
     )
 
 
-def test_has_private_bubble_other_clienterrors(botomock):
-    def mock_api_call(self, operation_name, api_params):
-        parsed_response = {"Error": {"Code": "403", "Message": "Not found"}}
-        raise ClientError(parsed_response, operation_name)
-
-    urls = ("https://s3.example.com/private/prefix/",)
-    downloader = SymbolDownloader(urls)
-    # Expect this to raise a ClientError because the bucket ('private')
-    # doesn't exist. So boto3 would normally trigger a ClientError
-    # with a code 'Forbidden'.
-    with botomock(mock_api_call):
-        with pytest.raises(ClientError):
-            downloader.has_symbol(
-                "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-            )
-
-
-def test_has_private(botomock):
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "ListObjectsV2"
-        if api_params["Prefix"].endswith("xxx.sym"):
-            return {}
-        return {"Contents": [{"Key": api_params["Prefix"]}]}
-
-    urls = ("https://s3.example.com/private/prefix/",)
-    downloader = SymbolDownloader(urls)
-    with botomock(mock_api_call):
-        assert downloader.has_symbol(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        assert downloader.time_took > 0.0
-        assert not downloader.has_symbol(
-            "xxx.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xxx.sym"
-        )
-        assert downloader.time_took > 0.0
-
-
-def test_has_private_caching_and_invalidation(botomock):
-    mock_calls = []
-
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "ListObjectsV2"
-        mock_calls.append(api_params["Prefix"])
-        return {"Contents": [{"Key": api_params["Prefix"]}]}
-
-    urls = ("https://s3.example.com/private/prefix/",)
-    downloader = SymbolDownloader(urls)
-    with botomock(mock_api_call):
-        assert downloader.has_symbol(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        assert len(mock_calls) == 1
-        assert downloader.has_symbol(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        # This should be cached
-        assert len(mock_calls) == 1
-
-        # Now invalidate it
-        downloader.invalidate_cache(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        assert downloader.has_symbol(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        assert len(mock_calls) == 2
-
-        # Invalidating unrecognized keys shouldn't break anything
-        downloader.invalidate_cache(
-            "never", "44E4EC8C2F41492B9369D6B9A059577C2", "heardof"
-        )
-
-
-def test_get_url_private_caching_and_invalidation(botomock):
-    mock_calls = []
-
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "ListObjectsV2"
-        mock_calls.append(api_params["Prefix"])
-        return {"Contents": [{"Key": api_params["Prefix"]}]}
-
-    urls = ("https://s3.example.com/private/prefix/",)
-    downloader = SymbolDownloader(urls)
-    with botomock(mock_api_call):
-        assert downloader.get_symbol_url(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        assert len(mock_calls) == 1
-        assert downloader.get_symbol_url(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        # This should be cached
-        assert len(mock_calls) == 1
-
-        # Now invalidate it
-        downloader.invalidate_cache(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        assert downloader.get_symbol_url(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        assert len(mock_calls) == 2
-
-
-def test_has_private_without_prefix(botomock):
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "ListObjectsV2"
-        if api_params["Prefix"].endswith("xul.sym"):
-            # found
-            return {"Contents": [{"Key": api_params["Prefix"]}]}
-        elif api_params["Prefix"].endswith("xxx.sym"):
-            # not found
-            return {}
-
-        raise NotImplementedError(api_params)
-
-    urls = ("https://s3.example.com/private",)
-    downloader = SymbolDownloader(urls)
-    with botomock(mock_api_call):
-        assert downloader.has_symbol(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        assert not downloader.has_symbol(
-            "xxx.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xxx.sym"
-        )
-
-
-def test_get_url_public(requestsmock):
-    requestsmock.head(
-        "https://s3.example.com/public/prefix/v0/xul.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xul.sym",
-        text="",
+def test_get_url_public(s3_helper):
+    s3_helper.create_bucket("publicbucket")
+    s3_helper.upload_fileobj(
+        bucket_name="publicbucket",
+        key="v1/xul.pdb/44E4EC8C2F41492B9369D6B9A059577C2/xul.sym",
+        data=b"abc123",
     )
-    requestsmock.head(
-        "https://s3.example.com/public/prefix/v0/xxx.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xxx.sym",
-        text="Page Not Found",
-        status_code=404,
-    )
-    urls = ("https://s3.example.com/public/prefix/?access=public",)
+    urls = ("http://localstack:4566/publicbucket/",)
     downloader = SymbolDownloader(urls)
     url = downloader.get_symbol_url(
         "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
     )
     assert url == (
-        "https://s3.example.com/public/prefix/v0/xul.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xul.sym"
+        "http://localstack:4566/publicbucket/v1/xul.pdb/"
+        + "44E4EC8C2F41492B9369D6B9A059577C2/xul.sym"
     )
     url = downloader.get_symbol_url(
         "xxx.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xxx.sym"
@@ -242,38 +71,7 @@ def test_get_url_public(requestsmock):
     assert url is None
 
 
-def test_get_url_private(botomock):
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "ListObjectsV2"
-        if api_params["Prefix"].endswith("xxx.sym"):
-            # not found
-            return {}
-        return {"Contents": [{"Key": api_params["Prefix"]}]}
-
-    urls = ("https://s3.example.com/private/prefix/",)
-    downloader = SymbolDownloader(urls)
-    with botomock(mock_api_call):
-        url = downloader.get_symbol_url(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        # The bucket gets put in the top-domain.
-        assert url.startswith("https://s3.example.com/")
-        assert (
-            "/private/prefix/v0/xul.pdb/" "44E4EC8C2F41492B9369D6B9A059577C2/xul.sym?"
-        ) in url
-        assert "Expires=" in url
-        assert "AWSAccessKeyId=" in url
-        assert "Signature=" in url
-
-        url = downloader.get_symbol_url(
-            "xxx.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xxx.sym"
-        )
-        assert url is None
-
-        assert len(botomock.calls) == 2
-
-
-def test_public_default_file_prefix(requestsmock, settings):
+def test_public_default_file_prefix():
     """The idea with settings.SYMBOL_FILE_PREFIX is to make it easier
     to specify the settings.SYMBOL_URLS. That settings.SYMBOL_FILE_PREFIX
     is *always* used when uploading symbols. So it's *always* useful to
@@ -285,33 +83,13 @@ def test_public_default_file_prefix(requestsmock, settings):
     However, we don't want to lose the flexibility to actually override
     it on a *per URL* basis.
     """
-    # settings.SYMBOL_FILE_PREFIX = 'myprfx'
-
-    requestsmock.head(
-        "https://s3.example.com/public/start/myprfx/xxx.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xxx.sym",
-        text="Page Not Found",
-        status_code=404,
-    )
-    requestsmock.head(
-        "https://s3.example.com/also-public/prrffxx/myprfx/xxx.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xxx.sym",
-        text="Page Not Found",
-        status_code=404,
-    )
-    requestsmock.head(
-        "https://s3.example.com/special/myprfx/xxx.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xxx.sym",
-        text="Page Not Found",
-        status_code=404,
-    )
 
     urls = (
-        "https://s3.example.com/public/start/?access=public",
+        "http://localstack:4566/publicbucket/start/",
         # No trailing / in the path part
-        "https://s3.example.com/also-public/prrffxx?access=public",
+        "http://localstack:4566/publicbucket/prrffxx",
         # No prefix!
-        "https://s3.example.com/special?access=public",
+        "http://localstack:4566/publicbucket",
     )
     downloader = SymbolDownloader(urls, file_prefix="myprfx")
     assert not downloader.has_symbol(
@@ -319,164 +97,15 @@ def test_public_default_file_prefix(requestsmock, settings):
     )
 
 
-def test_private_default_file_prefix(botomock, settings):
-    """See doc string in test_public_default_file_prefix"""
-    all_mock_calls = []
-
-    def mock_api_call(self, operation_name, api_params):
-        if operation_name == "ListObjectsV2":
-            # the has_symbol() was called
-            all_mock_calls.append(api_params["Prefix"])
-            # pretend it doesn't exist
-            return {}
-        elif operation_name == "GetObject":
-            # someone wants a stream
-            all_mock_calls.append(api_params["Key"])
-            parsed_response = {"Error": {"Code": "NoSuchKey", "Message": "Not found"}}
-            raise ClientError(parsed_response, operation_name)
-        else:
-            raise NotImplementedError(operation_name)
-
-    urls = (
-        # Private URL with prefix and trailing /
-        "https://s3.example.com/priv-bucket/borje/",
-        # No trailing /
-        "https://s3.example.com/also-priv-bucket/prrffxx",
-        # No prefix
-        "https://s3.example.com/some-bucket",
+def test_has_public_case_insensitive_debugid(s3_helper):
+    s3_helper.create_bucket("publicbucket")
+    s3_helper.upload_fileobj(
+        bucket_name="publicbucket",
+        key="v1/xul.pdb/44E4EC8C2F41492B9369D6B9A059577C2/xul.sym",
+        data=b"abc123",
     )
-    downloader = SymbolDownloader(urls, file_prefix="myprfx")
-    with botomock(mock_api_call):
-        assert not downloader.has_symbol(
-            "xxx.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xxx.sym"
-        )
-
-        assert len(all_mock_calls) == 3
-        assert all_mock_calls[0].startswith("borje/myprfx/xxx.pdb")
-        assert all_mock_calls[1].startswith("prrffxx/myprfx/xxx.pdb")
-        assert all_mock_calls[2].startswith("myprfx/xxx.pdb")
-
-
-def test_get_url_private_dotted_name(botomock):
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "ListObjectsV2"
-        if api_params["Prefix"].endswith("xxx.sym"):
-            # not found
-            return {}
-        return {"Contents": [{"Key": api_params["Prefix"]}]}
-
-    urls = ("https://s3.example.com/com.example.private/prefix/",)
-    downloader = SymbolDownloader(urls)
-    with botomock(mock_api_call):
-        url = downloader.get_symbol_url(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        assert (
-            "/com.example.private/prefix/v0/xul.pdb/"
-            "44E4EC8C2F41492B9369D6B9A059577C2/xul.sym?"
-        ) in url
-
-        url = downloader.get_symbol_url(
-            "xxx.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xxx.sym"
-        )
-        assert url is None
-
-        assert len(botomock.calls) == 2
-
-
-def test_multiple_urls_public_then_private(requestsmock, botomock):
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "ListObjectsV2"
-        if api_params["Prefix"].endswith("xxx.sym"):
-            # not found
-            return {}
-        # found
-        return {"Contents": [{"Key": api_params["Prefix"]}]}
-
-    requestsmock.head(
-        "https://s3.example.com/public/prefix/v0/xul.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xul.sym",
-        text="",
-    )
-    requestsmock.head(
-        "https://s3.example.com/public/prefix/v0/xxx.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xxx.sym",
-        text="Page Not Found",
-        status_code=404,
-    )
-
-    urls = (
-        "https://s3.example.com/public/prefix/?access=public",
-        "https://s3.example.com/private/prefix/",
-    )
-    downloader = SymbolDownloader(urls)
-    with botomock(mock_api_call):
-        assert downloader.has_symbol(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        assert not downloader.has_symbol(
-            "xxx.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xxx.sym"
-        )
-
-
-def test_multiple_urls_private_then_public(requestsmock, botomock):
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "ListObjectsV2"
-        if api_params["Prefix"].endswith("xxx.sym"):
-            # not found
-            return {}
-        # found
-        return {"Contents": [{"Key": api_params["Prefix"]}]}
-
-    requestsmock.head(
-        "https://s3.example.com/public/prefix/v0/xul.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xul.sym",
-        text="",
-    )
-    requestsmock.head(
-        "https://s3.example.com/public/prefix/v0/xxx.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xxx.sym",
-        text="Page Not Found",
-        status_code=404,
-    )
-
-    urls = (
-        "https://s3.example.com/private/prefix/",
-        "https://s3.example.com/public/prefix/?access=public",
-    )
-    downloader = SymbolDownloader(urls)
-    with botomock(mock_api_call):
-        assert downloader.has_symbol(
-            "xul.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xul.sym"
-        )
-        assert not downloader.has_symbol(
-            "xxx.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xxx.sym"
-        )
-
-
-def test_has_public_case_insensitive_debugid(requestsmock):
-    requestsmock.head(
-        "https://s3.example.com/public/prefix/v0/xul.pdb/"
-        "44E4EC8C2F41492B9369D6B9A059577C2/xul.sym",
-        text="",
-    )
-    urls = ("https://s3.example.com/public/prefix/?access=public",)
+    urls = ("http://localstack:4566/publicbucket/",)
     downloader = SymbolDownloader(urls)
     assert downloader.has_symbol(
         "xul.pdb", "44e4ec8c2f41492b9369d6b9a059577c2", "xul.sym"
     )
-
-
-def test_has_private_case_insensitive_debugid(botomock):
-    def mock_api_call(self, operation_name, api_params):
-        assert operation_name == "ListObjectsV2"
-        assert "44E4EC8C2F41492B9369D6B9A059577C2" in api_params["Prefix"]
-        # found
-        return {"Contents": [{"Key": api_params["Prefix"]}]}
-
-    urls = ("https://s3.example.com/private/prefix/",)
-    downloader = SymbolDownloader(urls)
-    with botomock(mock_api_call):
-        assert downloader.has_symbol(
-            "xul.pdb", "44e4ec8c2f41492b9369d6b9a059577c2", "xul.sym"
-        )

--- a/tecken/tests/test_views.py
+++ b/tecken/tests/test_views.py
@@ -139,8 +139,9 @@ def test_auth_debug(client):
     assert "Session cookies work!" in text
 
 
-@pytest.mark.django_db
-def test_heartbeat_no_warnings(client, settings):
+def test_heartbeat_no_warnings(client, db, s3_helper, settings):
+    s3_helper.create_bucket("publicbucket")
+
     def debug_function():
         from django.core import checks
 

--- a/tecken/upload/views.py
+++ b/tecken/upload/views.py
@@ -126,7 +126,7 @@ def get_bucket_info(user, try_symbols=None, preferred_bucket_name=None):
     if preferred_bucket_name:
         # If the user has indicated a preferred bucket name, check that they have
         # permission to use it.
-        for url, _ in get_possible_bucket_urls(user):
+        for url in get_upload_bucket_urls():
             if preferred_bucket_name in url:
                 return StorageBucket(url, try_symbols=try_symbols)
         raise NoPossibleBucketName(preferred_bucket_name)
@@ -134,25 +134,17 @@ def get_bucket_info(user, try_symbols=None, preferred_bucket_name=None):
     return StorageBucket(url, try_symbols=try_symbols)
 
 
-def get_possible_bucket_urls(user):
-    """Return list of possible buckets this user can upload to.
+def get_upload_bucket_urls():
+    """Return list of upload bucket urls.
 
-    If the user is not specified, then the user can upload to the public bucket.
+    :return: list of urls
 
-    :param user: a django user
-
-    :return: list of tuples of (url, "private"/"public")
     """
 
     # NOTE(willkg): This used to handle UPLOAD_URL_EXCEPTIONS, but we took that out. Now
     # it does nothing interesting. We should rework the structure of all this when we
     # rewrite the storage API.
-
-    urls = []
-
-    urls.append((settings.UPLOAD_DEFAULT_URL, "public"))
-
-    return urls
+    return [settings.UPLOAD_DEFAULT_URL]
 
 
 def _ignore_member_file(filename):


### PR DESCRIPTION
This is a big PR because it covers several tangled things:

1. removes all the `UPLOAD_URL_EXCEPTIONS` stuff which tied specific accounts to specific private buckets via configuration
2. removes all the private bucket support
3. reworks the tests removing the bulk of the mocking and instead relying on manipulating the localstack fake s3 service the tests run with (bug 1834626)
