### PR TITLE
Fix timeout values for systemtests scripts

### DIFF
--- a/systemtests/bin/make-symbols-zip.py
+++ b/systemtests/bin/make-symbols-zip.py
@@ -20,7 +20,7 @@ import requests
 
 
 # Number of seconds to wait for a response from server
-CONNECTION_TIMEOUT = 60
+CONNECTION_TIMEOUT = 600
 
 SYMBOLS_URL = "https://symbols.mozilla.org/"
 

--- a/systemtests/bin/upload-symbols-by-download.py
+++ b/systemtests/bin/upload-symbols-by-download.py
@@ -23,7 +23,7 @@ MAX_ATTEMPTS = 5
 # Number of seconds to wait for a response from server; this is 3 minutes
 # because the server has to do all the work and requests needs to wait for that
 # to happen
-CONNECTION_TIMEOUT = 180
+CONNECTION_TIMEOUT = 600
 
 # Number of seconds to sleep between tries to account for rate limiting
 SLEEP_TIMEOUT = 10

--- a/systemtests/bin/upload-symbols.py
+++ b/systemtests/bin/upload-symbols.py
@@ -22,7 +22,7 @@ import requests
 MAX_ATTEMPTS = 5
 
 # Number of seconds to wait for a response from server
-CONNECTION_TIMEOUT = 60
+CONNECTION_TIMEOUT = 600
 
 # Number of seconds to sleep between tries to account for rate limiting
 SLEEP_TIMEOUT = 15


### PR DESCRIPTION
Some symbols zip files are big, so the timeout values should match the timeout values we're using.