### PR TITLE
bug 1843356: improve download-sym-files.py script

### DIFF
--- a/systemtests/bin/download-sym-files.py
+++ b/systemtests/bin/download-sym-files.py
@@ -75,6 +75,12 @@ def download_sym_files(base_url, csv_file):
             headers = {"User-Agent": "tecken-systemtests"}
             resp = requests.get(url, headers=headers, timeout=60)
 
+            for item in resp.history:
+                if item.status_code in (301, 302):
+                    click.echo(f">>> redirect: {item.url}")
+            click.echo(f">>> final: {resp.url}")
+            click.echo(f">>> status code: {resp.status_code}")
+
             # Compare status code with expected status code
             if resp.status_code != int(parts[1]):
                 click.echo(

--- a/systemtests/bin/download-sym-files.py
+++ b/systemtests/bin/download-sym-files.py
@@ -73,7 +73,7 @@ def download_sym_files(base_url, csv_file):
 
             # Download the file
             headers = {"User-Agent": "tecken-systemtests"}
-            resp = requests.get(url, headers=headers)
+            resp = requests.get(url, headers=headers, timeout=60)
 
             # Compare status code with expected status code
             if resp.status_code != int(parts[1]):


### PR DESCRIPTION
This fixes `download-sym-file.py` so it logs redirects and the final status code. This makes it clearer when the download API that's being tested is returning the correct values.

This also fixes the timeout for `download-sym-files.py` script.

Previous unhelpful output:

```
Working on https://symbols.stage.mozaws.net/cryptsp.pdb/410A559EA9162634084E228ADDEE69A91/cryptsp.sym ...
Elapsed time: timing download_time 2.33s
```

New much more informative output:

```
Working on https://symbols.stage.mozaws.net/cryptsp.pdb/410A559EA9162634084E228ADDEE69A91/cryptsp.sym ...
>>> redirect: https://symbols.stage.mozaws.net/cryptsp.pdb/410A559EA9162634084E228ADDEE69A91/cryptsp.sym
>>> final: https://s3.us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/cryptsp.pdb/410A559EA9162634084E228ADDEE69A91/cryptsp.sym
>>> status code: 200
Elapsed time: timing download_time 0.52s
```

And now we [1] know that we tried to download a symbol file from stage, stage didn't have it in the stage bucket, and stage redirected to the prod bucket.

[1] "We" generally don't know, but those of us who know the bucket names will.