### PR TITLE
bug 1847937: fix upload file view for files in incomplete uploads

### DIFF
--- a/frontend/src/Common.js
+++ b/frontend/src/Common.js
@@ -224,8 +224,16 @@ export const DisplayFilesSummary = (files, incomplete, skipped, ignored) => {
   const sentences = [];
   sentences.push(pluralize(files, "file uploaded", "files uploaded"));
   if (incomplete) {
+    // FIXME(willkg): If the upload is interrupted during processing, Tecken
+    // only has records for files it started processing. All the files it
+    // hadn't gotten to aren't accounted for in either the uploaded or
+    // incomplete lists.
     sentences.push(
-      pluralize(incomplete, "file incomplete", "files incomplete")
+      pluralize(
+        incomplete,
+        "file incomplete (or more)",
+        "files incomplete (or more)"
+      )
     );
   }
   sentences.push(`${skipped} skipped`);
@@ -357,10 +365,7 @@ export const ShowUploadMetadata = ({ upload }) => {
             {upload.completed_at ? (
               <DisplayDate date={upload.completed_at} />
             ) : (
-              <i>
-                Incomplete!{" "}
-                <DisplayIncompleteRatio files={upload.file_uploads} />
-              </i>
+              <i>Incomplete!</i>
             )}
             {upload.completed_at ? (
               <small>
@@ -378,14 +383,6 @@ export const ShowUploadMetadata = ({ upload }) => {
       </tbody>
     </table>
   );
-};
-
-const DisplayIncompleteRatio = ({ files }) => {
-  // Return a string like "56 of 103 (54%)" to mean that 56 of 103 files are complete.
-  const all = files.length;
-  const complete = files.filter((file) => !!file.completed_at).length;
-  const percentage = (100 * complete) / all;
-  return `${complete} of ${all} (${Math.trunc(percentage)}%)`;
 };
 
 export const ShowFileMetadata = ({ file }) => (


### PR DESCRIPTION
If an upload is interrupted, Tecken doesn't end up with a correct count of the number of files in the upload. It only knows about the files it has processed so far or was in the process of processing. This fixes some language in the UI around that.

If an upload is interrupted, when you go to look at an upload file view for a file in the upload, it displays some stats about the upload including a `DisplayIncompleteRatio` section which required data that wasn't in the API response. Because Tecken doesn't know how many files were in the upload, I decided to just nix the `DisplayIncompleteRatio` section altogether because the information it was trying to render wasn't meaningful.