### PR TITLE
Add --no-deps to pip install for image building

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,7 @@ COPY requirements.txt /tmp/
 WORKDIR /tmp
 
 RUN pip install -U 'pip>=20' && \
-    pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir --no-deps -r requirements.txt && \
     pip check --disable-pip-version-check
 
 COPY . /app


### PR DESCRIPTION
This adds --no-deps to the pip install flags for building the tecken app image. This prevents pip from installing dependencies not explicitly listed in the requirements.txt file.