### PR TITLE
bug 1851809: implement createtoken command

### DIFF
--- a/tecken/tests/test_tokens.py
+++ b/tecken/tests/test_tokens.py
@@ -3,15 +3,48 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import datetime
+from io import StringIO
 
 import pytest
 
-from django.utils import timezone
 from django.contrib.auth.models import User, Permission, Group
 from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.urls import reverse
+from django.utils import timezone
 
-from tecken.tokens.models import Token
+from tecken.tokens.models import make_key, Token
+
+
+@pytest.mark.django_db
+def test_createtoken_no_key_command():
+    assert Token.objects.all().count() == 0
+    stdout = StringIO()
+    call_command("superuser", "foo@example.com", stdout=stdout)
+    stdout = StringIO()
+    call_command("createtoken", "foo@example.com", stdout=stdout)
+
+    assert Token.objects.all().count() == 1
+
+
+@pytest.mark.django_db
+def test_createtoken_with_key_command():
+    assert Token.objects.all().count() == 0
+    stdout = StringIO()
+    call_command("superuser", "foo@example.com", stdout=stdout)
+    stdout = StringIO()
+    token_key = make_key()
+    call_command("createtoken", "foo@example.com", token_key, stdout=stdout)
+
+    assert Token.objects.filter(key=token_key).count() == 1
+
+
+@pytest.mark.django_db
+def test_createtoken_command_no_user():
+    with pytest.raises(CommandError):
+        stdout = StringIO()
+        call_command("createtoken", "foo@example.com", stdout=stdout)
 
 
 @pytest.mark.django_db

--- a/tecken/tests/test_useradmin.py
+++ b/tecken/tests/test_useradmin.py
@@ -6,8 +6,8 @@ from io import StringIO
 
 import pytest
 
-from django.core.management.base import CommandError
 from django.contrib.auth.models import User
+from django.core.management.base import CommandError
 from django.core.management import call_command
 from django.urls import reverse
 

--- a/tecken/tokens/management/__init__.py
+++ b/tecken/tokens/management/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tecken/tokens/management/commands/__init__.py
+++ b/tecken/tokens/management/commands/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tecken/tokens/management/commands/createtoken.py
+++ b/tecken/tokens/management/commands/createtoken.py
@@ -12,15 +12,11 @@ class Command(BaseCommand):
     help = "Create an API token."
 
     def add_arguments(self, parser):
-        parser.add_argument("email", default=None, nargs="?")
+        parser.add_argument("email")
         parser.add_argument("token_key", default=None, nargs="?")
 
     def handle(self, *args, **options):
         email = options["email"]
-        if not email:
-            email = input("Email: ").strip()
-        if " " in email or email.count("@") != 1:
-            raise CommandError(f"Invalid email {email!r}")
 
         token_key = options["token_key"]
         if not token_key:

--- a/tecken/tokens/management/commands/createtoken.py
+++ b/tecken/tokens/management/commands/createtoken.py
@@ -1,0 +1,48 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.contrib.auth.models import Permission, User
+from django.core.management.base import BaseCommand, CommandError
+
+from tecken.tokens.models import make_key, Token
+
+
+class Command(BaseCommand):
+    help = "Create an API token."
+
+    def add_arguments(self, parser):
+        parser.add_argument("email", default=None, nargs="?")
+        parser.add_argument("token_key", default=None, nargs="?")
+
+    def handle(self, *args, **options):
+        email = options["email"]
+        if not email:
+            email = input("Email: ").strip()
+        if " " in email or email.count("@") != 1:
+            raise CommandError(f"Invalid email {email!r}")
+
+        token_key = options["token_key"]
+        if not token_key:
+            token_key = make_key()
+
+        try:
+            user = User.objects.get(email__iexact=email)
+        except User.DoesNotExist:
+            raise CommandError(f"Account {email!r} does not exist.") from None
+
+        if Token.objects.filter(user=user, key=token_key).exists():
+            raise CommandError(f"Token with key {token_key!r} already exists")
+
+        permissions = [
+            Permission.objects.get(codename="upload_symbols"),
+            Permission.objects.get(codename="view_all_uploads"),
+        ]
+        self.stdout.write(self.style.SUCCESS(f"{token_key} created"))
+        token = Token.objects.create(
+            user=user,
+            key=token_key,
+        )
+        for permission in permissions:
+            token.permissions.add(permission)
+            self.stdout.write(self.style.SUCCESS(f"{permission} added"))


### PR DESCRIPTION
This will aid development since it makes it possible to create API tokens from the command line.

```
$ docker compose run --rm web bash python manage.py createtoken EMAIL
```

```
$ docker compose run --rm web bash python manage.py createtoken EMAIL TOKENKEY
```