### PR TITLE
bug 1851909: switch to django-admin-cursor-paginator

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ click==8.1.6
 datadog==0.46.0
 dj-database-url==2.0.0
 django-cache-memoize==0.1.10
+django-admin-cursor-paginator==0.1.4
 django-redis==5.3.0
 dockerflow==2022.8.0
 encore==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -181,8 +181,12 @@ django==3.2.21 \
     # via
     #   -r requirements.in
     #   dj-database-url
+    #   django-admin-cursor-paginator
     #   django-redis
     #   mozilla-django-oidc
+django-admin-cursor-paginator==0.1.4 \
+    --hash=sha256:133a79a30c38f9a69fc51d6131b0c7e459043a4d3620fac17194badb97ee5df4
+    # via -r requirements.in
 django-cache-memoize==0.1.10 \
     --hash=sha256:63e8faa245a41c0dbad843807e9f21a6e59eba8e6e50df310fdf6485a6749843 \
     --hash=sha256:676299313079cde9242ae84db0160e80b1d44e8dd6bc9b1f4f1247e11b30c9e0

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -204,6 +204,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.contrib.messages",
     "django.contrib.admin.apps.SimpleAdminConfig",
+    "admin_cursor_paginator",
     # Project specific apps
     "tecken.apps.TeckenAppConfig",
     "tecken.base",

--- a/tecken/upload/admin.py
+++ b/tecken/upload/admin.py
@@ -3,12 +3,13 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from django.contrib import admin
+from admin_cursor_paginator import CursorPaginatorAdmin
 
 from tecken.upload.models import Upload, FileUpload
 
 
 @admin.register(Upload)
-class UploadAdmin(admin.ModelAdmin):
+class UploadAdmin(CursorPaginatorAdmin):
     date_hierarchy = "created_at"
     search_fields = ["user.email", "bucket_name"]
     list_display = [
@@ -31,7 +32,7 @@ class UploadAdmin(admin.ModelAdmin):
 
 
 @admin.register(FileUpload)
-class FileUploadAdmin(admin.ModelAdmin):
+class FileUploadAdmin(CursorPaginatorAdmin):
     readonly_fields = [
         "upload",
     ]


### PR DESCRIPTION
This switches pagination in the Django admin for the Upload and FileUpload models to django-admin-cursor-paginator which doesn't do limit/offset stuff which is rough when the tables are big.