### PR TITLE
bug 1746940: rework download API to support /code_file/code_id/sym_file

### DIFF
--- a/docs/download.rst
+++ b/docs/download.rst
@@ -17,8 +17,7 @@ to maintain lists of buckets.
 
 For example, at the time of this writing doing a ``GET`` for
 :base_url:`/firefox.pdb/448794C699914DB8A8F9B9F88B98D7412/firefox.sym` will
-return a ``302 Found`` redirect to
-``https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/firefox.pdb/448794C699914DB8A8F9B9F88B98D7412/firefox.sym``.
+return a ``302 Found`` redirect to the file in storage.
 
 
 .. _download-try-builds:
@@ -41,8 +40,8 @@ For example:
     $ curl --user-agent "example/1.0" https://symbols.mozilla.org/try/tried.pdb/HEX/tried.sym
     ...302 Found...
 
-If you specify that you're requesting a try build, Tecken will look at
-all the S3 bucket locations as well as all the try locations in those
+If you specify that you're requesting a Try build, Tecken will look at
+all the S3 bucket locations as well as all the Try locations in those
 S3 buckets.
 
 Symbols from Try builds is always tried last! So if there's a known symbol
@@ -68,18 +67,43 @@ Downloading API
 
    :query try: use ``try=1`` to download Try symbols
 
-   :query _refresh: use ``_refresh=1`` to force Tecken to look for the symbol file
-       in the AWS S3 buckets and update the cache
-
-   :query code_id: the ``code_id`` from the module if any
-
-   :query code_file: the ``code_file`` from the module if any
+   :query _refresh: use ``_refresh=1`` to force Tecken to update cache
 
    :statuscode 200: symbol file exists
    :statuscode 404: symbol file does not exist
    :statuscode 500: sleep for a bit and retry; if retrying doesn't work, then please
        file a bug report
    :statuscode 503: sleep for a bit and retry
+
+
+.. http:head:: /try/<DEBUG_FILENAME>/<DEBUG_ID>/<SYMBOL_FILE>
+
+   Same as ``HEAD /<DEBUG_FILENAME>/<DEBUG_ID>/<SYMBOL_FILE>``, but for try symbols.
+
+
+.. http:head:: /<CODE_FILE>/<CODE_ID>/<SYMBOL_FILE>
+
+   Looks for an upload record for a symbol file with the specified
+   ``code_file`` and ``code_id``. If it has one, then this returns an HTTP 302
+   to the download API using the ``debug_filename`` and ``debug_id``.
+
+   :reqheader Debug: if ``true``, includes a ``Debug-Time`` header in the response.
+
+      If ``Debug-Time`` is `0.0``: symbol file ends in an unsupported extension
+
+   :reqheader User-Agent: please provide a unique user agent to make it easier for us
+       to help you debug problems
+
+   :query try: use ``try=1`` to download Try symbols
+
+   :query _refresh: use ``_refresh=1`` to force Tecken to update cache
+
+   :statuscode 302: redirect to download API url using ``debug_filename`` and ``debug_id``
+   :statuscode 404: symbol file does not exist
+   :statuscode 500: sleep for a bit and retry; if retrying doesn't work, then please
+       file a bug report
+   :statuscode 503: sleep for a bit and retry
+
 
 .. http:get:: /<DEBUG_FILENAME>/<DEBUG_ID>/<SYMBOL_FILE>
 
@@ -94,12 +118,7 @@ Downloading API
 
    :query try: use ``try=1`` to download Try symbols
 
-   :query _refresh: use ``_refresh=1`` to force Tecken to look for the symbol file
-       in the AWS S3 buckets and update the cache
-
-   :query code_id: the ``code_id`` from the module if any
-
-   :query code_file: the ``code_file`` from the module if any
+   :query _refresh: use ``_refresh=1`` to force Tecken to update cache
 
    :statuscode 302: symbol file was found and the final url was returned as a redirect
    :statuscode 400: requested symbol file has bad characters
@@ -107,11 +126,36 @@ Downloading API
    :statuscode 429: sleep for a bit and retry
    :statuscode 500: sleep for a bit and retry; if retrying doesn't work, then please
        file a bug report
-   :statuscode 503: sleep for a bit and retry
+   :statuscode 503: sleep for a bit and retry; if retrying doesn't work, then please
+       file a bug report
 
-.. http:head:: /try/<DEBUG_FILENAME>/<DEBUG_ID>/<SYMBOL_FILE>
 
-   Same as ``HEAD /<DEBUG_FILENAME>/<DEBUG_ID>/<SYMBOL_FILE>``, but for try symbols.
+.. http:get:: /<CODE_FILE>/<CODE_ID>/<SYMBOL_FILE>
+
+   Looks for an upload record for a symbol file with the specified
+   ``code_file`` and ``code_id``. If it has one, then this returns an HTTP 302
+   to the download API using the ``debug_filename`` and ``debug_id``.
+
+   :reqheader Debug: if ``true``, includes a ``Debug-Time`` header in the response.
+
+      If ``Debug-Time`` is `0.0``: symbol file ends in an unsupported extension
+
+   :reqheader User-Agent: please provide a unique user agent to make it easier for us
+       to help you debug problems
+
+   :query try: use ``try=1`` to download Try symbols
+
+   :query _refresh: use ``_refresh=1`` to force Tecken to update cache
+
+   :statuscode 302: redirect to download API url using ``debug_filename`` and ``debug_id``
+   :statuscode 400: requested symbol file has bad characters
+   :statuscode 404: symbol file was not found
+   :statuscode 429: sleep for a bit and retry
+   :statuscode 500: sleep for a bit and retry; if retrying doesn't work, then please
+       file a bug report
+   :statuscode 503: sleep for a bit and retry; if retrying doesn't work, then please
+       file a bug report
+
 
 .. http:get:: /try/<DEBUG_FILENAME>/<DEBUG_ID>/<SYMBOL_FILE>
 

--- a/tecken/download/urls.py
+++ b/tecken/download/urls.py
@@ -26,12 +26,12 @@ app_name = "download"
 
 urlpatterns = [
     path(
-        "try/<str:symbol>/<hex:debugid>/<str:filename>",
+        "try/<str:debugfilename>/<hex:debugid>/<str:filename>",
         views.download_symbol_try,
         name="download_symbol_try",
     ),
     path(
-        "<str:symbol>/<hex:debugid>/<str:filename>",
+        "<str:debugfilename>/<hex:debugid>/<str:filename>",
         views.download_symbol,
         name="download_symbol",
     ),

--- a/tecken/download/views.py
+++ b/tecken/download/views.py
@@ -8,6 +8,7 @@ import markus
 
 from django import http
 from django.conf import settings
+from django.urls import reverse
 
 from tecken.base.decorators import (
     set_request_debug,
@@ -36,10 +37,13 @@ try_downloader = SymbolDownloader(
 )
 
 
-def _ignore_symbol(symbol, debugid, filename):
+def _ignore_symbol(debugfilename, debugid, filename):
     # The MS debugger will always try to look up these files. We
     # never have them in our symbol stores. So it can be safely ignored.
     if filename == "file.ptr":
+        return True
+
+    if debugid == BOGUS_DEBUG_ID:
         return True
 
     if not filename.endswith(tuple(settings.DOWNLOAD_FILE_EXTENSIONS_ALLOWED)):
@@ -49,51 +53,57 @@ def _ignore_symbol(symbol, debugid, filename):
     return False
 
 
-def download_symbol_try(request, symbol, debugid, filename):
-    return download_symbol(request, symbol, debugid, filename, try_symbols=True)
+def download_symbol_try(request, debugfilename, debugid, filename):
+    return download_symbol(request, debugfilename, debugid, filename, try_symbols=True)
 
 
-def lookup_debug_id_by_code_id(code_file, code_id):
-    """Returns the debug id for a FileUpload for code_file/code_id
+def lookup_by_code_file_code_id(code_file, code_id):
+    """Returns the debug_filename/debug_id for given code_file/code_id
 
     This is only useful for Windows module sym files. Other platforms don't have valid
-    code_file / code_id.
+    code_file/code_id values.
 
     :arg code_file: the code_file to look up with; ex. "xul.dll"
     :arg code_id: the code_id to look up with
 
-    :returns: None (no record with that combination) or the debug_id
+    :returns: dict with (debug_filename, debug_id) keys or None if there's no such
+        record
 
     """
+    logger.debug(f"lookup by code_file={code_file!r} code_id={code_id!r}")
     file_upload = (
         FileUpload.objects.filter(code_file=code_file, code_id=code_id)
         .order_by("created_at")
         .last()
     )
+
     if file_upload:
-        return file_upload.debug_id
+        return {
+            "debug_filename": file_upload.debug_filename,
+            "debug_id": file_upload.debug_id,
+        }
 
 
 @metrics.timer_decorator("download_symbol")
 @set_request_debug
 @api_require_http_methods(["GET", "HEAD"])
 @set_cors_headers(origin="*", methods="GET")
-def download_symbol(request, symbol, debugid, filename, try_symbols=False):
+def download_symbol(request, debugfilename, debugid, filename, try_symbols=False):
     # First there's an opportunity to do some basic pattern matching on the symbol,
     # debugid, and filename parameters to determine if we can, with confidence, simply
     # ignore it.
     #
     # Not only can we avoid doing a SymbolDownloader call, we also don't have to bother
     # logging that it could not be found.
-    if _ignore_symbol(symbol, debugid, filename):
-        logger.debug(f"Ignoring symbol {symbol}/{debugid}/{filename}")
+    if _ignore_symbol(debugfilename, debugid, filename):
+        logger.debug(f"Ignoring symbol {debugfilename}/{debugid}/{filename}")
         response = http.HttpResponseNotFound("Symbol Not Found (and ignored)")
         if request._request_debug:
             response["Debug-Time"] = 0
         return response
 
-    if invalid_key_name_characters(symbol + filename):
-        logger.debug(f"Invalid character {symbol!r}/{debugid}/{filename!r}")
+    if invalid_key_name_characters(debugfilename + filename):
+        logger.debug(f"Invalid character {debugfilename!r}/{debugid}/{filename!r}")
         response = http.HttpResponseBadRequest(
             "Symbol name lookup contains invalid characters and will never be found."
         )
@@ -102,30 +112,17 @@ def download_symbol(request, symbol, debugid, filename, try_symbols=False):
         return response
 
     refresh_cache = "_refresh" in request.GET
+    if refresh_cache:
+        logger.debug("refreshing cache")
 
     if "try" in request.GET or try_symbols:
         downloader = try_downloader
     else:
         downloader = normal_downloader
 
-    if debugid == BOGUS_DEBUG_ID:
-        code_file = request.GET.get("code_file", None)
-        code_id = request.GET.get("code_id", None)
-        if code_file and code_id:
-            new_debugid = lookup_debug_id_by_code_id(
-                code_file=code_file, code_id=code_id
-            )
-            if new_debugid:
-                # We swap out the bogus debug id with the new debug id. We do it with a
-                # string replacement because it's easy.
-                new_url = request.get_full_path()
-                new_url = new_url.replace(BOGUS_DEBUG_ID, new_debugid)
-                metrics.incr("download_symbol_code_id_lookup")
-                return http.HttpResponseRedirect(new_url)
-
     if request.method == "HEAD":
         if downloader.has_symbol(
-            symbol, debugid, filename, refresh_cache=refresh_cache
+            debugfilename, debugid, filename, refresh_cache=refresh_cache
         ):
             response = http.HttpResponse()
             if request._request_debug:
@@ -134,7 +131,7 @@ def download_symbol(request, symbol, debugid, filename, try_symbols=False):
 
     else:
         url = downloader.get_symbol_url(
-            symbol, debugid, filename, refresh_cache=refresh_cache
+            debugfilename, debugid, filename, refresh_cache=refresh_cache
         )
         if url:
             # If doing local development, with Docker, you're most likely running
@@ -153,6 +150,20 @@ def download_symbol(request, symbol, debugid, filename, try_symbols=False):
             if request._request_debug:
                 response["Debug-Time"] = downloader.time_took
             return response
+
+    # If we can't find the file, maybe it's in the form
+    # /{code_file}/{code_id}/{sym_file}, so see if we have a record with that
+    # code_file/code_id combination
+    ret = lookup_by_code_file_code_id(code_file=debugfilename, code_id=debugid)
+    if ret:
+        new_url = reverse(
+            "download:download_symbol",
+            args=(ret["debug_filename"], ret["debug_id"], filename),
+        )
+        if request.GET:
+            new_url = f"{new_url}?{request.GET.urlencode()}"
+        metrics.incr("download_symbol_code_id_lookup")
+        return http.HttpResponseRedirect(new_url)
 
     response = http.HttpResponseNotFound("Symbol Not Found")
     if request._request_debug:

--- a/tecken/download/views.py
+++ b/tecken/download/views.py
@@ -112,8 +112,6 @@ def download_symbol(request, debugfilename, debugid, filename, try_symbols=False
         return response
 
     refresh_cache = "_refresh" in request.GET
-    if refresh_cache:
-        logger.debug("refreshing cache")
 
     if "try" in request.GET or try_symbols:
         downloader = try_downloader

--- a/tecken/tests/test_download.py
+++ b/tecken/tests/test_download.py
@@ -383,7 +383,10 @@ def test_get_code_id_lookup(client, db, s3_helper):
     assert response.status_code == 302
     parsed = urlparse(response["location"])
     assert parsed.path == f"/{debug_filename}/{debug_id}/{sym_file}"
-    assert parsed.query == f"code_file={code_file}&code_id={code_id}"
+    assert parsed.query in [
+        f"code_file={code_file}&code_id={code_id}",
+        f"code_id={code_id}&code_file={code_file}",
+    ]
 
 
 def test_head_code_id_lookup(client, db, s3_helper):
@@ -442,4 +445,7 @@ def test_head_code_id_lookup(client, db, s3_helper):
     assert response.status_code == 302
     parsed = urlparse(response["location"])
     assert parsed.path == f"/{debug_filename}/{debug_id}/{sym_file}"
-    assert parsed.query == f"code_file={code_file}&code_id={code_id}"
+    assert parsed.query in [
+        f"code_file={code_file}&code_id={code_id}",
+        f"code_id={code_id}&code_file={code_file}",
+    ]


### PR DESCRIPTION
This reworks the download API to support `/code_file/code_id/sym_file` urls. If it sees this, it'll look up `code_file` / `code_id` in the fileupload records. If it finds one, it'll return an HTTP 302 with the correct `debug_filename` and `debug_id`.

This works for both HEAD and GET requests.

This updates the download API documentation as well.