### PR TITLE
bug 1774217: add support for token comments

### DIFF
--- a/docs/upload.rst
+++ b/docs/upload.rst
@@ -223,6 +223,20 @@ or "Upload Try Symbols" permission.
 
 The auth token is sent as an ``Auth-Token`` HTTP header in the HTTP POST.
 
+.. Note::
+
+   Auth tokens support labels to make it easier to know which auth token has
+   which permissions. A `-` and anything after that in the auth token is
+   considered a label and ignored.
+
+   For example, if you had an auth token for "Upload Try Symbols"::
+
+      E468C3D4BBDA43DEBC0B856983895835
+
+   you could use::
+
+      E468C3D4BBDA43DEBC0B856983895835-uploadtry-20230913
+
 
 Testing symbol uploads with our stage environment
 =================================================

--- a/frontend/src/Tokens.js
+++ b/frontend/src/Tokens.js
@@ -330,11 +330,20 @@ class CreateTokenForm extends PureComponent {
         </div>
 
         {hasBothUploadPermissions ? (
-          <p>
-            <b>Note!</b> An API Token can not contain <i>both</i> the{" "}
-            <code>Upload Symbols Files</code> <i>and</i>
-            <code>Upload Try Symbols Files</code>.
-          </p>
+          <>
+            <p>
+              You can append a <code>-</code> and a label to your API tokens.
+              Anything including and after the <code>-</code> is ignored. For
+              example, if you had a token with "Upload Try Symbols Files"
+              permissions, you could append a <code>-uploadtry</code> to help
+              differentiate it from other tokens with different permissions.
+            </p>
+            <p>
+              <b>Note</b>: An API Token cannot contain <i>both</i> the{" "}
+              <code>Upload Symbols Files</code> <i>and</i>
+              <code>Upload Try Symbols Files</code>.
+            </p>
+          </>
         ) : null}
       </form>
     );

--- a/tecken/tests/test_tokens.py
+++ b/tecken/tests/test_tokens.py
@@ -57,8 +57,18 @@ def test_client_homepage_with_valid_token(client):
     user = User.objects.create(username="peterbe", email="peterbe@example.com")
     assert not user.last_login
     token = Token.objects.create(user=user)
+    token_key = token.key
 
-    response = client.get(url, HTTP_AUTH_TOKEN=token.key)
+    response = client.get(url, HTTP_AUTH_TOKEN=token_key)
+    assert response.status_code == 200
+    assert "sign_in_url" not in response.json()["user"]
+    assert response.json()["user"]["email"] == user.email
+    user.refresh_from_db()
+    assert user.last_login
+
+    # Test with token comment
+    token_key = f"{token_key}-testtoken"
+    response = client.get(url, HTTP_AUTH_TOKEN=token_key)
     assert response.status_code == 200
     assert "sign_in_url" not in response.json()["user"]
     assert response.json()["user"]["email"] == user.email

--- a/tecken/tokens/middleware.py
+++ b/tecken/tokens/middleware.py
@@ -61,6 +61,11 @@ class APITokenAuthenticationMiddleware:
         if not key:
             return
 
+        # Auth tokens allow for a "comment" which is anything after the first "-";
+        # peel it off and ignore it
+        if "-" in key:
+            key = key.split("-", 1)[0]
+
         try:
             token = Token.objects.select_related("user").get(key=key)
             if token.is_expired:


### PR DESCRIPTION
This adds support for appending a "-" and some text as a comment to a token. If you have multiple tokens with different permissions, this makes it easier to keep them straight.

For example, if I had an API token with "upload try symbols" permission, I could comment it like this:

```
E468C3D4BBDA43DEBC0B856983895835-uploadtry
```

