### PR TITLE
bug 1854206: fix url for try symbols

### DIFF
--- a/tecken/api/views.py
+++ b/tecken/api/views.py
@@ -677,11 +677,12 @@ def syminfo(request, some_file, some_id):
         if sym_file.endswith(".pdb"):
             sym_file = sym_file[:-4] + ".sym"
 
+        view_name = "download:download_symbol"
+        if ret["key"].startswith("try"):
+            view_name = "download:download_symbol_try"
+
         new_url = request.build_absolute_uri(
-            reverse(
-                "download:download_symbol",
-                args=(ret["debug_filename"], ret["debug_id"], sym_file),
-            )
+            reverse(view_name, args=(ret["debug_filename"], ret["debug_id"], sym_file))
         )
 
         return http.JsonResponse(

--- a/tecken/upload/models.py
+++ b/tecken/upload/models.py
@@ -100,12 +100,15 @@ class FileUploadManager(models.Manager):
                 | (models.Q(code_file=some_file) & models.Q(code_id=some_id))
             )
             .order_by()
-            .values("debug_filename", "debug_id", "code_file", "code_id", "generator")
+            .values(
+                "key", "debug_filename", "debug_id", "code_file", "code_id", "generator"
+            )
             .last()
         )
 
         if file_upload:
             return {
+                "key": file_upload["key"],
                 "debug_filename": file_upload["debug_filename"],
                 "debug_id": file_upload["debug_id"],
                 "code_file": file_upload["code_file"],


### PR DESCRIPTION
This fixes the url value in the syminfo API for try symbols. Now it points to the right place.