### PR TITLE
bug 1851909: remove unneeded upload_id method

### DIFF
--- a/tecken/upload/admin.py
+++ b/tecken/upload/admin.py
@@ -41,8 +41,3 @@ class FileUploadAdmin(CursorPaginatorAdmin):
     list_display = ["id", "upload_id", "bucket_name", "key", "size", "created_at"]
 
     view_on_site = True
-
-    def upload_id(self, obj):
-        if obj.upload:
-            return obj.upload.id
-        return -1


### PR DESCRIPTION
upload_id already works and we don't need the additional upload_id method which forces the Django admin to additionally pull each upload record one-by-one.