### PR TITLE
bug 1855483: add cleanup.sh script

### DIFF
--- a/bin/build_frontend.sh
+++ b/bin/build_frontend.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -eo pipefail
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,6 +8,8 @@ set -eo pipefail
 
 # NOTE(willkg): Since this is in the image at /app/frontend/build, it gets
 # stomped on when you mount your repo directory as /app.
+
+set -eo pipefail
 
 # We prefer to not leave any JavaScript as inline no matter how small.
 export INLINE_RUNTIME_CHUNK=false

--- a/bin/cleanup.sh
+++ b/bin/cleanup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Usage: bin/cleanup.sh
+#
+# Runs Django commands to clean up application state.
+
+set -eo pipefail
+
+# Remove stale contenttypes
+echo ">>> running remove_stale_contenttypes"
+time python manage.py remove_stale_contenttypes
+
+# Clear expired sessions
+echo ""
+echo ">>> running clearsessions"
+time python manage.py clearsessions
+
+# Clear expired upload and fileupload records
+echo ""
+echo ">>> running clearuploads"
+time python manage.py clearuploads

--- a/tecken/tests/test_upload.py
+++ b/tecken/tests/test_upload.py
@@ -823,8 +823,8 @@ def test_UploadByDownloadForm_redirection_exhaustion(requestsmock, settings):
     assert "Too many redirects" in validation_errors[0].message
 
 
-def test_cleanse_upload_records(db, fakeuser):
-    """cleanse_upload deletes appropriate records"""
+def test_clearuploads_records(db, fakeuser):
+    """clearuploads deletes appropriate records"""
     today = timezone.now()
     try_cutoff = today - datetime.timedelta(days=30)
     reg_cutoff = today - datetime.timedelta(days=365 * 2)
@@ -860,7 +860,7 @@ def test_cleanse_upload_records(db, fakeuser):
         FileUpload.objects.create(upload=upload, key="try-2-2.sym", size=100)
 
     stdout = StringIO()
-    call_command("cleanse_upload", dry_run=False, stdout=stdout)
+    call_command("clearuploads", dry_run=False, stdout=stdout)
 
     assert "DRY RUN" not in stdout.getvalue()
 
@@ -873,8 +873,8 @@ def test_cleanse_upload_records(db, fakeuser):
     assert file_keys == ["reg-1-1.sym", "reg-1-2.sym", "try-1-1.sym", "try-1-2.sym"]
 
 
-def test_cleanse_upload_records_dry_run(db, fakeuser):
-    """cleanse_upload dry_run doesn't delete records"""
+def test_clearuploads_records_dry_run(db, fakeuser):
+    """clearuploads dry_run doesn't delete records"""
     today = timezone.now()
     try_cutoff = today - datetime.timedelta(days=30)
     reg_cutoff = today - datetime.timedelta(days=365 * 2)
@@ -910,7 +910,7 @@ def test_cleanse_upload_records_dry_run(db, fakeuser):
         FileUpload.objects.create(upload=upload, key="try-2-2.sym", size=100)
 
     stdout = StringIO()
-    call_command("cleanse_upload", dry_run=True, stdout=stdout)
+    call_command("clearuploads", dry_run=True, stdout=stdout)
 
     assert "DRY RUN" in stdout.getvalue()
 

--- a/tecken/upload/management/commands/clearuploads.py
+++ b/tecken/upload/management/commands/clearuploads.py
@@ -20,14 +20,14 @@ REGULAR_RECORD_AGE_CUTOFF = 365 * 2
 
 
 class Command(BaseCommand):
-    """Periodic maintenance task for deleting old upload records.
+    """Clean out expired upload and fileupload records.
 
-    The S3 buckets expire old objects, so we should expire the related records
-    in these tables as well.
+    The S3 buckets expire old objects, so we should expire the related records in these
+    tables as well.
 
     """
 
-    help = "Cleanse the upload_upload and upload_fileupload table of impurities."
+    help = "Clean out expired upload and fileupload records."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -64,7 +64,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        self.stdout.write("cleanse_upload:")
+        self.stdout.write("clearuploads:")
 
         # NOTE(willkg): if DEBUG=False, there's nothing to reset and this is a no-op
         reset_queries()
@@ -80,17 +80,17 @@ class Command(BaseCommand):
             upload_count = Upload.objects.all().count()
             fileupload_count = FileUpload.objects.all().count()
             self.stdout.write(
-                ">>> count before cleansing: "
+                ">>> count before clearing: "
                 + f"upload={upload_count}, fileupload={fileupload_count}"
             )
 
         with record_timing("delete", self.stdout):
-            # First cleanse try records
+            # First clear try records
             try_cutoff = today - datetime.timedelta(days=TRY_RECORD_AGE_CUTOFF)
             self.delete_records(is_dry_run=is_dry_run, is_try=True, cutoff=try_cutoff)
 
         with record_timing("delete", self.stdout):
-            # Now cleanse regular records
+            # Now clear regular records
             cutoff = today - datetime.timedelta(days=REGULAR_RECORD_AGE_CUTOFF)
             self.delete_records(is_dry_run=is_dry_run, is_try=False, cutoff=cutoff)
 


### PR DESCRIPTION
Adds a bin/cleanup.sh script we can use to run all the cleanup commands. This also renames cleanse_upload to clearuploads to be more like the existing clearsessions command.