### PR TITLE
bug 1847579: Make download-sym.py work for Windows modules.

### DIFF
--- a/bin/download-sym.py
+++ b/bin/download-sym.py
@@ -24,11 +24,14 @@ import requests
 @click.argument("outputdir")
 @click.argument("debugid")
 @click.argument("debugfilename")
+@click.argument("symfilename", required=False)
 @click.pass_context
-def download_sym_file(ctx, base_url, outputdir, debugid, debugfilename):
+def download_sym_file(ctx, base_url, outputdir, debugid, debugfilename, symfilename):
     """Downloads a sym file given a debug id and debug filename."""
     # Download sym file
-    path = f"{debugfilename}/{debugid}/{debugfilename}.sym"
+    if symfilename is None:
+        symfilename = debugfilename.removesuffix(".pdb") + ".sym"
+    path = f"{debugfilename}/{debugid}/{symfilename}"
     url = urljoin(base_url, path)
     headers = {"User-Agent": "tecken-download-sym"}
 


### PR DESCRIPTION
This change strips of the `.pdb` suffix of the debug filename if it exists before adding the `.sym` extension. For extra flexibilty it also supports overriding the sym file name manually. I tested this locally for a Windows symfile with these two commands, and both downloaded the symbols:
```
bin/download-sym.py sym 69425277EC5145FFAB3266EB4C20384D1 nvcuda.pdb
bin/download-sym.py sym 69425277EC5145FFAB3266EB4C20384D1 nvcuda.pdb nvcuda.sym
```
