### PR TITLE
Set SHELL env variable in local development containers to bash.

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -46,3 +46,7 @@ OIDC_OP_USER_ENDPOINT=http://oidcprovider:8080/openid/userinfo
 OIDC_VERIFY_SSL=false
 # Disable NotBlockedInAuth0Middleware
 ENABLE_AUTH0_BLOCKED_CHECK=false
+
+# This makes the shell inside a dev container in VS Code work.
+# The shell for the app user otherwise defaults to /sbin/nologin.
+SHELL=/bin/bash


### PR DESCRIPTION
This makes it possible to open a shell in a dev container in VS Code. The shell for the `app` user [otherwise defaults to `nologin`](https://github.com/mozilla-services/tecken/blob/aba9574708b08e1ffe80a6ea34cc89d1220ed2e4/docker/Dockerfile#L27-L29), which i not a useful shell.

We probably also want this fix for other projects.