### PR TITLE
bug-1809727: upgrade django to 4.2.7 LTS

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -44,5 +44,5 @@ importlib-metadata==6.8.0
 typing-extensions==4.8.0
 zipp==3.17.0
 
-# NOTE(willkg): We stick with LTS releases and the next one is 4.2 (2023).
-Django==3.2.23
+# NOTE(willkg): We stick with LTS releases.
+Django==4.2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -264,9 +264,9 @@ dj-database-url==2.1.0 \
     --hash=sha256:04bc34b248d4c21aaa13e4ab419ae6575ef5f10f3df735ce7da97722caa356e0 \
     --hash=sha256:f2042cefe1086e539c9da39fad5ad7f61173bf79665e69bf7e4de55fa88b135f
     # via -r requirements.in
-django==3.2.23 \
-    --hash=sha256:82968f3640e29ef4a773af2c28448f5f7a08d001c6ac05b32d02aeee6509508b \
-    --hash=sha256:d48608d5f62f2c1e260986835db089fa3b79d6f58510881d316b8d88345ae6e1
+django==4.2.7 \
+    --hash=sha256:8e0f1c2c2786b5c0e39fe1afce24c926040fad47c8ea8ad30aaf1188df29fc41 \
+    --hash=sha256:e1d37c51ad26186de355cbcec16613ebdabfa9689bbade9c538835205a8abbe9
     # via
     #   -r requirements.in
     #   dj-database-url
@@ -570,10 +570,6 @@ python-dateutil==2.8.2 \
     # via
     #   -r requirements.in
     #   botocore
-pytz==2023.3.post1 \
-    --hash=sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b \
-    --hash=sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7
-    # via django
 redis==5.0.1 \
     --hash=sha256:0dab495cd5753069d3bc650a0dde8a8f9edde16fc5691b689a566eda58100d0f \
     --hash=sha256:ed4802971884ae19d640775ba3b03aa2e7bd5e8fb8dfaed2decce4d0fc48391f


### PR DESCRIPTION
@smarnach went through the release notes for Django comparing to the previously installed version and reviewed all the major changes and the extent to which we were using those Django features. He didn't find any changes strictly necessary, though he did find that we could upgrade our Postgres DB library `psycopg2` to version 3.