### PR TITLE
bug-1743835: switch python image from bookworm to bullseye

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN bin/build_frontend.sh
 
 
-FROM python:3.11.6-slim@sha256:52cf1e24d0baa095fd8137e69a13042442d40590f03930388df49fe4ecb8ebdb
+FROM python:3.11.6-slim-bullseye@sha256:44c644f4146ef0af8a06a1eeec5bd2cc2956c8976b2c8809efde69df4a3a614b
 
 ARG userid=10001
 ARG groupid=10001


### PR DESCRIPTION
I had problems with using Debian 12 (aka bookworm) with Socorro where bookworm has a different version of glibc than bullseye does in [bug 1853662](https://bugzilla.mozilla.org/show_bug.cgi?id=1853662). Thus Socorro uses bullseye and we should probably use bullseye across all the things we maintain.

I theorize this might fix the issue where honcho is failing with a `RuntimeError` trying to start threads in Tecken stage. I hypothesize that Python compiled in bookworm is compiled against a newer glibc (or some other system library) and that doesn't work on the hosts Tecken is running on. So when honcho starts a thread, it fails with a `RuntimeError`.

If the theory holds true, the problem will go away if we downgrade to Debian 11. Even if it doesn't, we'll switch Tecken to bullseye which is what Socorro is using.