### PR TITLE
bug-1863007: change UPLOAD_TEMPDIR_ORPHANS_CUTOFF to 15 minutes

### DIFF
--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -492,7 +492,7 @@ UPLOAD_TEMPDIR = _config(
 )
 UPLOAD_TEMPDIR_ORPHANS_CUTOFF = _config(
     "UPLOAD_TEMPDIR_ORPHANS_CUTOFF",
-    default="60",
+    default="15",
     parser=int,
     doc=(
         "Time in minutes before we consider a file to have been orphaned and should "


### PR DESCRIPTION
This drops the cutoff from 60 minutes which kept orphaned files way too long causing an instance to have disk-full problems for over an hour to 15 minutes which will allow instances to recover more quickly.

15 minutes far exceeds the 6 minute timeout for HTTP request handling, so files that are still around after 15 minutes are certainly orphaned.

---

The Tecken webapp handles upload API requests. These requests can take a very long time to handle. If the request exceeds 6 minutes, it's possible that the gunicorn worker serving the request will get killed off. If that happens, then the symbols files on disk that the upload API handler was processing get orphaned and remain on disk. The disk is finite, so after enough of these events, then the instance has no more disk left and starts throwing out-of-disk errors.

There is also a disk cache manager process running in the docker container. The `UPLOAD_TEMPDIR_ORPHANS_CUTOFF` setting affects how old a file can be before the disk cache manager determines it's an orphaned file and deletes it.

This reduces the cutoff number from 60 minutes to 15 minutes by changing the default value. We don't set this value in the infrastructure configuration, so changing the default changes it everywhere. There isn't a whole lot to review here.