### PR TITLE
bug-1853962: improve disk manager resilience

### DIFF
--- a/bin/run_web_disk_manager.sh
+++ b/bin/run_web_disk_manager.sh
@@ -16,14 +16,14 @@ cd /app/
 
 export PROCESS_NAME=disk_manager
 
-SLEEP_SECONDS=300
-PROCESS_TIMEOUT=60
+SLEEP_SECONDS=60
+PROCESS_TIMEOUT_SECONDS=60
 
 # Run disk manager in a loop sleeping SLEEP_SECONDS between rounds. Wrap in
 # sentry-wrap so it sends errors to Sentry.
 while true
 do
-    python /app/bin/sentry-wrap.py wrap-process --timeout="${PROCESS_TIMEOUT}" -- \
+    python /app/bin/sentry-wrap.py wrap-process --timeout="${PROCESS_TIMEOUT_SECONDS}" -- \
         python /app/manage.py remove_orphaned_files --skip-checks
     sleep "${SLEEP_SECONDS}"
 done

--- a/tecken/upload/management/commands/remove_orphaned_files.py
+++ b/tecken/upload/management/commands/remove_orphaned_files.py
@@ -90,7 +90,7 @@ class Command(BaseCommand):
 
         watchdir = os.path.abspath(str(watchdir))
         if not os.path.exists(watchdir):
-            logger.error("error: %r does not exist. Exiting.", watchdir)
-            return 1
+            logger.info("%r does not exist; exiting.", watchdir)
+            return 0
 
         self.delete_orphans(watchdir=watchdir, expires=expires)

--- a/tecken/upload/management/commands/remove_orphaned_files.py
+++ b/tecken/upload/management/commands/remove_orphaned_files.py
@@ -90,7 +90,7 @@ class Command(BaseCommand):
 
         watchdir = os.path.abspath(str(watchdir))
         if not os.path.exists(watchdir):
-            logger.info("%r does not exist; exiting.", watchdir)
+            logger.info("%r does not exist", watchdir)
             return 0
 
         self.delete_orphans(watchdir=watchdir, expires=expires)

--- a/tecken/upload/utils.py
+++ b/tecken/upload/utils.py
@@ -153,6 +153,9 @@ class FileMember:
     def size(self):
         return os.stat(self.path).st_size
 
+    def __repr__(self):
+        return f"<FileMenber {self.path} {self.name}>"
+
 
 def _key_existing_miss(client, bucket, key):
     logger.debug(f"key_existing cache miss on {bucket}:{key}")


### PR DESCRIPTION
- bug-1853962: improve disk cache manager error handling
- bug-1853962: change UPLOAD_TEMPDIR does not exist into non-error

This does a few things to make the disk manager more resilient:
    
1. removes the daemon functionality: the script runs in a loop already, so we don't need the additional daemon loop in the command
2. wrap the `remove_orphaned_files` command in `sentry-wrap`: this will make sure we get errors sent to sentry
3. add a timeout for the command: we probably don't need a timeout, but this adds one anyway so if it takes longer than 60 seconds to run, `sentry-wrap` will kill it and send an error to Sentry
4. adds a `--verbose` to `sentry-wrap`: this makes it so that `sentry-wrap` doesn't spit out non-essential output unless asked to
5. fix output: this removes non-error output which gets logged and moves errors to stderr

A while back, we had a problem where the db disappeared and then the disk manager process died and then the instances all went sideways after some time as they accumulated orphaned files. Lots of problems here, but this reduces the lack of resilience with the disk manager so it doesn't die when the db isn't available because it doesn't need the db.

This also improves the likelihood we get some signal that things are bad in Sentry with details we can use to debug the issue.