### PR TITLE
bug-1847235: emit tecken.gunicorn_worker_abort incr on timeout

### DIFF
--- a/bin/run_web.sh
+++ b/bin/run_web.sh
@@ -23,6 +23,7 @@ else
         --bind 0.0.0.0:"${PORT}" \
         --timeout "${GUNICORN_TIMEOUT}" \
         --workers "${GUNICORN_WORKERS}" \
+        --config=tecken/gunicornhooks.py \
         --access-logfile - \
         tecken.wsgi:application
 fi

--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -7,6 +7,9 @@
 # Tecken
 # ------
 
+# Gunicorn things
+GUNICORN_TIMEOUT=60
+
 # Statsd things
 STATSD_HOST=statsd
 STATSD_PORT=8125

--- a/tecken/gunicornhooks.py
+++ b/tecken/gunicornhooks.py
@@ -6,19 +6,23 @@
 Gunicorn server hooks.
 
 See https://docs.gunicorn.org/en/stable/settings.html#server-hooks
+
+Note: Don't import anything that involves Django machinery here.
 """
 
 import markus
-
-from tecken import settings
 
 
 metrics = markus.get_metrics("tecken")
 
 
-def configure_markus():
-    markus.configure(settings.MARKUS_BACKENDS)
-
-
 def worker_abort(worker):
+    """Emit metric when a Gunicorn worker is terminated from timeout
+
+    .. Note::
+
+       This gets called by the Gunicorn worker handle_abort() function so it'll use the
+       markus and logging configuration of the Django webapp.
+
+    """
     metrics.incr("gunicorn_worker_abort")

--- a/tecken/gunicornhooks.py
+++ b/tecken/gunicornhooks.py
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""
+Gunicorn server hooks.
+
+See https://docs.gunicorn.org/en/stable/settings.html#server-hooks
+"""
+
+import markus
+
+from tecken import settings
+
+
+metrics = markus.get_metrics("tecken")
+
+
+def configure_markus():
+    markus.configure(settings.MARKUS_BACKENDS)
+
+
+def worker_abort(worker):
+    metrics.incr("gunicorn_worker_abort")

--- a/tecken/tests/test_gunicornhooks.py
+++ b/tecken/tests/test_gunicornhooks.py
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from tecken import gunicornhooks
+
+
+def test_worker_abort_emits_metric(metricsmock):
+    # NOTE(willkg): we pass in a None here, but it's really expecting a gunicorn worker
+    # instance. Since our worker_abort hook doesn't do anything with the worker
+    # instance, that's fine.
+    gunicornhooks.worker_abort(None)
+
+    metricsmock.assert_incr("tecken.gunicorn_worker_abort", value=1)


### PR DESCRIPTION
This uses gunicorn server hooks to emit a tecken.gunicorn_worker_abort incr when the gunicorn manager terminates a gunicorn worker because it's exceeded the timeout. This happens when it's taking too long to process an upload API request.

The test for this is contrived at best and only verifies that the metric we expect is emitted.

It's difficult to do a real test because that requires Tecken to be running with gunicorn and for a gunicorn worker to exceed the timeout such that the gunicorn manager kills the process. We can manually test it using the steps in this blog post:

https://bluesock.org/~willkg/blog/mozilla/tecken_worker_exit.html

When the Gunicorn manager sends a SIGABRT to the Gunicorn worker, we'll see the metric emitted:

```
tecken-web-1           | INFO 2023-11-30 20:26:08,248 - webapp - markus METRICS|2023-11-30 20:26:08|timing|tecken.upload_file_exists|6.280567002249882|
tecken-web-1           | DEBUG 2023-11-30 20:26:08,249 - webapp - tecken key_existing cache miss on publicbucket:v1/libglib-2.0.so.0/441450BE1030C69946EC77871CA83C5D0/libglib-2.0.so.0
tecken-web-1           | [2023-11-30 20:27:08 +0000] [16] [CRITICAL] WORKER TIMEOUT (pid:22)
tecken-web-1           | INFO 2023-11-30 20:27:08,968 - webapp - markus METRICS|2023-11-30 20:27:08|incr|tecken.gunicorn_worker_abort|1|
tecken-web-1           | [2023-11-30 20:27:09 +0000] [16] [ERROR] Worker (pid:22) was sent SIGKILL! Perhaps out of memory?
tecken-web-1           | [2023-11-30 20:27:09 +0000] [34] [INFO] Booting worker with pid: 34
tecken-web-1           | WARNING 2023-11-30 20:27:10,365 - webapp - tecken Auth0 blocked check disabled
```