### PR TITLE
bug-1847235: move markus usage to hook function

### DIFF
--- a/tecken/gunicornhooks.py
+++ b/tecken/gunicornhooks.py
@@ -7,13 +7,9 @@ Gunicorn server hooks.
 
 See https://docs.gunicorn.org/en/stable/settings.html#server-hooks
 
-Note: Don't import anything that involves Django machinery here.
+Note: This file is imported by the Gunicorn manager, so don't import anything that
+involves Tecken webapp machinery here.
 """
-
-import markus
-
-
-metrics = markus.get_metrics("tecken")
 
 
 def worker_abort(worker):
@@ -25,4 +21,7 @@ def worker_abort(worker):
        markus and logging configuration of the Django webapp.
 
     """
+    import markus
+
+    metrics = markus.get_metrics("tecken")
     metrics.incr("gunicorn_worker_abort")


### PR DESCRIPTION
We don't want the gunicorn manager process to import Tecken webapp stuff, so this moves importing markus and creating a markus client to the point where it's used.