### PR TITLE
bug-1868132: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in this repository
+*   @mozilla-services/obs-team


### PR DESCRIPTION
This adds a CODEOWNERS file which adds a default rule covering the
entire repository with the obs-team.
