### PR TITLE
bug-1835888: initialize CLOUD_SERVICE_PROVIDER env var

### DIFF
--- a/tecken/base/admin.py
+++ b/tecken/base/admin.py
@@ -108,10 +108,11 @@ def site_status(request):
 
     # Only include keys that can never be useful in security context.
     keys = (
+        "ALLOW_UPLOAD_BY_DOWNLOAD_DOMAINS",
+        "CLOUD_SERVICE_PROVIDER",
+        "DOWNLOAD_FILE_EXTENSIONS_ALLOWED",
         "ENABLE_AUTH0_BLOCKED_CHECK",
         "ENABLE_TOKENS_AUTHENTICATION",
-        "ALLOW_UPLOAD_BY_DOWNLOAD_DOMAINS",
-        "DOWNLOAD_FILE_EXTENSIONS_ALLOWED",
     )
     for key in keys:
         value = getattr(settings, key)

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -421,6 +421,12 @@ else:
         },
     }
 
+CLOUD_SERVICE_PROVIDER = _config(
+    "CLOUD_SERVICE_PROVIDER",
+    default="AWS",
+    doc="The cloud service provider Tecken is using. Either AWS or GCP.",
+)
+
 AWS_ACCESS_KEY_ID = _config("AWS_ACCESS_KEY_ID", default="", doc="AWS access key id.")
 AWS_SECRET_ACCESS_KEY = _config(
     "AWS_SECRET_ACCESS_KEY", default="", doc="AWS secret access key."


### PR DESCRIPTION
Because:
* There is application-level branching logic required[1], depending on which cloud service provider we are using.

This commit:
* Creates a new env var, CLOUD_SERVICE_PROVIDER, defaulting to "AWS"
* Adds this env var to the Settings section in the Django /admin/sitestatus page.

[1]: For example, markus needs to add an additional tag in GCP that is already tagged by Telegraf in AWS. Another example is that we will need different storage backend setup code depending on if we're using AWS S3 or GCP GCS.

Tecken config docs:
![Screenshot 2023-12-06 at 1 14 19 PM](https://github.com/mozilla-services/tecken/assets/17437436/92767131-5083-4890-8321-e1d4015b85f2)

Django admin settings page:
![Screenshot 2023-12-06 at 1 14 07 PM](https://github.com/mozilla-services/tecken/assets/17437436/40589cde-b533-44e2-a12f-c2ed477d9d17)

I have separately added a line item for the [Tecken GCP migration plan](https://docs.google.com/document/d/1tLoGhMJQrP1m6A5H3D5zElNbTHQ9_vzYbOE9QnrxLUc/edit?usp=sharing) to set this env var to "GCP" as part of setting up the GCP stage and prod environments. Since it is defaulting to "AWS", no further upstream config is needed in our cloudops repo currently.
