### PR TITLE
bug-1868790: Return Unix timestamps from get_last_modified().

### DIFF
--- a/docker/config/test.env
+++ b/docker/config/test.env
@@ -31,3 +31,7 @@ OIDC_RP_CLIENT_SECRET=abcdef
 OIDC_OP_USER_ENDPOINT=https://auth.example.com/authorize
 
 UPLOAD_TEMPDIR=/tmp/test/uploads
+
+# Use a different Redis database for the tests, so the tests don't interfere
+# with the dev environment.
+REDIS_URL=redis://redis-cache:6379/1

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -399,7 +399,7 @@ DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = True
 
 REDIS_IGNORE_EXCEPTIONS = True
 
-if TEST_ENV or TOOL_ENV:
+if TOOL_ENV:
     CACHES = {
         "default": {
             "BACKEND": "tecken.libcache.RedisLocMemCache",


### PR DESCRIPTION
The results of `get_last_modified()` are cached in Redis, so we can't use datetime objects here, since they can't be serialized by MessagePack. We did not catch this mistake in the tests because the tests used to use an in-memory cache without serialization. This change also makes the tests use an actual Redis container in the tests.