### PR TITLE
Add VS Code dev container configuration.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/devcontainers/python:3.11-bullseye@sha256:105bf6a63ab025206f019a371a735fec6553db0be520030c7a2fd0e002947232
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt /app/
+RUN pip install -U 'pip>=20' && \
+    pip install --no-cache-dir --no-deps -r requirements.txt && \
+    pip install --no-cache-dir ipython && \
+    pip check --disable-pip-version-check

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,5 @@
 {
+  "name": "Tecken",
   "dockerComposeFile": [
     "../docker-compose.yml",
     "docker-compose.yml"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "dockerComposeFile": [
+    "../docker-compose.yml",
+    "docker-compose.yml"
+  ],
+  "service": "devcontainer",
+  "runServices": [
+    "devcontainer"
+  ],
+  "shutdownAction": "none",
+  "workspaceFolder": "/app",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestEnabled": true,
+        "[python]": {
+          "editor.defaultFormatter": "ms-python.black-formatter"
+        }
+      },
+      "extensions": [
+        "ms-python.black-formatter"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       service: test
     build:
       dockerfile: .devcontainer/Dockerfile
+    image: tecken-devcontainer
     links:
       - db
       - fakesentry

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,18 @@
+---
+# Dev container https://containers.dev/, e.g. for VS Code
+version: '2.4'
+services:
+  devcontainer:
+    extends:
+      file: "docker-compose.yml"
+      service: test
+    build:
+      dockerfile: .devcontainer/Dockerfile
+    links:
+      - db
+      - fakesentry
+      - redis-cache
+      - localstack
+      - oidcprovider
+      - statsd
+    entrypoint: ["sleep", "inf"]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-vscode-remote.remote-containers"
+    ]
+}

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -101,6 +101,7 @@ should be prompted whether you want to reopen the folder in a container on
 startup. You can also use the "Dev containers: Reopen in container" command
 from the command palette. The container has all Python requirements installed.
 IntelliSense, type checking, code formatting with Black and running the tests
+from the test browser are all set up to work without further configuration.
 
 What services are running in a local dev environment
 ----------------------------------------------------

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -91,6 +91,17 @@ The Symbols Service webapp is at: http://localhost:3000
 How to
 ======
 
+How to set up a development container for VS Code
+-------------------------------------------------
+
+The repository contains configuration files to build a
+`development container <https://containers.dev/>`_ in the `.devcontainer`
+directory. If you have the "Dev Containers" extension installed in VS Code, you
+should be prompted whether you want to reopen the folder in a container on
+startup. You can also use the "Dev containers: Reopen in container" command
+from the command palette. The container has all Python requirements installed.
+IntelliSense, type checking, code formatting with Black and running the tests
+
 What services are running in a local dev environment
 ----------------------------------------------------
 


### PR DESCRIPTION
This PR adds a dev container configuration for VS Code. Features:

* All dependencies are installed in the dev container, so IntelliSense fully works, and type checking will also work once we add type annotations.
* Allows running the tests using [VS Code's Python test browser](https://code.visualstudio.com/docs/python/testing), which makes running and debugging tests really convenient. (This is the main reason to use a container instead of a virtualenv in the first place.)
* Sets up Black as the default Python formatter. We can consider adding a setting to automatically format Python code on save.

I'm not really an expert on VS Code, so it's possible there are better ways of setting this up. This configuration works well for me, though, and it might be useful for others as well.