### PR TITLE
Make ports exposed in docker compose configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - db
       - redis-cache
     ports:
-      - "8000:8000"
+      - "${EXPOSE_TECKEN_PORT:-8000}:8000"
     links:
       - db
       - fakesentry
@@ -62,7 +62,7 @@ services:
     extends:
       service: base
     ports:
-      - "8000:8000"
+      - "${EXPOSE_TECKEN_PORT:-8000}:8000"
     links:
       - db
       - redis-cache
@@ -108,7 +108,7 @@ services:
     environment:
       - LOCALSTACK_HOST=localstack
     ports:
-      - "4566:4566"
+      - "${EXPOSE_LOCALSTACK_PORT:-4566}:4566"
 
   # https://github.com/willkg/kent
   fakesentry:
@@ -116,7 +116,7 @@ services:
       context: docker/images/fakesentry
     image: local/tecken_fakesentry
     ports:
-      - "8090:8090"
+      - "${EXPOSE_SENTRY_PORT:-8090}:8090"
     command: run --host 0.0.0.0 --port 8090
 
   # https://hub.docker.com/r/mozilla/oidc-testprovider
@@ -125,14 +125,10 @@ services:
       context: docker/images/oidcprovider
     image: local/tecken_oidcprovider
     ports:
-      - "8080:8080"
+      - "${EXPOSE_OIDC_PORT:-8080}:8080"
 
   # https://hub.docker.com/r/hopsoft/graphite-statsd/
   statsd:
     image: hopsoft/graphite-statsd:latest
     ports:
-      - "8081:80"
-      - "2003-2004:2003-2004"
-      - "2023-2024:2023-2024"
-      - "8125:8125/udp"
-      - "8126:8126"
+      - "${EXPOSE_GRAFANA_PORT:-8081}:80"


### PR DESCRIPTION
see also https://github.com/mozilla-services/eliot/pull/113

per https://github.com/mozilla-services/tecken/pull/2857/files#r1430382049
> ```
>  "shutdownAction": "none",
> ```
> [biancadanforth](https://github.com/biancadanforth) [Dec 18, 2023](https://github.com/mozilla-services/tecken/pull/2857/files#r1430382049):
>  This is what prevents the devcontainer from shutting down when we close out of VS Code IIUC.

with devcontainer and its docker-compose dependencies running even when vscode isn't open, ports conflict between tecken, eliot, and socorro, so this PR makes the exposed ports configurable via environment variables, which can be set in `.env` in each project to avoid overlap.