### PR TITLE
Don't error out when building the dev container for uid/gid 1000.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,9 +5,10 @@ ARG groupid=10001
 
 WORKDIR /app
 
-# add a non-privileged user for installing and running the application
-RUN groupadd --gid $groupid app && \
-    useradd -g app --uid $userid --shell /usr/sbin/nologin --create-home app && \
+# Add a non-privileged user for installing and running the application.
+# We use --non-unique in case $groupid/$userid collide with the existing "vscode" user.
+RUN groupadd --gid $groupid --non-unique app && \
+    useradd -g app --uid $userid --non-unique --shell /usr/sbin/nologin --create-home app && \
     chown app:app /app/
 
 # Install Debian packages


### PR DESCRIPTION
This fixes a problem introduced in #2872.

If the user or group id is 1000, this will still create a user or group with the same id as the existing `vscode` user or group. This can in general be a bit confusing, but I don't think it will cause actual problems in the dev container.

The existing `vscode` user has a home directory in the container, and owns some random stuff in `/usr/local` (probably unintentionally).