### PR TITLE
Fix upload-sym.py sym_file generation

### DIFF
--- a/bin/upload-sym.py
+++ b/bin/upload-sym.py
@@ -52,7 +52,7 @@ def upload_sym_file(ctx, auth_token, base_url, symfile):
     if debugfilename.endswith(".pdb"):
         sym_file = debugfilename[:-4] + ".sym"
     else:
-        sym_file = debugfilename
+        sym_file = debugfilename + ".sym"
 
     path = f"{debugfilename}/{debugid}/{sym_file}"
     with tempfile.TemporaryDirectory(prefix="symbols") as tmpdirname:


### PR DESCRIPTION
This fixes a bug introduced in September 2023 in 23daea485d, where I fixed the code to generate the right sym_file filename for Windows, but broke it for Linux/macOS. This fixes Linux/macOS.

For Windows, the sym_file filename involves taking the debug file, dropping `.pdb`, and adding `.sym`. e.g. `libxul.pdb` -> `libxul.sym`.

For Linux/macOS, the sym_file filename involves adding `.sym` to the end of the debug file. e.g. `glxtrace.so` -> `glxtrace.so.sym` and `XUL` -> `XUL.sym`.