### PR TITLE
bug-1835880: switch tag pattern to vYYYY.MM.DD[-N]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,4 +96,4 @@ workflows:
       - main:
           filters:
             tags:
-              only: /.*/
+              only: /^v.*/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ github_project = "tecken"
 bugzilla_product = "Tecken"
 bugzilla_component = "General"
 main_branch = "main"
-tag_name_template = "%Y.%m.%d"
+tag_name_template = "v%Y.%m.%d"
 
 
 [tool.service-status]


### PR DESCRIPTION
Because:
* We have standardized on tags starting with v

This commit:
* Ensures the `main` job for CI is run for all branches and only tags starting with v, instead of all branches and all tags.
* Updates our `release.py` config to pass in the new tag format when creating the tag as part of a release.

Notes:
* I didn't update any docs, since I didn't see any mentions of the tag format in either the `/docs` directory in the repo or on the [Tecken page in Confluence](https://mozilla-hub.atlassian.net/wiki/spaces/CS1/pages/178061663/Symbols+aka+Tecken)[1]. Please let me know if I missed anywhere.
* I've added two new [tag protection rules](https://github.com/mozilla-services/tecken/settings/tag_protection) in the repo based on the [match patterns used by Eliot for its `build-and-push` GitHub Action](https://github.com/mozilla-services/eliot/blob/ccd40340db031584b9a498e3356bb34a5edc86ec/.github/workflows/build-and-push.yml#L8-L9).
* @willkg or @smarnach : Can one of you help me to complete this step in Jenkins per Willkg's [comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1835880#c1) in the ticket?:
 > update the deploy pipeline in jenkins which has regexps for recognizing what to do based on the tag

[1]: I could update the example output for `bin/service-status.py` in the [Verify deploy section](https://mozilla-hub.atlassian.net/wiki/spaces/CS1/pages/490602899/Runbook+Tecken+prod+deploy#Verify-deploy), but I haven't so far.