### PR TITLE
bug-1759554: remove django-cache-memoize

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,6 @@ botocore==1.31.78
 click==8.1.7
 datadog==0.47.0
 dj-database-url==2.1.0
-django-cache-memoize==0.2.0
 django-admin-cursor-paginator==0.1.4
 django-redis==5.4.0
 dockerflow==2022.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -255,10 +255,6 @@ django==4.2.7 \
 django-admin-cursor-paginator==0.1.4 \
     --hash=sha256:133a79a30c38f9a69fc51d6131b0c7e459043a4d3620fac17194badb97ee5df4
     # via -r requirements.in
-django-cache-memoize==0.2.0 \
-    --hash=sha256:79950a027ba40e4aff4efed587b76036bf5ba1f59329d7b158797b832be72ca6 \
-    --hash=sha256:a6bfd112da699d1fa85955a1e15b7c48ee25e58044398958e269678db10736f3
-    # via -r requirements.in
 django-redis==5.4.0 \
     --hash=sha256:6a02abaa34b0fea8bf9b707d2c363ab6adc7409950b2db93602e6cb292818c42 \
     --hash=sha256:ebc88df7da810732e2af9987f7f426c96204bf89319df4c6da6ca9a2942edd5b

--- a/tecken/base/symboldownloader.py
+++ b/tecken/base/symboldownloader.py
@@ -106,18 +106,6 @@ class SymbolDownloader:
             self._sources = list(self._get_sources())
         return self._sources
 
-    def invalidate_cache(self, symbol, debugid, filename):
-        # Because we can't know exactly which source (aka URL) was
-        # used when the key was cached by exists_in_source() we have
-        # to iterate over the source.
-        for source in self.sources:
-            prefix = source.prefix
-            assert prefix
-            file_url = "{}/{}".format(
-                source.base_url, self.make_url_path(prefix, symbol, debugid, filename)
-            )
-            get_last_modified.invalidate(file_url)
-
     @staticmethod
     def make_url_path(prefix, symbol, debugid, filename):
         """Generates a url quoted path which works with HTTP requests against AWS S3
@@ -135,7 +123,7 @@ class SymbolDownloader:
         # uppercased. If so, we override it. Every debug ID is always in uppercase.
         return quote(f"{prefix}/{symbol}/{debugid.upper()}/{filename}")
 
-    def _get(self, symbol, debugid, filename, refresh_cache=False):
+    def _get(self, symbol, debugid, filename):
         """Return a dict if the symbol can be found.
 
         Dict includes a "url" key.
@@ -166,18 +154,18 @@ class SymbolDownloader:
                 }
 
     @set_time_took
-    def has_symbol(self, symbol, debugid, filename, refresh_cache=False):
+    def has_symbol(self, symbol, debugid, filename):
         """return True if the symbol can be found, False if not
         found in any of the URLs provided."""
-        return bool(self._get(symbol, debugid, filename, refresh_cache=refresh_cache))
+        return bool(self._get(symbol, debugid, filename))
 
     @set_time_took
-    def get_symbol_url(self, symbol, debugid, filename, refresh_cache=False):
+    def get_symbol_url(self, symbol, debugid, filename):
         """Return the redirect URL or None.
 
         If we return None it means we can't find the object in any of the URLs provided.
 
         """
-        found = self._get(symbol, debugid, filename, refresh_cache=refresh_cache)
+        found = self._get(symbol, debugid, filename)
         if found:
             return found["url"]

--- a/tecken/download/views.py
+++ b/tecken/download/views.py
@@ -157,18 +157,14 @@ def download_symbol(request, debugfilename, debugid, filename, try_symbols=False
         downloader = normal_downloader
 
     if request.method == "HEAD":
-        if downloader.has_symbol(
-            debugfilename, debugid, filename, refresh_cache=refresh_cache
-        ):
+        if downloader.has_symbol(debugfilename, debugid, filename):
             response = http.HttpResponse()
             if request._request_debug:
                 response["Debug-Time"] = downloader.time_took
             return response
 
     else:
-        url = downloader.get_symbol_url(
-            debugfilename, debugid, filename, refresh_cache=refresh_cache
-        )
+        url = downloader.get_symbol_url(debugfilename, debugid, filename)
         if url:
             # If doing local development, with Docker, you're most likely running
             # localstack as a fake S3. It runs on its own hostname that is only

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -680,18 +680,6 @@ DISALLOWED_SYMBOLS_SNIPPETS = _config(
     ),
 )
 
-SYMBOLDOWNLOAD_EXISTS_TTL_SECONDS = _config(
-    "SYMBOLDOWNLOAD_EXISTS_TTL_SECONDS",
-    default=str(60 * 60 * 6),
-    parser=int,
-    doc=(
-        "We can cache quite aggressively here because the SymbolDownloader "
-        "has chance to invalidate certain keys. "
-        "Also, any time a symbol archive file is upload, for each file within "
-        "that we end up uploading to S3 we also cache invalidate."
-    ),
-)
-
 # How many uploads to display per page when paginating through
 # past uploads.
 API_UPLOADS_BATCH_SIZE = 20

--- a/tecken/upload/utils.py
+++ b/tecken/upload/utils.py
@@ -22,8 +22,6 @@ from tecken.libmarkus import METRICS
 
 logger = logging.getLogger("tecken")
 
-# FIXME(willkg): This downloader needs to point to all the things that can be downloaded
-# from so it can correctly invalidate the cache
 downloader = SymbolDownloader(settings.SYMBOL_URLS + [settings.UPLOAD_TRY_SYMBOLS_URL])
 
 
@@ -152,14 +150,6 @@ class FileMember:
 
     def __repr__(self):
         return f"<FileMenber {self.path} {self.name}>"
-
-
-def _key_existing_miss(client, bucket, key):
-    logger.debug(f"key_existing cache miss on {bucket}:{key}")
-
-
-def _key_existing_hit(client, bucket, key):
-    logger.debug(f"key_existing cache hit on {bucket}:{key}")
 
 
 @METRICS.timer_decorator("upload_file_exists")
@@ -340,28 +330,5 @@ def upload_file_upload(
     FileUpload.objects.filter(id=file_upload.id).update(completed_at=timezone.now())
     logger.info(f"Uploaded key {key_name}")
     METRICS.incr("upload_file_upload_upload", 1)
-
-    # If we managed to upload a file, different or not, cache invalidate the
-    # key_existing_size() lookup.
-    try:
-        key_existing.invalidate(client, bucket_name, key_name)
-    except Exception:  # pragma: no cover
-        if settings.DEBUG:
-            raise
-        logger.error(f"Unable to invalidate key size {key_name}", exc_info=True)
-
-    # Take this opportunity to inform possible caches that the file,
-    # if before wasn't the case, is now stored in S3.
-    symbol, debugid, filename = key_name.split(settings.SYMBOL_FILE_PREFIX + "/")[
-        1
-    ].split("/")
-    try:
-        downloader.invalidate_cache(symbol, debugid, filename)
-    except Exception:  # pragma: no cover
-        if settings.DEBUG:
-            raise
-        logger.error(
-            f"Unable to invalidate symbol {symbol}/{debugid}/{filename}", exc_info=True
-        )
 
     return file_upload

--- a/tecken/upload/utils.py
+++ b/tecken/upload/utils.py
@@ -17,12 +17,9 @@ from django.conf import settings
 from django.utils import timezone
 
 from tecken.upload.models import FileUpload
-from tecken.base.symboldownloader import SymbolDownloader
 from tecken.libmarkus import METRICS
 
 logger = logging.getLogger("tecken")
-
-downloader = SymbolDownloader(settings.SYMBOL_URLS + [settings.UPLOAD_TRY_SYMBOLS_URL])
 
 
 class UnrecognizedArchiveFileExtension(ValueError):

--- a/tecken/upload/utils.py
+++ b/tecken/upload/utils.py
@@ -12,7 +12,6 @@ import socket
 
 from botocore.exceptions import ClientError
 from botocore.vendored.requests.exceptions import ReadTimeout
-from cache_memoize import cache_memoize
 
 from django.conf import settings
 from django.utils import timezone
@@ -163,13 +162,6 @@ def _key_existing_hit(client, bucket, key):
     logger.debug(f"key_existing cache hit on {bucket}:{key}")
 
 
-@cache_memoize(
-    settings.MEMOIZE_KEY_EXISTING_SIZE_SECONDS,
-    prefix="key_existing",
-    args_rewrite=lambda client, bucket, key: (f"{bucket}:{key}",),
-    miss_callable=_key_existing_miss,
-    hit_callable=_key_existing_hit,
-)
 @METRICS.timer_decorator("upload_file_exists")
 def key_existing(client, bucket, key):
     """return a tuple of (


### PR DESCRIPTION
Because:
* This library is no longer maintained.
* The minimal caching it was doing doesn't warrant the continued maintenance burden (in particular the Redis caching backend).

This commit:
* Removes uses of the library in the source code.
* Removes it from our list of dependencies.
* Fixes tests for the affected functions.

Note: This PR does not remove the Redis config, as per [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1759554#c7) in the bug, we want to monitor some metrics in prod first before proceeding with that step.