### PR TITLE
increase interval, timeout and retries on oidcprovider service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,9 +170,9 @@ services:
       - "${EXPOSE_OIDC_PORT:-8080}:8080"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/"]
-      interval: 1s
-      timeout: 3s
-      retries: 5
+      interval: 2s
+      timeout: 5s
+      retries: 10
 
   # https://hub.docker.com/r/hopsoft/graphite-statsd/
   statsd:


### PR DESCRIPTION
Because:
* This service runs on the AMD64 platform instead of ARM on some Macs (e.g. my M1).
* Therefore it runs under emulation and is slower and fails the healthcheck added in PR #2880.

This commit:
* Increases the interval, timeout and retries, so that the devcontainer service starts up without issue on such OSes.