### PR TITLE
bug-1877411: Work around race condition in compose-go.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,9 +50,22 @@ services:
       oidcprovider: *condition_service_healthy
       statsd: *condition_service_healthy
 
+  # TODO(2024-01-30): This configuration can be simplified using `extends: test-ci` once the fix for
+  # https://github.com/docker/compose/issues/11413 is available in all relevant environments.
   test:
     extends:
-      service: test-ci
+      service: base
+    env_file:
+      - docker/config/local_dev.env
+      - docker/config/test.env
+    depends_on:
+      db: *condition_service_healthy
+      gcs-emulator: *condition_service_healthy
+      fakesentry: *condition_service_healthy
+      redis-cache: *condition_service_healthy
+      localstack: *condition_service_healthy
+      oidcprovider: *condition_service_healthy
+      statsd: *condition_service_healthy
     volumes:
       - $PWD:/app
 


### PR DESCRIPTION
This duplicates the `test-ci` configuration into the `test` configuration, thereby avoiding the need to recursively resolve `extends` declarations. This works around https://github.com/docker/compose/issues/11413. We can revert this once the fix is available everywhere.