### PR TITLE
bug 1877534: mark backing services with --no-attach

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,17 @@ setup: .env  ## | Initialize services.
 
 .PHONY: run
 run: .env .docker-build  ## | Run the web app and services.
-	${DC} up web frontend fakesentry
+	# NOTE(willkg): We tag all the backing services with --no-attach here to
+	# prevent them from spamming stdout
+	${DC} up \
+		--no-attach db \
+		--no-attach statsd \
+		--no-attach gcs-emulator \
+		--no-attach redis-cache \
+		--no-attach localstack \
+		--no-attach oidcprovider \
+		--no-attach statsd \
+		web frontend fakesentry
 
 .PHONY: devcontainerbuild
 devcontainerbuild: .env .docker-build .devcontainer-build  ## | Build VS Code development container.


### PR DESCRIPTION
This reduces the copious output of backing services when running `make run`.

To test:

1. `docker compose stop` to reset everything
2. `./slick.sh` to start up backing services and set state for everything
3. `make run` to start up web, fakesentry, and frontend services

Expected: Output for web, fakesentry, and frontend services appears in stdout, but output for backing services (e.g. statsd and friends) does not.