### PR TITLE
bug-1877534: upgrade Kent to 1.2.0

### DIFF
--- a/docker/images/fakesentry/Dockerfile
+++ b/docker/images/fakesentry/Dockerfile
@@ -1,23 +1,25 @@
-FROM python:3.10.8-alpine3.16@sha256:d17cfece24cb5d0432b37c138f307a19dd461b88aded1fc6981ef5c997c74de1
+FROM python:3.11.6-slim-bullseye@sha256:44c644f4146ef0af8a06a1eeec5bd2cc2956c8976b2c8809efde69df4a3a614b
 
 ARG groupid=5000
 ARG userid=5000
 
 WORKDIR /app/
 
-RUN addgroup -g $groupid app && \
-    adduser --disabled-password --gecos "" --home /home/app --ingroup app --uid $userid app && \
-    chown app:app /app/
+RUN groupadd -r kent && useradd --no-log-init -r -g kent kent
 
-RUN apk add --no-cache curl tini
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl tini && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 RUN pip install -U 'pip>=20' && \
-    pip install --no-cache-dir 'kent==1.0.0'
+    pip install --no-cache-dir 'kent==1.2.0'
 
-USER app
+USER kent
 
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/kent-server"]
+ENTRYPOINT ["tini", "--", "/usr/local/bin/kent-server"]
 CMD ["run"]


### PR DESCRIPTION
This upgrades Kent to 1.2.0 to pick up fixes to logging and other things. That will quell the logging from the healthcheck hitting / every second.

This also updates the Dockerfile to use the same base image Tecken does.