### PR TITLE
obs-125: update django to 4.2.10

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -37,4 +37,4 @@ werkzeug==3.0.1
 whitenoise==6.6.0
 
 # NOTE(willkg): We stick with LTS releases.
-Django==4.2.7
+Django==4.2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -243,9 +243,9 @@ dj-database-url==2.1.0 \
     --hash=sha256:04bc34b248d4c21aaa13e4ab419ae6575ef5f10f3df735ce7da97722caa356e0 \
     --hash=sha256:f2042cefe1086e539c9da39fad5ad7f61173bf79665e69bf7e4de55fa88b135f
     # via -r requirements.in
-django==4.2.7 \
-    --hash=sha256:8e0f1c2c2786b5c0e39fe1afce24c926040fad47c8ea8ad30aaf1188df29fc41 \
-    --hash=sha256:e1d37c51ad26186de355cbcec16613ebdabfa9689bbade9c538835205a8abbe9
+django==4.2.10 \
+    --hash=sha256:a2d4c4d4ea0b6f0895acde632071aff6400bfc331228fc978b05452a0ff3e9f1 \
+    --hash=sha256:b1260ed381b10a11753c73444408e19869f3241fc45c985cd55a30177c789d13
     # via
     #   -r requirements.in
     #   dj-database-url


### PR DESCRIPTION
4.2.8 release notes: https://docs.djangoproject.com/en/5.0/releases/4.2.8/

4.2.9 release notes: https://docs.djangoproject.com/en/5.0/releases/4.2.9/

4.2.10 release notes: https://docs.djangoproject.com/en/5.0/releases/4.2.10/

Generally, this just upgrades the version we're using, but shouldn't affect Tecken at all since we don't use most of the things that changed.