### PR TITLE
bug-1881632: update circleci remote docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ jobs:
 
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 20.10.18
 
       - run:
           name: Get info


### PR DESCRIPTION
Previously, we specified an image that's now deprecated. This removes the version specification which will cause it to use the default which is currently docker 24. default will change over time, but we'll know if CI fails pretty quick and we're switching to GCP soon with a completely different deploy pipeline anyhow.

We did this with Socorro:

https://github.com/mozilla-services/socorro/pull/6533