### PR TITLE
bug-1884456: switch to tenacity in systemtests

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-backoff==2.2.1
 boltons==23.1.1
 boto3==1.28.78
 botocore==1.31.78
@@ -32,6 +31,7 @@ sentry-sdk==1.40.0
 Sphinx==7.2.6
 sphinx-rtd-theme==1.3.0
 sphinxcontrib-httpdomain==1.8.1
+tenacity==8.2.3
 ujson==5.8.0
 werkzeug==3.0.1
 whitenoise==6.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,6 @@ babel==2.13.1 \
     --hash=sha256:33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900 \
     --hash=sha256:7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed
     # via sphinx
-backoff==2.2.1 \
-    --hash=sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba \
-    --hash=sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8
-    # via -r requirements.in
 boltons==23.1.1 \
     --hash=sha256:80a8cd930ff21fbf03545b9863e5799d0c3e7e0e3b2546bdaf2efccd7b3708cc \
     --hash=sha256:d2cb2fa83cf2ebe791be1e284183e8a43a1031355156a968f8e0a333ad2448fc
@@ -763,6 +759,10 @@ sqlparse==0.4.4 \
     --hash=sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3 \
     --hash=sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c
     # via django
+tenacity==8.2.3 \
+    --hash=sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a \
+    --hash=sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c
+    # via -r requirements.in
 typing-extensions==4.8.0 \
     --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0 \
     --hash=sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef

--- a/systemtests/bin/download_sym_files.py
+++ b/systemtests/bin/download_sym_files.py
@@ -13,7 +13,8 @@ from urllib.parse import urljoin
 import click
 import markus
 from markus.backends import BackendBase
-import requests
+
+from systemtestslib.utils import http_get_with_retry
 
 
 class StdoutMetrics(BackendBase):
@@ -72,7 +73,7 @@ def download_sym_files(base_url, csv_file):
 
             # Download the file
             headers = {"User-Agent": "tecken-systemtests"}
-            resp = requests.get(url, headers=headers, timeout=60)
+            resp = http_get_with_retry(url, headers=headers, timeout=60)
 
             for item in resp.history:
                 if item.status_code in (301, 302):

--- a/systemtests/bin/download_sym_files.py
+++ b/systemtests/bin/download_sym_files.py
@@ -59,11 +59,6 @@ def download_sym_files(base_url, csv_file):
             # Skip commented out and blank lines
             continue
 
-        if line.startswith("@ECHO"):
-            # This lets us encode directions for the viewer in the csv files
-            click.echo(click.style(line[5:].strip(), fg="yellow"))
-            continue
-
         with METRICS.timer("download_time"):
             parts = line.split(",")
 
@@ -84,6 +79,8 @@ def download_sym_files(base_url, csv_file):
                     click.echo(f">>> redirect: {item.url}")
             click.echo(f">>> final: {resp.url}")
             click.echo(f">>> status code: {resp.status_code}")
+            if resp.status_code == 200:
+                click.echo(f">>> file size: {len(resp.content):,} bytes")
 
             # Compare status code with expected status code
             if resp.status_code != int(expected_status_code):

--- a/systemtests/bin/setup_download_tests.py
+++ b/systemtests/bin/setup_download_tests.py
@@ -117,9 +117,7 @@ def write_list_of_sym_filenames_to_csv(sym_file_type_to_filename, outputdir):
     date = datetime.datetime.now().strftime("%Y-%m-%d")
     csv_rows.append([f"# File built: {date}"])
     csv_rows.append(["# Format: symfile", "expected status code", "bucket"])
-    csv_rows.append(["@ECHO NOTE: None of these should take over 1000ms to download."])
-    csv_rows.append(["@ECHO"])
-    csv_rows.append(["# These are recent uploads, so they're 200s."])
+    csv_rows.append(["# These are recent uploads, so they should return HTTP 200s."])
     for file_type, sym_filename in sym_file_type_to_filename.items():
         bucket = "regular"
         if file_type == "try":

--- a/systemtests/bin/upload_symbols.py
+++ b/systemtests/bin/upload_symbols.py
@@ -15,7 +15,8 @@ from urllib.parse import urljoin
 import click
 import markus
 from markus.backends import BackendBase
-import requests
+
+from systemtestslib.utils import http_post
 
 
 # Maximum number of retry attempts
@@ -89,7 +90,7 @@ def upload_symbols(ctx, expect_code, auth_token, base_url, symbolsfile):
             with METRICS.timer("upload_time"):
                 with open(symbolsfile, "rb") as fp:
                     files = {basename: fp}
-                    resp = requests.post(
+                    resp = http_post(
                         api_url,
                         files=files,
                         headers=headers,

--- a/systemtests/bin/upload_symbols_by_download.py
+++ b/systemtests/bin/upload_symbols_by_download.py
@@ -14,7 +14,8 @@ from urllib.parse import urljoin
 import click
 import markus
 from markus.backends import BackendBase
-import requests
+
+from systemtestslib.utils import http_post
 
 
 # Maximum number of retry attempts
@@ -76,7 +77,7 @@ def upload_symbols_by_download(ctx, base_url, auth_token, url, expect_code):
         )
         try:
             with METRICS.timer("upload_time"):
-                resp = requests.post(
+                resp = http_post(
                     api_url,
                     data={"url": url},
                     headers=headers,

--- a/systemtests/setup_tests.py
+++ b/systemtests/setup_tests.py
@@ -27,44 +27,41 @@ def setup_tests(ctx):
         os.makedirs(ZIPS_DIR)
 
     click.echo("Generating systemtest data files ...")
-    try:
-        zips_count = len(
-            [
-                name
-                for name in os.listdir(f"{ZIPS_DIR}")
-                if os.path.isfile(f"{ZIPS_DIR}/{name}")
-            ]
+    zips_count = len(
+        [
+            name
+            for name in os.listdir(f"{ZIPS_DIR}")
+            if os.path.isfile(f"{ZIPS_DIR}/{name}")
+        ]
+    )
+    if zips_count < 4:
+        # Generate some symbols ZIP files to upload, and a CSV
+        # of those symbols files to download
+        ctx.invoke(
+            setup_download_tests,
+            start_page=1,
+            auth_token=f"{PROD_AUTH_TOKEN}",
+            csv_output_path="./data/sym_files_to_download.csv",
+            zip_output_dir=f"{ZIPS_DIR}",
         )
-        if zips_count < 4:
-            # Generate some symbols ZIP files to upload, and a CSV
-            # of those symbols files to download
-            ctx.invoke(
-                setup_download_tests,
-                start_page=1,
-                auth_token=f"{PROD_AUTH_TOKEN}",
-                csv_output_path="./data/sym_files_to_download.csv",
-                zip_output_dir=f"{ZIPS_DIR}",
-            )
 
-            # Generate some symbols ZIP files to upload
-            ctx.invoke(
-                setup_upload_tests,
-                max_size=10000000,
-                start_page=1,
-                auth_token=f"{PROD_AUTH_TOKEN}",
-                outputdir=f"{ZIPS_DIR}",
-            )
-            ctx.invoke(
-                setup_upload_tests,
-                max_size=50000000,
-                start_page=10,
-                auth_token=f"{PROD_AUTH_TOKEN}",
-                outputdir=f"{ZIPS_DIR}",
-            )
-        else:
-            click.echo(f"Already have {zips_count} zip files.")
-    except Exception as exc:
-        raise click.ClickException("Unexpected error") from exc
+        # Generate some symbols ZIP files to upload
+        ctx.invoke(
+            setup_upload_tests,
+            max_size=10_000_000,
+            start_page=1,
+            auth_token=f"{PROD_AUTH_TOKEN}",
+            outputdir=f"{ZIPS_DIR}",
+        )
+        ctx.invoke(
+            setup_upload_tests,
+            max_size=50_000_000,
+            start_page=10,
+            auth_token=f"{PROD_AUTH_TOKEN}",
+            outputdir=f"{ZIPS_DIR}",
+        )
+    else:
+        click.echo(f"Already have {zips_count} zip files.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This switches the systemtests code to use tenacity.

* remove `backoff` from requirements--we weren't using it
* add `tenacity` to requirements
* implement `http_get_with_retry` and `http_head_with_retry` which retry and have appropriate timeout default
* implement `http_post` which has an appropriate timeout default
* update the systemtests code to use `http_get_with_retry`, `http_head_with_retry`, and `http_post`
* fix `get_sym_files` to only emit files where completed_at is non-None so we don't get a 404 when trying to download them

While doing that, I fixed some minor issues with the systemtests:

* remove creation and consuming of `@ECHO` lines; the message we had was wrong because download csv can contain _very large_ symbols files that take longer than 1s to download
* remove outer try/except block in `setup_tests.py` so that errors percolate up and we see a traceback
* print file size when downloading a sym file and getting an HTTP 200.

Tenacity: https://tenacity.readthedocs.io/en/latest/
