### PR TITLE
Systemtest fixes

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-backoff==2.2.1
 boltons==23.1.1
 boto3==1.28.78
 botocore==1.31.78

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,6 @@ babel==2.13.1 \
     --hash=sha256:33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900 \
     --hash=sha256:7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed
     # via sphinx
-backoff==2.2.1 \
-    --hash=sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba \
-    --hash=sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8
-    # via -r requirements.in
 boltons==23.1.1 \
     --hash=sha256:80a8cd930ff21fbf03545b9863e5799d0c3e7e0e3b2546bdaf2efccd7b3708cc \
     --hash=sha256:d2cb2fa83cf2ebe791be1e284183e8a43a1031355156a968f8e0a333ad2448fc

--- a/systemtests/README.rst
+++ b/systemtests/README.rst
@@ -14,7 +14,10 @@ Contents of this directory::
 Setting up tests
 ================
 
-Set up the tests this way::
+Before running the systemtests, you need to `build a local dev environment
+<https://tecken.readthedocs.io/en/latest/dev.html>`__.
+
+Then set up the tests this way::
 
     $ make shell
     root@e62fb7ae586f:/app# cd systemtests

--- a/systemtests/README.rst
+++ b/systemtests/README.rst
@@ -22,15 +22,18 @@ Set up the tests this way::
 
 That creates files in directories under ``data/``.
 
-You only need to set up the tests once to run the system tests against all environments.
+You only need to set up the tests once to run the system tests against all
+environments.
 
 
 Running tests
 =============
 
-First, make sure you have valid, unexpired API tokens for the environment you're testing.
+First, make sure you have valid, unexpired API tokens for the environment
+you're testing.
 
-For destructive tests run in local and stage, you need separate auth tokens for try uploads with "Upload Try Symbols Files" permissions. See Bug 1759740.
+For destructive tests run in local and stage, you need separate auth tokens for
+try uploads with "Upload Try Symbols Files" permissions. See Bug 1759740.
 
 To set auth tokens, add these to your .env file:
 
@@ -56,8 +59,7 @@ where ``ENVIRONMENT`` is one of the following:
 Rules of systemtest
 ===================
 
-1. Thou shalt not import anything from ``tecken``. Test code must be
-   self-contained.
+1. Don't run destructive tests against the prod server environment.
 
-2. Destructive tests get added in ``test_env.sh`` in the destructive tests
+2. Destructive tests get added in ``test_env.py`` in the destructive tests
    section.

--- a/systemtests/bin/download_sym_files.py
+++ b/systemtests/bin/download_sym_files.py
@@ -18,9 +18,7 @@ import requests
 
 class StdoutMetrics(BackendBase):
     def emit(self, record):
-        click.echo(
-            f"Elapsed time: {record.stat_type} {record.key} {record.value/1000:,.2f}s"
-        )
+        click.echo(f"metric: {record.stat_type} {record.key} {record.value/1000:,.2f}s")
 
 
 markus.configure([{"class": StdoutMetrics}], raise_errors=True)
@@ -59,11 +57,6 @@ def download_sym_files(base_url, csv_file):
             # Skip commented out and blank lines
             continue
 
-        if line.startswith("@ECHO"):
-            # This lets us encode directions for the viewer in the csv files
-            click.echo(click.style(line[5:].strip(), fg="yellow"))
-            continue
-
         with METRICS.timer("download_time"):
             parts = line.split(",")
 
@@ -84,6 +77,8 @@ def download_sym_files(base_url, csv_file):
                     click.echo(f">>> redirect: {item.url}")
             click.echo(f">>> final: {resp.url}")
             click.echo(f">>> status code: {resp.status_code}")
+            if resp.status_code == 200:
+                click.echo(f">>> file size {len(resp.content):,} bytes")
 
             # Compare status code with expected status code
             if resp.status_code != int(expected_status_code):

--- a/systemtests/bin/list_firefox_symbols_zips.py
+++ b/systemtests/bin/list_firefox_symbols_zips.py
@@ -67,13 +67,21 @@ def list_artifacts(taskid):
 
 
 def get_symbols_urls():
-    for taskid in tasks_by_changeset(10):
+    for taskid in tasks_by_changeset(revisions_limit=10):
         artifacts = list(list_artifacts(taskid))
-        full_zip = [a for a in artifacts if a.endswith(SYMBOLS_FULL_ZIP_SUFFIX)]
+        full_zip = [
+            artifact
+            for artifact in artifacts
+            if artifact.endswith(SYMBOLS_FULL_ZIP_SUFFIX)
+        ]
         if full_zip:
             yield QUEUE + f"task/{taskid}/artifacts/{full_zip[0]}"
         else:
-            nonfull_zip = [a for a in artifacts if a.endswith(SYMBOLS_ZIP_SUFFIX)]
+            nonfull_zip = [
+                artifact
+                for artifact in artifacts
+                if artifact.endswith(SYMBOLS_ZIP_SUFFIX)
+            ]
             if nonfull_zip:
                 yield QUEUE + f"task/{taskid}/artifacts/{nonfull_zip[0]}"
 

--- a/systemtests/bin/setup_upload_tests.py
+++ b/systemtests/bin/setup_upload_tests.py
@@ -15,13 +15,25 @@ import tempfile
 from urllib.parse import urljoin
 
 import click
+import markus
+from markus.backends import BackendBase
 
 from systemtestslib.utils import build_zip_file, download_sym_file, get_sym_files
+
 
 # Number of seconds to wait for a response from server
 CONNECTION_TIMEOUT = 600
 
 SYMBOLS_URL = "https://symbols.mozilla.org/"
+
+
+class StdoutMetrics(BackendBase):
+    def emit(self, record):
+        click.echo(f"metric: {record.stat_type} {record.key} {record.value/1000:,.2f}s")
+
+
+markus.configure([{"class": StdoutMetrics}], raise_errors=True)
+METRICS = markus.get_metrics()
 
 
 def get_size(filename):
@@ -70,57 +82,68 @@ def setup_upload_tests(max_size, start_page, auth_token, outputdir):
     )
     zip_path = os.path.join(outputdir, zip_filename)
 
-    click.echo(f"Generating ZIP file {zip_path} ...")
-    with tempfile.TemporaryDirectory(prefix="symbols") as tmpdirname:
-        sym_dir = os.path.join(tmpdirname, "syms")
-        tmp_zip_path = os.path.join(tmpdirname, zip_filename)
+    with METRICS.timer("elapsed_time"):
+        click.echo(f"Generating ZIP file {zip_path} ...")
+        with tempfile.TemporaryDirectory(prefix="symbols") as tmpdirname:
+            sym_dir = os.path.join(tmpdirname, "syms")
+            tmp_zip_path = os.path.join(tmpdirname, zip_filename)
 
-        sym_files_url = urljoin(SYMBOLS_URL, "/api/uploads/files/")
-        sym_files_generator = get_sym_files(auth_token, sym_files_url, start_page)
-        for sym_filename, sym_size in sym_files_generator:
-            if sym_filename.endswith(".0"):
-                # Skip these because there aren't SYM files for them.
-                continue
+            params = {
+                "page": start_page,
+                "size": "< 10mb",
+            }
 
-            is_try = False
-
-            if os.path.exists(tmp_zip_path):
-                # See if the new zip file is too big; if it is, we're done!
-                zip_size = os.stat(tmp_zip_path).st_size
-                click.echo(f"size: {zip_size:,}, max_size: {max_size:,}")
-                if zip_size > max_size:
-                    # Handle weird case where the first zip file we built was
-                    # too big--just use that.
-                    if not os.path.exists(zip_path):
-                        shutil.copy(tmp_zip_path, zip_path)
-                    break
-
-                # This zip file isn't too big, so copy it over.
-                shutil.copy(tmp_zip_path, zip_path)
-
-            click.echo(
-                click.style(f"Adding {sym_filename} ({sym_size:,}) ...", fg="yellow")
+            sym_files_generator = get_sym_files(
+                baseurl=SYMBOLS_URL,
+                auth_token=auth_token,
+                params=params,
             )
+            for sym_filename, sym_size in sym_files_generator:
+                if sym_filename.endswith(".0"):
+                    # Skip these because there aren't SYM files for them.
+                    continue
 
-            # Download SYM file into temporary directory
-            if sym_filename.startswith("try/"):
-                sym_filename = sym_filename[4:]
-                is_try = True
+                is_try = False
 
-            if sym_filename.startswith("v1/"):
-                sym_filename = sym_filename[3:]
+                if os.path.exists(tmp_zip_path):
+                    # See if the new zip file is too big; if it is, we're done!
+                    zip_size = os.stat(tmp_zip_path).st_size
+                    click.echo(f"size: {zip_size:,}, max_size: {max_size:,}")
+                    if zip_size > max_size:
+                        # Handle weird case where the first zip file we built was
+                        # too big--just use that.
+                        if not os.path.exists(zip_path):
+                            shutil.copy(tmp_zip_path, zip_path)
+                        break
 
-            url = urljoin(SYMBOLS_URL, sym_filename)
-            if is_try:
-                url = url + "?try"
-            sym_file = os.path.join(sym_dir, sym_filename)
-            download_sym_file(url, sym_file)
+                    # This zip file isn't too big, so copy it over.
+                    shutil.copy(tmp_zip_path, zip_path)
 
-            # Build the new zip file
-            build_zip_file(tmp_zip_path, sym_dir)
+                click.echo(
+                    click.style(
+                        f"Adding {sym_filename} ({sym_size:,}) ...", fg="yellow"
+                    )
+                )
 
-    zip_size = os.stat(zip_path).st_size
-    click.echo(f"Completed {zip_path} ({zip_size:,})!")
+                # Download SYM file into temporary directory
+                if sym_filename.startswith("try/"):
+                    sym_filename = sym_filename[4:]
+                    is_try = True
+
+                if sym_filename.startswith("v1/"):
+                    sym_filename = sym_filename[3:]
+
+                url = urljoin(SYMBOLS_URL, sym_filename)
+                if is_try:
+                    url = url + "?try"
+                sym_file = os.path.join(sym_dir, sym_filename)
+                download_sym_file(url, sym_file)
+
+                # Build the new zip file
+                build_zip_file(tmp_zip_path, sym_dir)
+
+        zip_size = os.stat(zip_path).st_size
+        click.echo(f"Completed {zip_path} ({zip_size:,})!")
 
 
 if __name__ == "__main__":

--- a/systemtests/setup_tests.py
+++ b/systemtests/setup_tests.py
@@ -27,44 +27,38 @@ def setup_tests(ctx):
         os.makedirs(ZIPS_DIR)
 
     click.echo("Generating systemtest data files ...")
-    try:
-        zips_count = len(
-            [
-                name
-                for name in os.listdir(f"{ZIPS_DIR}")
-                if os.path.isfile(f"{ZIPS_DIR}/{name}")
-            ]
+    zips_count = len(
+        [name for name in os.listdir(ZIPS_DIR) if os.path.isfile(f"{ZIPS_DIR}/{name}")]
+    )
+    if zips_count < 4:
+        # Generate some symbols ZIP files to upload, and a CSV
+        # of those symbols files to download
+        ctx.invoke(
+            setup_download_tests,
+            start_page=1,
+            auth_token=PROD_AUTH_TOKEN,
+            csv_output_path="./data/sym_files_to_download.csv",
+            zip_output_dir=ZIPS_DIR,
         )
-        if zips_count < 4:
-            # Generate some symbols ZIP files to upload, and a CSV
-            # of those symbols files to download
-            ctx.invoke(
-                setup_download_tests,
-                start_page=1,
-                auth_token=f"{PROD_AUTH_TOKEN}",
-                csv_output_path="./data/sym_files_to_download.csv",
-                zip_output_dir=f"{ZIPS_DIR}",
-            )
+        click.echo("")
 
-            # Generate some symbols ZIP files to upload
-            ctx.invoke(
-                setup_upload_tests,
-                max_size=10000000,
-                start_page=1,
-                auth_token=f"{PROD_AUTH_TOKEN}",
-                outputdir=f"{ZIPS_DIR}",
-            )
-            ctx.invoke(
-                setup_upload_tests,
-                max_size=50000000,
-                start_page=10,
-                auth_token=f"{PROD_AUTH_TOKEN}",
-                outputdir=f"{ZIPS_DIR}",
-            )
-        else:
-            click.echo(f"Already have {zips_count} zip files.")
-    except Exception as exc:
-        raise click.ClickException("Unexpected error") from exc
+        # Generate some symbols ZIP files to upload
+        ctx.invoke(
+            setup_upload_tests,
+            max_size=2_000_000,
+            start_page=1,
+            auth_token=PROD_AUTH_TOKEN,
+            outputdir=ZIPS_DIR,
+        )
+        ctx.invoke(
+            setup_upload_tests,
+            max_size=4_000_000,
+            start_page=10,
+            auth_token=PROD_AUTH_TOKEN,
+            outputdir=ZIPS_DIR,
+        )
+    else:
+        click.echo(f"Already have {zips_count} zip files.")
 
 
 if __name__ == "__main__":

--- a/systemtests/test_env.py
+++ b/systemtests/test_env.py
@@ -45,19 +45,19 @@ def test_env(ctx, env):
     Note: Due to Bug 1759740, we need separate auth tokens
     for try uploads with "Upload Try Symbols Files" permissions.
     """
-    destructive_tests = 0
-    bad_token_test = 0
+    destructive_tests = False
+    bad_token_test = False
     tecken_host = ""
     auth_token = ""
 
     if env == "local":
-        destructive_tests = 1
-        bad_token_test = 1
+        destructive_tests = True
+        bad_token_test = True
         tecken_host = "http://web:8000/"
         auth_token = os.environ["LOCAL_AUTH_TOKEN"]
     elif env == "stage":
-        destructive_tests = 1
-        bad_token_test = 1
+        destructive_tests = True
+        bad_token_test = True
         tecken_host = "https://symbols.stage.mozaws.net/"
         auth_token = os.environ["STAGE_AUTH_TOKEN"]
     elif env == "prod":
@@ -73,8 +73,7 @@ def test_env(ctx, env):
 
     click.echo(click.style(f"tecken_host: {tecken_host}\n", fg="yellow"))
 
-    # DESTRUCTIVE TESTS
-    if destructive_tests == 1:
+    if destructive_tests:
         click.echo(click.style(">>> UPLOAD TEST (DESTRUCTIVE)", fg="yellow"))
         for fn in [
             name
@@ -89,56 +88,71 @@ def test_env(ctx, env):
             ctx.invoke(
                 upload_symbols,
                 expect_code=201,
-                auth_token=f"{auth_token}",
-                base_url=f"{tecken_host}",
+                auth_token=auth_token,
+                base_url=tecken_host,
                 symbolsfile=f"{ZIPS_DIR}{fn}",
             )
+        click.echo("")
 
         click.echo(
             click.style(">>> UPLOAD BY DOWNLOAD TEST (DESTRUCTIVE)", fg="yellow")
         )
-        URL = ctx.invoke(list_firefox_symbols_zips, number=1, max_size=1000000000)[0]
+        url = ctx.invoke(list_firefox_symbols_zips, number=1, max_size=1000000000)[0]
         ctx.invoke(
             upload_symbols_by_download,
-            base_url=f"{tecken_host}",
-            auth_token=f"{auth_token}",
-            url=f"{URL}",
+            base_url=tecken_host,
+            auth_token=auth_token,
+            url=url,
         )
-        click.echo("\n")
     else:
-        click.echo(click.style(">>> SKIPPING DESTRUCTIVE TESTS\n", fg="yellow"))
+        click.echo(click.style(">>> SKIPPING DESTRUCTIVE TESTS", fg="yellow"))
+    click.echo("")
 
-    if bad_token_test == 1:
-        # This tests a situation that occurs when nginx is a reverse-proxy to
-        # tecken and doesn't work in the local dev environment. bug 1655944
+    if bad_token_test:
+        # Pick a zip file that's > 120kb and upload it with a bad token. This tests a
+        # situation that occurs when nginx is a reverse-proxy to Tecken and doesn't
+        # correctly return a response if the stream isn't exhausted. This doesn't work
+        # in the local dev environment. bug #1655944
         click.echo(
             click.style(
-                ">>> UPLOAD WITH BAD TOKEN TEST--this should return a 403 and error and not a RemoteDisconnected",
+                (
+                    ">>> UPLOAD WITH BAD AUTH TOKEN TEST--this should return an HTTP "
+                    "403 and not a RemoteDisconnected"
+                ),
                 fg="yellow",
             )
         )
-        first_file = [
-            name
+        zip_files = [
+            f"{ZIPS_DIR}{name}"
             for name in os.listdir(f"{ZIPS_DIR}")
-            if os.path.isfile(f"{ZIPS_DIR}{name}")
-        ][0]
-        ctx.invoke(
-            upload_symbols,
-            expect_code=403,
-            auth_token="badtoken",
-            base_url=f"{tecken_host}",
-            symbolsfile=f"{ZIPS_DIR}{first_file}",
-        )
+            if (
+                os.path.isfile(f"{ZIPS_DIR}{name}")
+                and os.path.getsize(f"{ZIPS_DIR}{name}") > 120_000
+            )
+        ]
 
-    click.echo("\n")
+        if not zip_files:
+            click.echo(
+                click.style(
+                    ">>> No zip files > 120kb; skipping bad token test", fg="red"
+                )
+            )
+        else:
+            ctx.invoke(
+                upload_symbols,
+                expect_code=403,
+                auth_token="badtoken",
+                base_url=tecken_host,
+                symbolsfile=zip_files[0],
+            )
+            click.echo("")
 
     click.echo(click.style(">>> DOWNLOAD TEST", fg="yellow"))
     ctx.invoke(
         download_sym_files,
-        base_url=f"{tecken_host}",
+        base_url=tecken_host,
         csv_file="./data/sym_files_to_download.csv",
     )
-    click.echo("\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`systemtestslib/utils.py`: Change `get_sym_files` to only emit files where `completed_at` is non-None so we don't get a 404 when trying to download them.

`systemtestslib/utils.py`: Shuffle around parameters in `get_sym_files` and callers.

`systemtestslib/utils.py`: Optimize `get_sym_files` for the case where someone uploaded a ton of try symbols recently--this will move through the pages faster reducing the number of GET requests.

`test_env.py`: Converts integer values to bools for flags, tweaks the output code, and improves a comment about the bad token test. This also adjusts the bad token test to make sure it uses a zip file that's greater than 120kb which we think we need to trigger the situation the bad token test tests.

`bin/setup_upload_tests.py`:
`bin/setup_download_tests.py`: When looking for appropriate symbols to use in the tests, restrict files by size to reduce the time it takes to download, zip, and upload the files which will reduce the time it takes to set up and run the tests.

`setup_tests.py`: Drops the zip file sizes for upload tests to 2mb and 4mb because that's plenty big; this reduces the number of files setup has to download and add to the zip file.

Add timings for setup scripts.

Fix some documentation, comments, curiosities, etc.

Remove backoff dependency--we're not using it.