### PR TITLE
 bug-1889200: specify release in sentry-wrap.py

### DIFF
--- a/bin/run_migrations.sh
+++ b/bin/run_migrations.sh
@@ -18,7 +18,7 @@ PRECMD=""
 # send errors to sentry.
 if [ -n "${SENTRY_DSN:-}" ]; then
     echo "SENTRY_DSN defined--enabling sentry."
-    PRECMD="python bin/sentry-wrap.py wrap-process --timeout=600 --"
+    PRECMD="python bin/sentry_wrap.py wrap-process --timeout=600 --"
 else
     echo "SENTRY_DSN not defined--not enabling sentry."
 fi

--- a/bin/run_web_disk_manager.sh
+++ b/bin/run_web_disk_manager.sh
@@ -20,10 +20,10 @@ SLEEP_SECONDS=60
 PROCESS_TIMEOUT_SECONDS=120
 
 # Run disk manager in a loop sleeping SLEEP_SECONDS between rounds. Wrap in
-# sentry-wrap so it sends errors to Sentry.
+# sentry_wrap so it sends errors to Sentry.
 while true
 do
-    python /app/bin/sentry-wrap.py wrap-process --timeout="${PROCESS_TIMEOUT_SECONDS}" -- \
+    python /app/bin/sentry_wrap.py wrap-process --timeout="${PROCESS_TIMEOUT_SECONDS}" -- \
         python /app/manage.py remove_orphaned_files --skip-checks
     sleep "${SLEEP_SECONDS}"
 done

--- a/bin/sentry_wrap.py
+++ b/bin/sentry_wrap.py
@@ -19,7 +19,6 @@ import os
 from pathlib import Path
 import shlex
 import subprocess
-import sys
 import time
 import traceback
 
@@ -63,13 +62,7 @@ def get_release_name(basedir):
     return f"{version}:{commit}"
 
 
-def set_up_sentry():
-    sentry_dsn = os.environ.get("SENTRY_DSN")
-
-    if not sentry_dsn:
-        click.echo("SENTRY_DSN is not defined. Exiting.", err=True)
-        sys.exit(1)
-
+def set_up_sentry(sentry_dsn):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     base_dir = os.path.dirname(current_dir)
     release = get_release_name(base_dir)
@@ -84,7 +77,13 @@ def cli_main():
 @cli_main.command()
 @click.pass_context
 def test_sentry(ctx):
-    set_up_sentry()
+    sentry_dsn = os.environ.get("SENTRY_DSN")
+
+    if not sentry_dsn:
+        click.echo("SENTRY_DSN is not defined. Exiting.", err=True)
+        ctx.exit(1)
+
+    set_up_sentry(sentry_dsn)
 
     capture_message("Sentry test")
     click.echo("Success. Check Sentry.")
@@ -107,9 +106,15 @@ def wrap_process(ctx, timeout, verbose, cmd):
     if not cmd:
         raise click.UsageError("CMD required")
 
-    set_up_sentry()
+    sentry_dsn = os.environ.get("SENTRY_DSN")
+
+    if not sentry_dsn:
+        click.echo("SENTRY_DSN is not defined. Exiting.", err=True)
+        ctx.exit(1)
 
     start_time = time.time()
+
+    set_up_sentry(sentry_dsn)
 
     cmd = " ".join(cmd)
     cmd_args = shlex.split(cmd)

--- a/bin/sentry_wrap.py
+++ b/bin/sentry_wrap.py
@@ -7,10 +7,10 @@
 # Wraps a command such that if it fails, an error report is sent to the Sentry service
 # specified by SENTRY_DSN in the environment.
 #
-# Usage: python bin/sentry-wrap.py wrap-process -- [CMD]
+# Usage: python bin/sentry_wrap.py wrap-process -- [CMD]
 #    Wraps a process in error-reporting Sentry goodness.
 #
-# Usage: python bin/sentry-wrap.py test-sentry
+# Usage: python bin/sentry_wrap.py test-sentry
 #    Tests Sentry configuration and connection.
 
 

--- a/tecken/libdockerflow.py
+++ b/tecken/libdockerflow.py
@@ -45,6 +45,7 @@ def check_storage_urls(app_configs, **kwargs):
     return errors
 
 
+# Please update bin/sentry_wrap.py when updating this function.
 def get_version_info(basedir):
     """Returns version.json data from deploys"""
     path = Path(basedir) / "version.json"
@@ -58,6 +59,7 @@ def get_version_info(basedir):
         return {}
 
 
+# Please update bin/sentry_wrap.py when updating this function.
 def get_release_name(basedir):
     """Return a friendly name for the release that is running
 


### PR DESCRIPTION
Because:
* We want to be able to mark an error hit in `sentry_wrap.py` as "Resolved in the next release" in Sentry, but we weren't passing in the `release` in this context (see this [reference error's events](https://mozilla.sentry.io/issues/4723701783/events/?project=6700123)).

![Screenshot 2024-04-23 at 4 57 46 PM](https://github.com/mozilla-services/tecken/assets/17437436/c99638cf-21fa-4fee-b088-96ae7c108c44)

This commit:
* Passes `release` when calling `sentry_sdk.init` in `sentry_wrap.py`.