### PR TITLE
bug-1896962: improve Token admin

### DIFF
--- a/tecken/tokens/admin.py
+++ b/tecken/tokens/admin.py
@@ -24,6 +24,7 @@ class TokenAdmin(admin.ModelAdmin):
     def key_truncated(self, obj):
         return obj.key[:12] + "..."
 
+    @admin.display(description="Permissions")
     def get_permissions(self, obj):
         return ", ".join(perm.codename for perm in obj.permissions.all())
 

--- a/tecken/tokens/admin.py
+++ b/tecken/tokens/admin.py
@@ -28,5 +28,6 @@ class TokenAdmin(admin.ModelAdmin):
     def get_permissions(self, obj):
         return ", ".join(perm.codename for perm in obj.permissions.all())
 
+    @admin.display(description="Email")
     def get_user_email(self, obj):
         return obj.user.email

--- a/tecken/tokens/admin.py
+++ b/tecken/tokens/admin.py
@@ -9,12 +9,22 @@ from tecken.tokens.models import Token
 
 @admin.register(Token)
 class TokenAdmin(admin.ModelAdmin):
-    date_hierarchy = "created_at"
     list_display = [
-        "user_email",
+        "key_truncated",
+        "get_user_email",
+        "get_permissions",
         "expires_at",
-        "created_at",
+        "notes",
     ]
 
-    def user_email(self, obj):
+    list_filter = ["permissions"]
+    search_fields = ["user__email", "notes"]
+
+    def key_truncated(self, obj):
+        return obj.key[:12] + "..."
+
+    def get_permissions(self, obj):
+        return ", ".join(perm.codename for perm in obj.permissions.all())
+
+    def get_user_email(self, obj):
         return obj.user.email

--- a/tecken/tokens/admin.py
+++ b/tecken/tokens/admin.py
@@ -20,6 +20,7 @@ class TokenAdmin(admin.ModelAdmin):
     list_filter = ["permissions"]
     search_fields = ["user__email", "notes"]
 
+    @admin.display(description="Key")
     def key_truncated(self, obj):
         return obj.key[:12] + "..."
 


### PR DESCRIPTION
This impproves the Token admin making it effectively like the one in Crash Stats. One nice thing is that tokens are searchable now.

To test:

1. create a token:
   ```
   docker compose run --rm web bash python manage.py createtoken EMAIL TOKEN
   ```
2. run everything with `make run`
3. log in, go to the admin, go to the token manager
4. view token list
5. search tokens using email address substring