### PR TITLE
bug-1827507: Fix GCS emulator settings.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,7 +156,11 @@ services:
     build:
       context: docker/images/gcs-emulator
     image: local/tecken_gcs_emulator
-    command: -port 8001 -scheme http
+    command: >-
+      -port 8001
+      -scheme http
+      -external-url http://gcs-emulator:"${EXPOSE_GCS_EMULATOR_PORT:-8001}"
+      -public-host gcs-emulator:"${EXPOSE_GCS_EMULATOR_PORT:-8001}"
     ports:
       - "${EXPOSE_GCS_EMULATOR_PORT:-8001}:8001"
     healthcheck:


### PR DESCRIPTION
The GCS emulator needs special settings to allow public downloads and retriable uploads.

Public downloads are required so we can redirect to files in the GCS emulator from the download API. They are enabled by the `-public-host` command-Line option.

Retriable uploads are used by the `Blob.upload_from_file()` method. They return a redirect in the initial request, which requires the server to know its external URL, which can be set using `-external-url`.