### PR TITLE
Fix `make devcontainerbuild` command when .devcontainer-build file doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ all-metrics-keys.json
 coverage
 coverage.xml
 *.db
+.devcontainer-build
 dist/
 .docker-build
 docs/_build

--- a/Makefile
+++ b/Makefile
@@ -60,12 +60,12 @@ run: .env .docker-build  ## | Run the web app and services.
 		web frontend fakesentry
 
 .PHONY: devcontainerbuild
-devcontainerbuild: .env .docker-build .devcontainer-build  ## | Build VS Code development container.
+devcontainerbuild: .env .docker-build  ## | Build VS Code development container.
 	${DC} build devcontainer
 	touch .devcontainer-build
 
 .PHONY: devcontainer
-devcontainer: .env .docker-build  ## | Run VS Code development container.
+devcontainer: .env .docker-build .devcontainer-build ## | Run VS Code development container.
 	${DC} up --detach devcontainer
 
 .PHONY: stop


### PR DESCRIPTION
Because:
* The [Tecken docs](https://tecken.readthedocs.io/en/latest/dev.html#how-to-set-up-a-development-container-for-vs-code) suggest running this command to build the devcontainer docker container.
* The command had a cyclic dependency on the .devcontainer-build file it is intended to create, causing it to enter an infinite loop when running the command locally if the .devcontainer-build file doesn't yet exist.

This commit:
* Moves the .devcontainer-build file requirement from `make devcontainerbuild` to the `make devcontainer` command.
* adds .devcontainer-build to .gitignore