### PR TITLE
Don't reference exposed port in gcs emulator options

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,8 +159,8 @@ services:
     command: >-
       -port 8001
       -scheme http
-      -external-url http://gcs-emulator:"${EXPOSE_GCS_EMULATOR_PORT:-8001}"
-      -public-host gcs-emulator:"${EXPOSE_GCS_EMULATOR_PORT:-8001}"
+      -external-url http://gcs-emulator:8001
+      -public-host gcs-emulator:8001
     ports:
       - "${EXPOSE_GCS_EMULATOR_PORT:-8001}:8001"
     healthcheck:


### PR DESCRIPTION
`$EXPOSE_GCS_EMULATOR_PORT` is the port used with `localhost`, while the port used with `gcs-emulator` will always be 8001.