### PR TITLE
bug-1909637: allow searching for files from regular and try symbol uploads

### DIFF
--- a/frontend/src/Files.js
+++ b/frontend/src/Files.js
@@ -201,6 +201,7 @@ class DisplayFiles extends React.PureComponent {
     const filter = this.props.filter;
     this.refs.key.value = filter.key || "";
     this.refs.size.value = filter.size || "";
+    this.refs.upload_type.value = filter.upload_type || "";
     this.refs.created_at.value = filter.created_at || "";
     this.refs.bucketName.value = filter.bucket_name || "";
   }
@@ -209,6 +210,7 @@ class DisplayFiles extends React.PureComponent {
     event.preventDefault();
     const key = this.refs.key.value.trim();
     const size = this.refs.size.value.trim();
+    const upload_type = this.refs.upload_type.value.trim();
     const created_at = this.refs.created_at.value.trim();
     const bucketName = this.refs.bucketName.value.trim();
     this.props.updateFilter({
@@ -217,6 +219,7 @@ class DisplayFiles extends React.PureComponent {
       size,
       created_at,
       bucket_name: bucketName,
+      upload_type: upload_type,
     });
   };
 
@@ -224,6 +227,7 @@ class DisplayFiles extends React.PureComponent {
     this.refs.key.value = "";
     this.refs.size.value = "";
     this.refs.bucketName.value = "";
+    this.refs.upload_type.value = "";
     this.refs.created_at.value = "";
     this.submitForm(event);
   };
@@ -238,6 +242,7 @@ class DisplayFiles extends React.PureComponent {
               <th>Key</th>
               <th>Size</th>
               <th>Bucket</th>
+              <th>Upload type</th>
               <th>Uploaded</th>
               <th
                 className="bool-row is-clipped"
@@ -254,6 +259,7 @@ class DisplayFiles extends React.PureComponent {
               <th>Time to complete</th>
             </tr>
           </thead>
+
           <tfoot>
             <tr>
               <td>
@@ -281,6 +287,15 @@ class DisplayFiles extends React.PureComponent {
                   placeholder="filter bucket ..."
                   style={{ width: 140 }}
                 />
+              </td>
+              <td>
+                <span className="select">
+                  <select name="upload_type" ref="upload_type">
+                    <option></option>
+                    <option>regular</option>
+                    <option>try</option>
+                  </select>
+                </span>
               </td>
               <td>
                 <input
@@ -317,6 +332,20 @@ class DisplayFiles extends React.PureComponent {
                   <td>{formatFileSize(file.size)}</td>
                   <td>{file.bucket_name}</td>
                   <td>
+                    {file.upload && file.upload.upload_type === "try" ? (
+                      <span className="tag is-info" title="try symbol upload">
+                        try
+                      </span>
+                    ) : (
+                      <span
+                        className="tag"
+                        title="{file.upload.upload_type} symbol upload"
+                      >
+                        {file.upload.upload_type}
+                      </span>
+                    )}
+                  </td>
+                  <td>
                     {file.upload ? (
                       <Link
                         to={`/uploads/upload/${file.upload.id}`}
@@ -327,14 +356,6 @@ class DisplayFiles extends React.PureComponent {
                     ) : (
                       <DisplayDate date={file.created_at} />
                     )}{" "}
-                    {file.upload && file.upload.try_symbols ? (
-                      <span
-                        className="tag is-info"
-                        title="Part of a Try build upload"
-                      >
-                        Try
-                      </span>
-                    ) : null}
                   </td>
                   <td>{BooleanIcon(file.update)}</td>
                   <td>{BooleanIcon(file.compressed)}</td>

--- a/tecken/api/forms.py
+++ b/tecken/api/forms.py
@@ -209,6 +209,9 @@ class FileUploadsForm(UploadsForm):
     size = forms.CharField(required=False)
     created_at = forms.CharField(required=False)
     completed_at = forms.CharField(required=False)
+    upload_type = forms.ChoiceField(
+        choices=[("", ""), ("try", "try"), ("regular", "regular")], required=False
+    )
     key = forms.CharField(required=False)
     update = forms.BooleanField(required=False)
     compressed = forms.BooleanField(required=False)


### PR DESCRIPTION
Previously, you could sort of search for try uploads by searching for "try/" in the key. But you couldn't search for regular uploads.

We recently changed the key data in the model, so "try/" no longer appears in the key which breaks this flimsy filtering method.

This introduces a new upload_type filter field that lets you filter on nothing (""), try upload files ("try"), and regular upload files ("regular").