### PR TITLE
bug-1910180: fix file upload upload info try_symbols value

### DIFF
--- a/tecken/api/views.py
+++ b/tecken/api/views.py
@@ -557,6 +557,7 @@ def upload_file(request, id):
             "user": {"id": upload_obj.user.id, "email": upload_obj.user.email},
             "size": upload_obj.size,
             "bucket_name": upload_obj.bucket_name,
+            "try_symbols": upload_obj.try_symbols,
             "skipped_keys": upload_obj.skipped_keys or [],
             "ignored_keys": upload_obj.ignored_keys or [],
             "download_url": upload_obj.download_url,

--- a/tecken/tests/test_api.py
+++ b/tecken/tests/test_api.py
@@ -1136,8 +1136,42 @@ def test_file_upload_try_upload(client):
     url = reverse("api:upload_file", args=(file_upload.id,))
     response = client.get(url)
     assert response.status_code == 200
-    data = response.json()["file"]
-    assert data["url"] == "/foo.pdb/deadbeaf123/foo.sym?try"
+    data = response.json()
+    assert data == {
+        "file": {
+            "bucket_name": "",
+            "code_file": None,
+            "code_id": None,
+            "completed_at": None,
+            "compressed": False,
+            "created_at": ANY,
+            "debug_filename": None,
+            "debug_id": None,
+            "generator": None,
+            "id": file_upload.id,
+            "key": "foo.pdb/deadbeaf123/foo.sym",
+            "size": 1234,
+            "update": False,
+            "upload": {
+                "bucket_name": "",
+                "completed_at": None,
+                "created_at": ANY,
+                "download_url": None,
+                "filename": "",
+                "id": upload.id,
+                "ignored_keys": [],
+                "redirect_urls": [],
+                "size": 123_456,
+                "skipped_keys": [],
+                "try_symbols": True,
+                "user": {
+                    "email": "peterbe@example.com",
+                    "id": user.id,
+                },
+            },
+            "url": "/foo.pdb/deadbeaf123/foo.sym?try",
+        }
+    }
 
 
 class Test_syminfo:


### PR DESCRIPTION
This carries the try_symbols value from the Upload instance to the file upload upload info section in the frontend.