### PR TITLE
bug-1909013: remove upload now view forms

### DIFF
--- a/docs/upload.rst
+++ b/docs/upload.rst
@@ -282,7 +282,7 @@ To get access to our stage server:
    <https://symbols.stage.mozaws.net/>`__. When you log in, an account will be
    created automatically.
 
-2. Ask a Tecken admin (currently willkg) to grant you upload permissions.
+2. Ask a Tecken admin to grant you upload permissions.
 
    We hang out in `#crashreporting matrix channel
    <https://chat.mozilla.org/#/room/#crashreporting:mozilla.org>`_.

--- a/frontend/src/UploadNow.js
+++ b/frontend/src/UploadNow.js
@@ -6,8 +6,6 @@
 import React, { PureComponent } from "react";
 import { Link } from "react-router-dom";
 
-import { Loading, formatFileSize } from "./Common";
-import Fetch from "./Fetch";
 import store from "./Store";
 
 export default class UploadNow extends PureComponent {
@@ -16,38 +14,16 @@ export default class UploadNow extends PureComponent {
     this.pageTitle = "Symbol Upload Now";
     this.state = {
       loading: false,
-      possibleUploadUrls: [],
-      // upload: null
     };
   }
+
   componentWillMount() {
     store.resetApiRequests();
   }
 
   componentDidMount() {
     document.title = this.pageTitle;
-    this.fetchPossibleUploadUrls();
   }
-
-  fetchPossibleUploadUrls = () => {
-    Fetch("/api/uploads/_possible_upload_urls/").then((r) => {
-      if (store.fetchError) {
-        store.fetchError = null;
-      }
-      this.setState({ loading: false });
-      if (r.ok) {
-        this.setState({
-          validationError: null,
-          warning: null,
-        });
-        r.json().then((data) => {
-          this.setState({ possibleUploadUrls: data.urls });
-        });
-      } else {
-        store.fetchError = r;
-      }
-    });
-  };
 
   render() {
     return (
@@ -88,24 +64,6 @@ export default class UploadNow extends PureComponent {
           </div>
         )}
 
-        {this.state.loading && <Loading />}
-
-        <div className="section">
-          <div className="container">
-            <h3 className="title is-3">Upload archive file via web</h3>
-            <UploadForm possibleUploadUrls={this.state.possibleUploadUrls} />
-          </div>
-        </div>
-
-        <div className="section">
-          <div className="container">
-            <h3 className="title is-3">Upload by download URL</h3>
-            <UploadByDownloadForm
-              possibleUploadUrls={this.state.possibleUploadUrls}
-            />
-          </div>
-        </div>
-
         <div className="section">
           <div className="container">
             <h3 className="title is-3">Upload via command line</h3>
@@ -130,7 +88,7 @@ class AboutCommandLineUpload extends PureComponent {
 
         <p>
           <a
-            href="https://tecken.readthedocs.io/en/latest/upload.html#how-it-works"
+            href="https://tecken.readthedocs.io/en/latest/upload.html"
             rel="noopener noreferrer"
           >
             Use the official documentation
@@ -140,320 +98,4 @@ class AboutCommandLineUpload extends PureComponent {
       </div>
     );
   }
-}
-
-class UploadForm extends PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      loading: false,
-      fileInfo: null,
-      warning: null,
-      validationError: null,
-    };
-  }
-  submitForm = (event) => {
-    event.preventDefault();
-    if (!this.filesInput.files.length) {
-      return;
-    }
-    const formData = new FormData();
-    const file = this.filesInput.files[0];
-    formData.append(file.name, file);
-    if (this.refs.try.checked) {
-      formData.append("try", true);
-    }
-    if (this.preferredBucketName && this.preferredBucketName.value) {
-      formData.append("bucket_name", this.preferredBucketName.value);
-    }
-    this.setState({ loading: true, validationError: null });
-    return fetch("/upload/", {
-      method: "POST",
-      body: formData,
-    }).then((r) => {
-      if (store.fetchError) {
-        store.fetchError = null;
-      }
-      this.setState({ loading: false });
-      if (r.status === 201) {
-        this.setState({
-          validationError: null,
-          warning: null,
-        });
-        r.json().then((data) => {
-          const upload = data.upload;
-          store.setRedirectTo(`/uploads/upload/${upload.id}`, {
-            message: "Symbols uploaded.",
-            success: true,
-          });
-        });
-      } else if (r.status === 400) {
-        r.json().then((data) => {
-          this.setState({
-            validationError: data.error,
-            warning: null,
-          });
-        });
-      } else {
-        store.fetchError = r;
-      }
-    });
-  };
-
-  onFileInputChange = (event) => {
-    const file = this.filesInput.files[0];
-    if (!/\.(zip|tar|tag\.gz)$/i.test(file.name)) {
-      this.setState({
-        warning: "Make sure the file is a zip, tar.gz or tar file.",
-      });
-    } else if (this.state.warning) {
-      this.setState({ warning: null });
-    }
-    this.setState({
-      fileInfo: {
-        name: file.name,
-        size: file.size,
-        type: file.type,
-      },
-    });
-  };
-
-  render() {
-    return (
-      <form onSubmit={this.submitForm}>
-        {this.state.validationError && (
-          <article className="message is-danger">
-            <div className="message-body">{this.state.validationError}</div>
-          </article>
-        )}
-        <div className="field">
-          <div className="file has-name is-fullwidth">
-            <label className="file-label">
-              <input
-                className="file-input"
-                type="file"
-                name="archive"
-                onChange={this.onFileInputChange}
-                ref={(input) => {
-                  this.filesInput = input;
-                }}
-              />
-              <span className="file-cta">
-                <span className="file-icon">
-                  <i className="fa fa-upload" />
-                </span>
-                <span className="file-label">Choose a file…</span>
-              </span>
-
-              <span className="file-name">
-                {this.state.fileInfo ? (
-                  <ShowFileInfo info={this.state.fileInfo} />
-                ) : (
-                  <i>no file selected yet</i>
-                )}
-              </span>
-            </label>
-          </div>
-        </div>
-        <div className="field">
-          <div className="control">
-            <label className="checkbox">
-              <input type="checkbox" name="try" ref="try" value="yes" /> This is{" "}
-              <b>Try</b> build symbols
-            </label>
-          </div>
-        </div>
-        <PossibleUploadUrlsField
-          possibleUploadUrls={this.props.possibleUploadUrls}
-          preferredBucketName={(input) => (this.preferredBucketName = input)}
-        />
-        {this.state.warning && (
-          <article className="message is-warning">
-            <div className="message-body">{this.state.warning}</div>
-          </article>
-        )}
-        <div className="field is-grouped">
-          <p className="control">
-            <button
-              type="submit"
-              className={
-                this.state.loading
-                  ? "button is-primary is-loading"
-                  : "button is-primary"
-              }
-              disabled={this.state.loading}
-            >
-              Upload
-            </button>
-          </p>
-          <p className="control">
-            <Link to="/uploads" className="button is-light">
-              Cancel
-            </Link>
-          </p>
-        </div>
-      </form>
-    );
-  }
-}
-
-const ShowFileInfo = ({ info }) => (
-  <span>
-    {info.name}{" "}
-    <small>
-      ({formatFileSize(info.size)} {info.type})
-    </small>
-  </span>
-);
-
-class UploadByDownloadForm extends UploadForm {
-  constructor(props) {
-    super(props);
-    this.state = {
-      url: null,
-    };
-  }
-  submitForm = (event) => {
-    event.preventDefault();
-    const url = this.refs.url.value.trim();
-    if (!url) {
-      return;
-    }
-    const formData = new FormData();
-    formData.append("url", url);
-    if (this.refs.try.checked) {
-      formData.append("try", true);
-    }
-    if (this.preferredBucketName && this.preferredBucketName.value) {
-      formData.append("bucket_name", this.preferredBucketName.value);
-    }
-    this.setState({ loading: true, validationError: null });
-    return fetch("/upload/", {
-      method: "POST",
-      body: formData,
-    }).then((r) => {
-      this.setState({ loading: false });
-      if (store.fetchError) {
-        store.fetchError = null;
-      }
-      if (r.status === 201) {
-        this.setState({
-          validationError: null,
-          warning: null,
-        });
-        r.json().then((data) => {
-          const upload = data.upload;
-          store.setRedirectTo(`/uploads/upload/${upload.id}`, {
-            message: "Symbols URL downloaded.",
-            success: true,
-          });
-        });
-      } else if (r.status === 400) {
-        r.json().then((data) => {
-          this.setState({
-            validationError: data.error,
-            warning: null,
-          });
-        });
-      } else {
-        store.fetchError = r;
-      }
-    });
-  };
-
-  onFileInputChange = (event) => {
-    const file = this.filesInput.files[0];
-    if (!/\.(zip|tar|tag\.gz)$/i.test(file.name)) {
-      this.setState({
-        warning: "Make sure the file is a zip, tar.gz or tar file.",
-      });
-    } else if (this.state.warning) {
-      this.setState({ warning: null });
-    }
-    this.setState({ fileName: file.name });
-  };
-
-  render() {
-    return (
-      <form onSubmit={this.submitForm}>
-        {this.state.validationError && (
-          <article className="message is-danger">
-            <div className="message-body">{this.state.validationError}</div>
-          </article>
-        )}
-        <div className="field">
-          <input
-            className="input"
-            type="text"
-            placeholder="E.g. https://download.example.com/YYYYMMDD/symbols.zip"
-            ref="url"
-          />
-          <p className="help">
-            The upload by download is restricted to a list of allowed domains
-            from which you can download.
-          </p>
-        </div>
-        <div className="field">
-          <div className="control">
-            <label className="checkbox">
-              <input type="checkbox" name="try" ref="try" value="yes" /> This is{" "}
-              <b>Try</b> build symbols
-            </label>
-          </div>
-        </div>
-        <PossibleUploadUrlsField
-          possibleUploadUrls={this.props.possibleUploadUrls}
-          preferredBucketName={(input) => (this.preferredBucketName = input)}
-        />
-        {this.state.warning && (
-          <article className="message is-warning">
-            <div className="message-body">{this.state.warning}</div>
-          </article>
-        )}
-        <div className="field is-grouped">
-          <p className="control">
-            <button
-              type="submit"
-              className={
-                this.state.loading
-                  ? "button is-primary is-loading"
-                  : "button is-primary"
-              }
-              disabled={this.state.loading}
-            >
-              Upload
-            </button>
-          </p>
-          <p className="control">
-            <Link to="/uploads" className="button is-light">
-              Cancel
-            </Link>
-          </p>
-        </div>
-      </form>
-    );
-  }
-}
-
-function PossibleUploadUrlsField({ possibleUploadUrls, preferredBucketName }) {
-  if (!possibleUploadUrls || possibleUploadUrls.length < 2) {
-    return null;
-  }
-  return (
-    <div className="field">
-      <div className="control">
-        <div className="select">
-          <select ref={preferredBucketName}>
-            {possibleUploadUrls.map((item) => {
-              return (
-                <option value={item.bucket_name} key={item.url}>
-                  {item.bucket_name}
-                </option>
-              );
-            })}
-          </select>
-        </div>
-      </div>
-    </div>
-  );
 }

--- a/tecken/api/urls.py
+++ b/tecken/api/urls.py
@@ -8,11 +8,6 @@ from . import views
 
 
 app_name = "api"
-
-# NOTE(peterbe): The endpoints that start with a '_' are basically only relevant for the
-# sake of the frontend. Meaning, it doesn't make sense to use them in your curl script,
-# for example.
-
 urlpatterns = [
     path("_auth/", views.auth, name="auth"),
     path("stats/", views.stats, name="stats"),
@@ -20,11 +15,6 @@ urlpatterns = [
     path("tokens/", views.tokens, name="tokens"),
     path("tokens/token/<int:id>/extend", views.extend_token, name="extend_token"),
     path("tokens/token/<int:id>", views.delete_token, name="delete_token"),
-    path(
-        "uploads/_possible_upload_urls/",
-        views.possible_upload_urls,
-        name="possible_upload_urls",
-    ),
     path("uploads/", views.uploads, name="uploads"),
     path("uploads/files/", views.upload_files, name="upload_files"),
     path("uploads/files/file/<int:id>", views.upload_file, name="upload_file"),

--- a/tecken/api/views.py
+++ b/tecken/api/views.py
@@ -22,7 +22,6 @@ from tecken.base.decorators import (
     set_cors_headers,
 )
 from tecken.base.form_utils import filter_form_dates, ORM_OPERATORS, PaginationForm
-from tecken.base.symbolstorage import symbol_storage
 from tecken.download.views import cached_lookup_by_syminfo
 from tecken.tokens.models import Token
 from tecken.upload.models import Upload, FileUpload
@@ -86,22 +85,6 @@ def auth(request):
             reverse("oidc_authentication_init")
         )
         context["user"] = None
-    return http.JsonResponse(context)
-
-
-@api_login_required
-@METRICS.timer_decorator("api", tags=["endpoint:possible_upload_urls"])
-def possible_upload_urls(request):
-    upload_backend = symbol_storage().get_upload_backend(False)
-    context = {
-        "urls": [
-            {
-                "bucket_name": upload_backend.bucket,
-                "prefix": upload_backend.prefix,
-                "default": True,
-            }
-        ]
-    }
     return http.JsonResponse(context)
 
 


### PR DESCRIPTION
This removes the forms from the Symbols Upload Now page. I kept the page because it contains a link to instructions on how to upload symbols using Python and curl. That seems helpful to keep.

This PR gets into a lot of react code I'm not wildly familiar with (and has no tests) so I might have missed some bits when cleaning up. However, only a handful of people in the world have the access on Mozilla Symbols to see this page, so this is pretty low risk even if we mess up.