### PR TITLE
bug-1909870: Make system test cases independent of each other.

### DIFF
--- a/systemtests/lib/fake_data.py
+++ b/systemtests/lib/fake_data.py
@@ -114,7 +114,6 @@ class FakeZipArchive:
 
         self.file_name: Optional[str] = None
         self.members: list[FakeSymFile] = []
-        self.uploaded = False
 
     def create(self, tmp_dir: os.PathLike):
         LOGGER.info(

--- a/systemtests/tests/test_upload_by_download.py
+++ b/systemtests/tests/test_upload_by_download.py
@@ -2,53 +2,47 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from typing import Callable
 import pytest
 
-from systemtests.lib.fake_data import FakeZipArchive
+from systemtests.lib.fake_data import FakeDataBucket, FakeZipArchive
 from systemtests.lib.tecken_client import TeckenClient
 
 
 # Mark all tests in this module as upload tests
 pytestmark = pytest.mark.upload
 
-small_archive_param = pytest.param((2**19, "windows"), id="small")
-large_archive_param = pytest.param(
-    (3 * 2**30, "linux"), id="large", marks=pytest.mark.large_files
-)
 
-small_and_large_archives = pytest.mark.parametrize(
-    "zip_archive", [small_archive_param, large_archive_param], indirect=True
-)
-small_archive = pytest.mark.parametrize(
-    "zip_archive", [small_archive_param], indirect=True
-)
+# Upload sizes
+SMALL = 2**16
+LARGE = 2**30
 
 
+@pytest.mark.parametrize(
+    ["size", "platform"],
+    [
+        pytest.param(SMALL, "windows", id="small"),
+        pytest.param(LARGE, "linux", id="large", marks=pytest.mark.large_files),
+    ],
+)
 @pytest.mark.write_bucket
-class TestUploadByDownload:
-    # Tests within a class scope are executed in definition order.
+def test_upload_and_download(
+    size: int,
+    platform: str,
+    tecken_client: TeckenClient,
+    create_zip_archive: Callable[[int, str], FakeZipArchive],
+    fake_data_bucket: FakeDataBucket,
+):
+    zip_archive = create_zip_archive(size, platform)
+    url = fake_data_bucket.upload_scratch(zip_archive.file_name)
+    response = tecken_client.upload_by_download(url)
+    assert response.status_code == 201
 
-    @small_and_large_archives
-    def test_upload(
-        self,
-        tecken_client: TeckenClient,
-        zip_archive: FakeZipArchive,
-        zip_archive_url: str,
-    ):
-        response = tecken_client.upload_by_download(zip_archive_url)
-        assert response.status_code == 201
-        zip_archive.uploaded = True
-
-    @small_and_large_archives
-    def test_download(self, tecken_client: TeckenClient, zip_archive: FakeZipArchive):
-        if not zip_archive.uploaded:
-            pytest.skip("upload failed")
-
-        for sym_file in zip_archive.members:
-            response = tecken_client.download(sym_file.key())
-            assert response.status_code == 200
-            [redirect] = response.history
-            assert redirect.status_code == 302
+    for sym_file in zip_archive.members:
+        response = tecken_client.download(sym_file.key())
+        assert response.status_code == 200
+        [redirect] = response.history
+        assert redirect.status_code == 302
 
 
 def test_disallowed_domain(tecken_client: TeckenClient):


### PR DESCRIPTION
This change makes the system test cases independent of each other. I combined the basic upload and download tests into a single test case. All other tests that need an upload simply upload a small archive first.

This change leads to a higher number of uploads when the system tests run. Since we switched to connection limiting for our Tecken deployments, this no longer leads to any rate limiting on the server side. We also introduced a lifecycle rule for our GCS buckets that expires the uploaded files early.