### PR TITLE
bug-1910092: Add Vary: Auth-Token header for requests with a token.

### DIFF
--- a/tecken/tests/test_tokens.py
+++ b/tecken/tests/test_tokens.py
@@ -63,6 +63,7 @@ def test_client_homepage_with_valid_token(client):
     assert response.status_code == 200
     assert "sign_in_url" not in response.json()["user"]
     assert response.json()["user"]["email"] == user.email
+    assert response.headers.get("Vary").lower() == "auth-token"
     user.refresh_from_db()
     assert user.last_login
 
@@ -72,6 +73,7 @@ def test_client_homepage_with_valid_token(client):
     assert response.status_code == 200
     assert "sign_in_url" not in response.json()["user"]
     assert response.json()["user"]["email"] == user.email
+    assert response.headers.get("Vary").lower() == "auth-token"
     user.refresh_from_db()
     assert user.last_login
 


### PR DESCRIPTION
To verify that this is working, run
```
curl -H "Auth-Token: c7c1f8cab79545b6a06bc4122f0eb3cb" -I http://localhost:3000/api/uploads/
```
substituting your auth token for the local env; the one above is the one from the slick.sh file we distribute. Verify that the Vary header includes "Auth-Token".