### PR TITLE
Update Python 3.11.10 slim-bullseye image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN bin/build_frontend.sh
 
 
-FROM --platform=linux/amd64 python:3.11.10-slim-bullseye@sha256:d1bdffe2ca65ea6b4862307fafed6c10a99e86a7d390140591a7dd8377bd59a6
+FROM --platform=linux/amd64 python:3.11.10-slim-bullseye@sha256:f6a64ef0a5cc14855b15548056a8fc77f4c3526b79883fa6709a8e23f676ac34
 
 ARG userid=10001
 ARG groupid=10001


### PR DESCRIPTION
It's this tag:

https://hub.docker.com/layers/library/python/3.11.10-slim-bullseye/images/sha256-99010d5cbf95418c4dbaeb3be33658bc1b65c3a6324bba447424c6768728e4f7?context=explore