### PR TITLE
enable github actions CI on merge queue

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
I think circleci is already configured such that CI will run on merge queue branches

note: this should be merged via the merge queue to ensure it's working