### PR TITLE
Prevent dependabot from proposing Python version upgrades beyond 3.11.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       interval: "weekly"
     rebase-strategy: "disabled"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: python
+        versions: [">=3.12"]
 
   # Set update schedule for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,8 @@ WORKDIR /app
 RUN bin/build_frontend.sh
 
 
+# NOTE(smarnach): To upgrade Python to a new minor or major version, see
+# https://tecken.readthedocs.io/en/latest/dev.html#how-to-upgrade-the-python-version
 FROM --platform=linux/amd64 python:3.11.10-slim-bullseye@sha256:f6a64ef0a5cc14855b15548056a8fc77f4c3526b79883fa6709a8e23f676ac34
 
 ARG userid=10001

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -358,6 +358,19 @@ We use postgresql. To open a psql shell, do:
 
 Note that it tells you the password to use.
 
+How to upgrade the Python version
+---------------------------------
+
+To upgrade Python to a new minor or major version, you need to change the version in
+these files:
+
+* ``.devcontainer/Dockerfile``
+* ``.github/dependabot.yml``
+* ``.readthedocs.yaml``
+* ``docker/Dockerfile``
+* ``docker/images/fakesentry/Dockerfile``
+* ``pyproject.toml``
+* ``tecken/tests/test_sentry.py``
 
 Bugs / Issues
 =============


### PR DESCRIPTION
While we want to upgrade Python to a newer version at some point, I don't think it's useful for depednabot to suggest this to us every week.