### PR TITLE
OBS-361: Remove tini from all Docker containers.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '2.4'
 services:
   # Base container is used for development tasks like tests, linting,
   # and building docs.
@@ -80,6 +79,7 @@ services:
         groupid: ${USE_GID:-10001}
     image: tecken-devcontainer
     entrypoint: ["sleep", "inf"]
+    stop_signal: SIGKILL  # Doesn't seem to respond to anything else
     env_file:
       - docker/config/local_dev.env
       - docker/config/test.env
@@ -196,6 +196,7 @@ services:
     ports:
       - "${EXPOSE_SENTRY_PORT:-8090}:8090"
     command: run --host 0.0.0.0 --port 8090
+    stop_signal: SIGINT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8090/"]
       interval: 1s
@@ -209,6 +210,9 @@ services:
     image: local/tecken_oidcprovider
     ports:
       - "${EXPOSE_OIDC_PORT:-8080}:8080"
+    # The next line can be removed if this PR is included in the image we use:
+    # https://github.com/mozilla/docker-test-mozilla-django-oidc/pull/84
+    stop_signal: SIGKILL
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/"]
       interval: 2s

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,8 +39,7 @@ RUN apt-get update && \
         git \
         libpq-dev \
         gettext \
-        libffi-dev \
-        tini && \
+        libffi-dev && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -70,6 +69,6 @@ USER app
 # Using /bin/bash as the entrypoint works around some volume mount issues on Windows
 # where volume-mounted files do not have execute bits set.
 # https://github.com/docker/compose/issues/2301#issuecomment-154450785 has additional background.
-ENTRYPOINT ["tini", "--", "/bin/bash", "/app/bin/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "/app/bin/entrypoint.sh"]
 
 CMD ["web"]

--- a/docker/images/fakesentry/Dockerfile
+++ b/docker/images/fakesentry/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app/
 RUN groupadd -r kent && useradd --no-log-init -r -g kent kent
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl tini && \
+    apt-get install -y --no-install-recommends curl && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -21,5 +21,5 @@ RUN pip install -U 'pip>=20' && \
 
 USER kent
 
-ENTRYPOINT ["tini", "--", "/usr/local/bin/kent-server"]
+ENTRYPOINT ["/usr/local/bin/kent-server"]
 CMD ["run"]

--- a/docker/images/oidcprovider/Dockerfile
+++ b/docker/images/oidcprovider/Dockerfile
@@ -1,10 +1,6 @@
 FROM mozilla/oidc-testprovider:oidc_testprovider-v0.10.7@sha256:cff948eeb665cd48a6bd343af585f4970d2788a7745ea8c84410bf80800e0ef9
 
-RUN apt-get update && \
-    apt install tini && \
-    rm -rf /var/lib/apt/lists/*
-
 # Modify redirect_urls specified in "fixtures.json" to fit our needs.
 COPY fixtures.json /code/fixtures.json
 
-CMD ["/usr/bin/tini", "--", "./bin/run.sh"]
+CMD ["./bin/run.sh"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,15 +22,6 @@ RUN if [ $userid -ne 1000 ]; then \
         chown app:app /app/; \
     fi
 
-# install tini
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        apt-transport-https \
-        tini && \
-    apt-get autoremove -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 ADD frontend/yarn.lock /yarn.lock
 ADD frontend/package.json /package.json
 RUN yarn
@@ -43,5 +34,5 @@ EXPOSE 35729
 # NOTE(willkg): use $userid here because we don't know what the user name is
 USER $userid
 
-ENTRYPOINT ["tini", "--", "/bin/bash", "/app/bin/run_frontend.sh"]
+ENTRYPOINT ["/bin/bash", "/app/bin/run_frontend.sh"]
 CMD ["start"]

--- a/frontend/bin/run_frontend.sh
+++ b/frontend/bin/run_frontend.sh
@@ -37,9 +37,8 @@ See https://prettier.io/docs/en/editors.html#content
 
 case $1 in
   start)
-    # The `| cat` is to trick Node that this is an non-TTY terminal
-    # then react-scripts won't clear the console.
-    yarn start | cat
+    # With CI=true react-scripts won't clear the console.
+    CI=true exec yarn start
     ;;
   lint)
     # The --list-different (alias -l) will error the execution if there


### PR DESCRIPTION
The tini process was originally added to make Docker comtainers quite properly when receiving the TERM signal on `docker compose stop`. Some containers don't react to this signal, so terminating them will hang for ten seconds before Docker Compose sends SIGKILL.

This change removes tini evertywhere while ensuring container shutdown still happens on the first signal. for some containers, I added the correct signal in `docker-compose.yml` using the `stop_signal` directive. For the frontend containers I made sure the shell script uses `exec` to start the actual main process, so there shell doesn't linger in the background to block signals. For the oidc-provider, I filed a [PR with a similar change](https://github.com/mozilla/docker-test-mozilla-django-oidc/pull/84).

https://mozilla-hub.atlassian.net/browse/OBS-361