### PR TITLE
bug 1950361: Remove statsd namespace for local development.

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -13,7 +13,6 @@ GUNICORN_TIMEOUT=180
 # Statsd things
 STATSD_HOST=statsd
 STATSD_PORT=8125
-STATSD_NAMESPACE=mcboatface
 
 ALLOWED_HOSTS=web,localhost
 SECRET_KEY=DontusethisinproductionbutitneedsbelongforCI1234567890


### PR DESCRIPTION
We use markus to prefix all metrics with `tecken.` now, so the namespace is no longer needed. Setting an additional namespace in `STATSD_NAMESPACE` results in metrics named `mcboatface.tecken.*`. By removing the namespace we get `tecken.*` instead.

(I could only observe this when I had replaced the statsd-graphite image with Telegraf, since I didn't manage to actually see the metrics with the former image. The namespace is added on the client side, though, so it shouldn't make any difference what statsd implementation I used to test this.)