### PR TITLE
OBS-469: Make run_migrations.sh run migrations again.

### DIFF
--- a/bin/run_migrations.sh
+++ b/bin/run_migrations.sh
@@ -26,7 +26,6 @@ fi
 echo "starting run_migrations.sh: $(date)"
 
 # Run Django migrations
-echo "migrations are disabled"
-# ${PRECMD} python manage.py migrate --no-input
+${PRECMD} python manage.py migrate --no-input
 
 echo "done migrations: $(date)"


### PR DESCRIPTION
Database migrations are not run as part of a normal deployment; they only run when manually triggered. If we manually trigger migrations, the script should actually run them.

https://mozilla-hub.atlassian.net/browse/OBS-469