### PR TITLE
CRINGE-74: Upgrade Django to version 4.2.24.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -32,7 +32,7 @@ werkzeug==3.1.3
 whitenoise==6.9.0
 
 # NOTE(willkg): We stick with LTS releases and the next one is 5.2 (2025).
-Django==4.2.23
+Django==4.2.24
 
 # Mozilla obs-team libraries that are published to GAR instead of pypi
 --extra-index-url https://us-python.pkg.dev/moz-fx-cavendish-prod/cavendish-prod-python/simple/

--- a/requirements.txt
+++ b/requirements.txt
@@ -246,9 +246,9 @@ dj-database-url==3.0.1 \
     --hash=sha256:43950018e1eeea486bf11136384aec0fe55b29fe6fd8a44553231b85661d9383 \
     --hash=sha256:8994961efb888fc6bf8c41550870c91f6f7691ca751888ebaa71442b7f84eff8
     # via -r requirements.in
-django==4.2.23 \
-    --hash=sha256:42fdeaba6e6449d88d4f66de47871015097dc6f1b87910db00a91946295cfae4 \
-    --hash=sha256:dafbfaf52c2f289bd65f4ab935791cb4fb9a198f2a5ba9faf35d7338a77e9803
+django==4.2.24 \
+    --hash=sha256:40cd7d3f53bc6cd1902eadce23c337e97200888df41e4a73b42d682f23e71d80 \
+    --hash=sha256:a6527112c58821a0dfc5ab73013f0bdd906539790a17196658e36e66af43c350
     # via
     #   -r requirements.in
     #   dj-database-url


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/CRINGE-74