### PR TITLE
CRINGE-111: enable CONN_HEALTH_CHECKS for Django DB

### DIFF
--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -528,7 +528,14 @@ CONN_MAX_AGE = _config(
     parser=int,
     doc="Maximum age in minutes for connections.",
 )
+CONN_HEALTH_CHECKS = _config(
+    "CONN_HEALTH_CHECKS",
+    default="true",
+    parser=bool,
+    doc="Existing persistent database connections will be health checked before they are reused in each request performing database access.",
+)
 DATABASES["default"]["CONN_MAX_AGE"] = CONN_MAX_AGE
+DATABASES["default"]["CONN_HEALTH_CHECKS"] = CONN_HEALTH_CHECKS
 
 if not LOCAL_DEV_ENV and not TEST_ENV:
     DATABASES["default"].setdefault("OPTIONS", {})["sslmode"] = "require"


### PR DESCRIPTION
Because:
* [DB connection health checks](https://docs.djangoproject.com/en/4.2/ref/settings/#conn-health-checks) are disabled by default.
* During DB maintenance, connections are closed, and Django isn't re-establishing a connection with existing configuration during uploads.

This commit:
* Enables DB connection health checks.