### PR TITLE
bug-2027684: Move recording of file uploads to the main thread.

### DIFF
--- a/tecken/tests/test_upload.py
+++ b/tecken/tests/test_upload.py
@@ -416,10 +416,8 @@ def test_upload_archive_one_uploaded_one_errored(
     assert upload.user == uploaderuser
     assert not upload.completed_at
 
-    assert FileUpload.objects.all().count() == 1
-    assert FileUpload.objects.get(
-        upload=upload, key="xpcshell.dbg/A7D6F1BB18CD4CB48/xpcshell.sym"
-    )
+    # Failed file uploads are not recorded in the database.
+    assert FileUpload.objects.all().count() == 0
 
 
 def test_upload_archive_with_cache_invalidation(

--- a/tecken/upload/utils.py
+++ b/tecken/upload/utils.py
@@ -122,6 +122,8 @@ def upload_file_upload(
     file_path: str,
     upload: Upload,
 ) -> Optional[FileUpload]:
+    # NOTE(smarnach): This function is run in a thread and should not access the database.
+
     with METRICS.timer("upload_file_exists"):
         # FIXME(smarnach): Use symbol_storage().get_metadata() so we don't upload a file that
         # already exists in regular storage to try storage.
@@ -195,8 +197,22 @@ def upload_file_upload(
         except SymParseError as exc:
             logging.debug("symparseerror: %s", exc)
 
-    file_upload = FileUpload.objects.create(
+    created_at = timezone.now()
+    metadata.content_length = size
+    logger.debug(f"Uploading file {key_name!r} into {backend.bucket!r}")
+    with METRICS.timer("upload_put_object"):
+        with open(file_path, "rb") as f:
+            backend.upload(key_name, f, metadata)
+    completed_at = timezone.now()
+    logger.info(f"Uploaded key {key_name}")
+    METRICS.incr("upload_file_upload_upload", 1)
+
+    # This only creates an in-memory instance of `FileUpload`. It's saved to the database
+    # in the main thread.
+    return FileUpload(
         upload=upload,
+        created_at=created_at,
+        completed_at=completed_at,
         bucket_name=backend.bucket,
         key=key_name,
         update=bool(existing_metadata),
@@ -209,14 +225,3 @@ def upload_file_upload(
         code_id=sym_data.get("code_id"),
         generator=sym_data.get("generator"),
     )
-
-    metadata.content_length = size
-    logger.debug(f"Uploading file {key_name!r} into {backend.bucket!r}")
-    with METRICS.timer("upload_put_object"):
-        with open(file_path, "rb") as f:
-            backend.upload(key_name, f, metadata)
-    FileUpload.objects.filter(id=file_upload.id).update(completed_at=timezone.now())
-    logger.info(f"Uploaded key {key_name}")
-    METRICS.incr("upload_file_upload_upload", 1)
-
-    return file_upload

--- a/tecken/upload/views.py
+++ b/tecken/upload/views.py
@@ -10,6 +10,7 @@ import os
 import re
 from tempfile import TemporaryDirectory
 import time
+from typing import Optional
 import zipfile
 
 from django import http
@@ -26,7 +27,7 @@ from tecken.base.symbolstorage import symbol_storage
 from tecken.base.utils import filesizeformat, invalid_key_name_characters
 from tecken.upload import executor
 from tecken.upload.forms import UploadByDownloadForm, UploadByDownloadRemoteError
-from tecken.upload.models import Upload
+from tecken.upload.models import FileUpload, Upload
 from tecken.upload.utils import (
     dump_and_extract,
     UnrecognizedArchiveFileExtension,
@@ -299,8 +300,9 @@ def upload_archive(request, upload_workspace):
     # Now lets wait for them all to finish and we'll see which ones
     # were skipped and which ones were created.
     for future in concurrent.futures.as_completed(future_to_key):
-        file_upload = future.result()
+        file_upload: Optional[FileUpload] = future.result()
         if file_upload:
+            file_upload.save()
             file_uploads_created += 1
             uploaded_symbol_keys.append(key_to_symbol_keys[file_upload.key])
         else:


### PR DESCRIPTION
This moves recording file uploads in the database to the main thread. This way, only the main thread needs a database connection, reducing the total number of database connections we need.

This changes Tecken's behaviour. Currently, we record an upload in the database before uploading it to object storage, and update the record with the completion time once the upload finishes. With this change, we only record uploads that actually finish. I think this change is acceptable – the database entries for unfinished file uploads don't provide much value.

The test suite is run without a thread pool; everything happens in the main thread. For this reason it's not possible to add a test that verifies that we don't open database connections from the thread pool without changing how the tests are run. Using threads in the tests has the potential to cause a lot of problems, so I think it's not worth it. Moreover, if we go ahead with our plan to change the upload API, the whole thread pool will go away in a couple of months.