### PR TITLE
bug-2028541: Install PostgreSQL client in the Docker image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,10 +37,11 @@ RUN apt-get update && \
         apt-transport-https \
         build-essential \
         curl \
-        git \
-        libpq-dev \
         gettext \
-        libffi-dev && \
+        git \
+        libffi-dev \
+        libpq-dev \
+        postgresql-client && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
This makes `psql` available inside the Docker image, which is useful to run ad-hoc queries against the database.

The uncompressed image size increased by 5 MB. Before the change:
```
$ docker image ls tecken:build
                                                                                                                                                                    i Info →   U  In Use
IMAGE          ID             DISK USAGE   CONTENT SIZE   EXTRA
tecken:build   847bde8b7671        775MB             0B        
```
After the change:
```
$ docker image ls tecken:build
                                                                                                                                                                    i Info →   U  In Use
IMAGE          ID             DISK USAGE   CONTENT SIZE   EXTRA
tecken:build   cf52fb1cb835        780MB             0B        
```