### PR TITLE
bug-2027684: Set the correct created_at timestamp for FileUploads.

### DIFF
--- a/tecken/upload/models.py
+++ b/tecken/upload/models.py
@@ -7,6 +7,7 @@ import logging
 from django.conf import settings
 from django.db import models
 from django.contrib.postgres.fields import ArrayField
+from django.utils import timezone
 
 
 logger = logging.getLogger("tecken")
@@ -133,7 +134,7 @@ class FileUpload(models.Model):
     compressed = models.BooleanField(default=False)
     size = models.PositiveIntegerField()
     completed_at = models.DateTimeField(null=True)
-    created_at = models.DateTimeField(auto_now_add=True, db_index=True)
+    created_at = models.DateTimeField(default=timezone.now, db_index=True)
 
     # NOTE(willkg): This used to be used when this upload belongs to a Microsoft proxy
     # download, but that code was removed, so now this does nothing and can be removed.


### PR DESCRIPTION
This is a fix for a problem introduced in #3294.

The code explicitly sets the `created_add` field of the new `FileUpload` instance. However, with `auto_now_add=True`, Django silently ignores the provided value and uses the current timestamp instead, resulting in virtually identical timestamps for `created_at` and `completed_at` for all file uploads.

This change replaces `auto_now_add=True` with the more relaxed `default=timezone.now`. This will still initialize the `created_at` field to the current time if it's not explicitly provided, but explicit values will be respected.