### PR TITLE
bug-2037388: Implement the /upload/auth_info/ endpoint.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "encore",
     "everett",
     "fillmore",
+    "google-cloud-iam",
     "google-cloud-storage",
     "gunicorn",
     "honcho",

--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -748,3 +748,31 @@ DOWNLOAD_FILE_EXTENSIONS_ALLOWED = _config(
         "the most common."
     ),
 )
+
+CLIENT_OTEL_SERVICE_ACCOUNT = (
+    _config(
+        "CLIENT_OTEL_SERVICE_ACCOUNT",
+        default="",
+        raise_error=False,
+        doc=(
+            "The GCP service account used to let the upload-symbols CLI tool submit "
+            "telemetry to Google's OTLP endpoint."
+        ),
+    )
+    or None
+)
+
+if CLIENT_OTEL_SERVICE_ACCOUNT:
+    CLIENT_OTEL_GCP_PROJECT = _config(
+        "CLIENT_OTEL_GCP_PROJECT",
+        doc=(
+            "The destination GCP project the upload-symbols CLI tool submits "
+            "telemetry to."
+        ),
+    )
+
+    CLIENT_OTEL_LOG_LEVEL = _config(
+        "CLIENT_OTEL_LOG_LEVEL",
+        default="info",
+        doc="The telemetry verbosity of the upload-symbols CLI tool.",
+    )

--- a/tecken/tests/test_sentry.py
+++ b/tecken/tests/test_sentry.py
@@ -35,6 +35,7 @@ BROKEN_EVENT = {
                     'SELECT "tokens_token"."id", "tokens_token"."user_id", '
                     + '"tokens_token"."key", "tokens_token"."expires_at", '
                     + '"tokens_token"."notes", "tokens_token"."created_at", '
+                    + '"tokens_token"."preferred_upload_api_version", '
                     + '"auth_user"."id", "auth_user"."password", '
                     + '"auth_user"."last_login", "auth_user"."is_superuser", '
                     + '"auth_user"."username", "auth_user"."first_name", '

--- a/tecken/tests/test_upload.py
+++ b/tecken/tests/test_upload.py
@@ -19,7 +19,7 @@ from django.utils import timezone
 
 from tecken.libstorage import ObjectMetadata, StorageBackend, StorageError
 from tecken.tokens.models import Token
-from tecken.upload import utils
+from tecken.upload import client_otel, utils
 from tecken.upload.forms import UploadByDownloadForm, UploadByDownloadRemoteError
 from tecken.upload.models import Upload, FileUpload
 
@@ -1182,3 +1182,31 @@ class Test_remove_orphaned_files:
             metricsmock.assert_not_incr(
                 "tecken.remove_orphaned_files.delete_file_error"
             )
+
+
+def test_upload_auth_info(client, db, uploaderuser):
+    token = Token.objects.create(user=uploaderuser, preferred_upload_api_version=2)
+    token.permissions.add(Permission.objects.get(codename="upload_try_symbols"))
+
+    client_otel.init(
+        service_account="otel-service-account@my-gcp-project.iam.gserviceaccount.com",
+        gcp_project="my-gcp-project",
+        log_level="info",
+        iam_client=client_otel.MockIAMCredentialsClient("some-access-token"),
+    )
+
+    url = reverse("upload:upload_auth_info")
+    response = client.post(url, HTTP_AUTH_TOKEN=token.key)
+    assert response.status_code == 200
+    assert response.json() == {
+        "email": uploaderuser.email,
+        "try_symbols": True,
+        "token_expires_at": int(token.expires_at.timestamp()),
+        "upload_api_version": 2,
+        "opentelemetry": {
+            "endpoint": "https://telemetry.googleapis.com/",
+            "headers": {"Authorization": "Bearer some-access-token"},
+            "resource_attributes": {"gcp.project_id": "my-gcp-project"},
+            "log_level": "info",
+        },
+    }

--- a/tecken/tests/test_upload.py
+++ b/tecken/tests/test_upload.py
@@ -8,6 +8,7 @@ import logging
 import os
 from unittest import mock
 
+from google.cloud import iam_credentials
 from markus.testing import AnyTagValue
 import pytest
 from requests.exceptions import ConnectionError, RetryError
@@ -1184,29 +1185,59 @@ class Test_remove_orphaned_files:
             )
 
 
+class MockIAMCredentialsClient:
+    """A mock implementation of IAMCredentialsClient for tests."""
+
+    def __init__(self, access_token):
+        self.access_token = access_token
+
+    def generate_access_token(
+        self, *, name: str, scope: list[str]
+    ) -> iam_credentials.GenerateAccessTokenResponse:
+        return iam_credentials.GenerateAccessTokenResponse(
+            access_token=self.access_token,
+            expire_time=datetime.datetime.now() + datetime.timedelta(seconds=3600),
+        )
+
+
 def test_upload_auth_info(client, db, uploaderuser):
     token = Token.objects.create(user=uploaderuser, preferred_upload_api_version=2)
     token.permissions.add(Permission.objects.get(codename="upload_try_symbols"))
 
-    client_otel.init(
+    config_provider = client_otel.ClientOTelConfigProvider(
         service_account="otel-service-account@my-gcp-project.iam.gserviceaccount.com",
         gcp_project="my-gcp-project",
         log_level="info",
-        iam_client=client_otel.MockIAMCredentialsClient("some-access-token"),
+        iam_client=MockIAMCredentialsClient("some-access-token"),
     )
+    with mock.patch("tecken.upload.client_otel.CONFIG", config_provider):
+        url = reverse("upload:upload_auth_info")
+        response = client.post(url, HTTP_AUTH_TOKEN=token.key)
+        assert response.status_code == 200
+        assert response.json() == {
+            "email": uploaderuser.email,
+            "try_symbols": True,
+            "token_expires_at": int(token.expires_at.timestamp()),
+            "upload_api_version": 2,
+            "opentelemetry": {
+                "endpoint": "https://telemetry.googleapis.com/",
+                "headers": {"Authorization": "Bearer some-access-token"},
+                "resource_attributes": {"gcp.project_id": "my-gcp-project"},
+                "log_level": "info",
+            },
+        }
+
+
+def test_upload_auth_info_no_otel(client, db, uploaderuser):
+    token = Token.objects.create(user=uploaderuser, preferred_upload_api_version=1)
+    token.permissions.add(Permission.objects.get(codename="upload_symbols"))
 
     url = reverse("upload:upload_auth_info")
     response = client.post(url, HTTP_AUTH_TOKEN=token.key)
     assert response.status_code == 200
     assert response.json() == {
         "email": uploaderuser.email,
-        "try_symbols": True,
+        "try_symbols": False,
         "token_expires_at": int(token.expires_at.timestamp()),
-        "upload_api_version": 2,
-        "opentelemetry": {
-            "endpoint": "https://telemetry.googleapis.com/",
-            "headers": {"Authorization": "Bearer some-access-token"},
-            "resource_attributes": {"gcp.project_id": "my-gcp-project"},
-            "log_level": "info",
-        },
+        "upload_api_version": 1,
     }

--- a/tecken/tokens/admin.py
+++ b/tecken/tokens/admin.py
@@ -14,6 +14,7 @@ class TokenAdmin(admin.ModelAdmin):
         "get_user_email",
         "get_permissions",
         "expires_at",
+        "preferred_upload_api_version",
         "notes",
     ]
 

--- a/tecken/tokens/middleware.py
+++ b/tecken/tokens/middleware.py
@@ -86,4 +86,5 @@ class APITokenAuthenticationMiddleware:
         # User is valid. Set request.user and persist user in the request
         # by logging the user in.
         request.user = user
+        request.token = token
         user_logged_in.send(sender=user.__class__, request=request, user=user)

--- a/tecken/tokens/models.py
+++ b/tecken/tokens/models.py
@@ -22,12 +22,21 @@ def get_future():
 
 
 class Token(models.Model):
+    class UploadApiVersion(models.IntegerChoices):
+        V1 = 1
+        V2 = 2
+
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     key = models.CharField(max_length=32, default=make_key)
     expires_at = models.DateTimeField(default=get_future)
     permissions = models.ManyToManyField(Permission)
     notes = models.TextField(blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
+    preferred_upload_api_version = models.IntegerField(
+        choices=UploadApiVersion,
+        default=UploadApiVersion.V1,
+        db_default=UploadApiVersion.V1,
+    )
 
     class Meta:
         permissions = (("manage_tokens", "Manage Your API Tokens"),)

--- a/tecken/upload/apps.py
+++ b/tecken/upload/apps.py
@@ -8,7 +8,7 @@ from django.apps import AppConfig
 from django.conf import settings
 from django.db.models.signals import post_migrate
 
-from tecken.upload import executor
+from tecken.upload import client_otel, executor
 
 logger = logging.getLogger("django")
 
@@ -47,6 +47,12 @@ class UploadAppConfig(AppConfig):
 
     def ready(self):
         post_migrate.connect(create_default_groups, sender=self)
+        if settings.CLIENT_OTEL_SERVICE_ACCOUNT:
+            client_otel.init(
+                settings.CLIENT_OTEL_SERVICE_ACCOUNT,
+                settings.CLIENT_OTEL_GCP_PROJECT,
+                settings.CLIENT_OTEL_LOG_LEVEL,
+            )
         executor.init(
             settings.SYNCHRONOUS_UPLOAD_FILE_UPLOAD,
             settings.UPLOAD_FILE_UPLOAD_MAX_WORKERS or None,

--- a/tecken/upload/client_otel.py
+++ b/tecken/upload/client_otel.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import datetime
 from google.cloud import iam_credentials
 
 
@@ -21,7 +20,7 @@ class ClientOTelConfigProvider:
         self.log_level = log_level
         self.iam_client = iam_client or iam_credentials.IAMCredentialsClient()
 
-    def get(self) -> dict | None:
+    def get(self) -> dict:
         """Return the OTel config.
 
         Each call to this function generates a new access token for the OTel service
@@ -46,29 +45,7 @@ class ClientOTelConfigProvider:
 CONFIG: ClientOTelConfigProvider | None = None
 
 
-def init(
-    service_account: str,
-    gcp_project: str,
-    log_level: str,
-    iam_client=None,
-):
+def init(service_account: str, gcp_project: str, log_level: str):
     """Initialize the global OTel config provider."""
     global CONFIG
-    CONFIG = ClientOTelConfigProvider(
-        service_account, gcp_project, log_level, iam_client
-    )
-
-
-class MockIAMCredentialsClient:
-    """A mock implementation of IAMCredentialsClient for tests."""
-
-    def __init__(self, access_token):
-        self.access_token = access_token
-
-    def generate_access_token(
-        self, *, name: str, scope: list[str]
-    ) -> iam_credentials.GenerateAccessTokenResponse:
-        return iam_credentials.GenerateAccessTokenResponse(
-            access_token=self.access_token,
-            expire_time=datetime.datetime.now() + datetime.timedelta(seconds=3600),
-        )
+    CONFIG = ClientOTelConfigProvider(service_account, gcp_project, log_level)

--- a/tecken/upload/client_otel.py
+++ b/tecken/upload/client_otel.py
@@ -1,0 +1,74 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import datetime
+from google.cloud import iam_credentials
+
+
+class ClientOTelConfigProvider:
+    """Provider for the OTel config returned by the /upload/auth_info/ endpoint."""
+
+    def __init__(
+        self,
+        service_account: str,
+        gcp_project: str,
+        log_level: str,
+        iam_client=None,
+    ):
+        self.service_account = service_account
+        self.gcp_project = gcp_project
+        self.log_level = log_level
+        self.iam_client = iam_client or iam_credentials.IAMCredentialsClient()
+
+    def get(self) -> dict | None:
+        """Return the OTel config.
+
+        Each call to this function generates a new access token for the OTel service
+        account that's valid for one hour.
+        """
+        access_token = self.iam_client.generate_access_token(
+            name=self.service_account,
+            scope=["https://www.googleapis.com/auth/cloud-platform"],
+        ).access_token
+
+        # The consumer of this configuration, the upload-symbols client, assumes the
+        # OTLP collector is using the http/protobuf OTLP protocol, but it doesn't make
+        # any other assumptions about the collector.
+        return {
+            "endpoint": "https://telemetry.googleapis.com/",
+            "headers": {"Authorization": f"Bearer {access_token}"},
+            "resource_attributes": {"gcp.project_id": self.gcp_project},
+            "log_level": self.log_level,
+        }
+
+
+CONFIG: ClientOTelConfigProvider | None = None
+
+
+def init(
+    service_account: str,
+    gcp_project: str,
+    log_level: str,
+    iam_client=None,
+):
+    """Initialize the global OTel config provider."""
+    global CONFIG
+    CONFIG = ClientOTelConfigProvider(
+        service_account, gcp_project, log_level, iam_client
+    )
+
+
+class MockIAMCredentialsClient:
+    """A mock implementation of IAMCredentialsClient for tests."""
+
+    def __init__(self, access_token):
+        self.access_token = access_token
+
+    def generate_access_token(
+        self, *, name: str, scope: list[str]
+    ) -> iam_credentials.GenerateAccessTokenResponse:
+        return iam_credentials.GenerateAccessTokenResponse(
+            access_token=self.access_token,
+            expire_time=datetime.datetime.now() + datetime.timedelta(seconds=3600),
+        )

--- a/tecken/upload/urls.py
+++ b/tecken/upload/urls.py
@@ -9,4 +9,7 @@ from . import views
 
 app_name = "upload"
 
-urlpatterns = [path("", views.upload_archive, name="upload_archive")]
+urlpatterns = [
+    path("", views.upload_archive, name="upload_archive"),
+    path("auth_info/", views.upload_auth_info, name="upload_auth_info"),
+]

--- a/tecken/upload/views.py
+++ b/tecken/upload/views.py
@@ -25,7 +25,7 @@ from tecken.base.decorators import (
 )
 from tecken.base.symbolstorage import symbol_storage
 from tecken.base.utils import filesizeformat, invalid_key_name_characters
-from tecken.upload import executor
+from tecken.upload import client_otel, executor
 from tecken.upload.forms import UploadByDownloadForm, UploadByDownloadRemoteError
 from tecken.upload.models import FileUpload, Upload
 from tecken.upload.utils import (
@@ -340,3 +340,29 @@ def _serialize_upload(upload):
         "user": upload.user.email,
         "skipped_keys": upload.skipped_keys or [],
     }
+
+
+@api_require_POST
+@api_login_required
+@api_any_permission_required("upload.upload_symbols", "upload.upload_try_symbols")
+def upload_auth_info(request):
+    """Return user and API information to the upload-symbols CLI tool.
+
+    This endpoint is used by the upload-symbols CLI tool before sending any upload
+    requests. It lets the tool verify that the token is valid and has upload
+    permissions, indicates whether the upload will be a try or regular upload,
+    indicates the upload API version the CLI should use and returns OpenTelemetry
+    settings so the client can submit telemetry.
+
+    This endpoint requires a POST request because it generates a new access token for
+    the OpenTelemetry service account.
+    """
+    response_data = {
+        "email": request.user.email,
+        "try_symbols": bool(request.user.has_perm("upload.upload_try_symbols")),
+        "token_expires_at": int(request.token.expires_at.timestamp()),
+        "upload_api_version": request.token.preferred_upload_api_version,
+    }
+    if client_otel.CONFIG:
+        response_data["opentelemetry"] = client_otel.CONFIG.get()
+    return http.JsonResponse(response_data)

--- a/uv.lock
+++ b/uv.lock
@@ -328,6 +328,23 @@ wheels = [
 ]
 
 [[package]]
+name = "google-cloud-iam"
+version = "2.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"], marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "google-auth", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "grpc-google-iam-v1", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "grpcio", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "proto-plus", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "protobuf", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/e5/07d4f1daf85a2a0bd9f78ad865ea678d7b4e1227ed76f671c7167aae147f/google_cloud_iam-2.22.0.tar.gz", hash = "sha256:203ddfece17e014ee4fbc5c3244daa14a88b7ee57c8e3a7622d0f2a1a3b8d7f3", size = 502498, upload-time = "2026-03-30T22:51:28.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/a8/d721ea11d0eb93803d14cb2e90d0442bb3b269a82f7cb5faff2b98022039/google_cloud_iam-2.22.0-py3-none-any.whl", hash = "sha256:c443b34b5a6a9e51d32cee397879bb781b900af68937c67a275def23bbc025f3", size = 463425, upload-time = "2026-03-30T20:02:42.967Z" },
+]
+
+[[package]]
 name = "google-cloud-pubsub"
 version = "2.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1149,6 +1166,7 @@ dependencies = [
     { name = "encore", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "everett", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "fillmore", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "google-cloud-iam", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "google-cloud-storage", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "gunicorn", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "honcho", marker = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -1191,6 +1209,7 @@ requires-dist = [
     { name = "encore" },
     { name = "everett" },
     { name = "fillmore" },
+    { name = "google-cloud-iam" },
     { name = "google-cloud-storage" },
     { name = "gunicorn" },
     { name = "honcho" },


### PR DESCRIPTION
This adds an /upload/auth_info/ endpoint intended to be used by the upload-symbols CLI tool.

The code is mostly straight-forward. The client-otel.py module exists for two reasons. First, as a container to hold the global OTel configuration provider, so we don't have to reinitialize the `IAMCredentialsClient` on every request. Second, probably more importantly, as a way to inject a mock version of the `IAMCredentialsClient` for tests.

We will need to create new service accounts with permission to submit telemetry and give Tecken permissions to create access tokens for these service accounts, which will happen later. In the meantime, the /upload/auth_info/ endpoint won't include any OTel configuration.

As a minor deviation from the proposed JSON response in the bug, the token expiry time is returned as a Unix timestamp rather than a ISO-formatted time string. This API is meant for machine consumption, and a Unix timestamp is easier to consume for machines than a formatted string.

This PR depends on #3310. The migration needs to be deployed and manually run in both stage and prod before we can deploy this PR.