### PR TITLE
bug-2017633: added logout url settings variable

### DIFF
--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -36,6 +36,7 @@ BASE_DIR = os.path.dirname(THIS_DIR)
 
 VERSION_FILE = get_version(BASE_DIR)
 
+LOGOUT_REDIRECT_URL = "/"
 
 LOCAL_DEV_ENV = _config(
     "LOCAL_DEV_ENV",


### PR DESCRIPTION
Because:
- The Tecken webapp logout button wasn't working: [bug-2017633](https://bugzilla.mozilla.org/show_bug.cgi?id=2017633)
- This error occurs due to a regression introduced by updating the [mozilla-django-oidc](https://github.com/mozilla-services/tecken/pull/3259) dependency. [This](https://github.com/mozilla/mozilla-django-oidc/pull/562/changes#diff-1504d28b5ffb4b75c7b9a071a0318e79994206e5dad47215b237594572fa649e) change in the oidc package adds `resolve_url()` which is what causes the logout button to stop functioning
- The default value for `LOGOUT_REDIRECT_URL` is None in Django settings since we have not defined it, which isn't able to be normalized by [resolve_url](https://github.com/django/django/blob/49ca2db7f4d4ca4a7735a40610d59c84a039eb32/django/shortcuts.py#L156) since it expects an iterable type to check for "/" and "."

This PR:
- Sets the `LOGOUT_REDIRECT_URL` to `"/"`, which redirects the logout back to the main page and doesn't raise a `TypeError` error in `resolve_url()`.