### PR TITLE
bug-2037388: Make /upload/auth_info/ return user id and GCP region.

### DIFF
--- a/tecken/settings.py
+++ b/tecken/settings.py
@@ -692,6 +692,12 @@ if CLIENT_OTEL_SERVICE_ACCOUNT:
         ),
     )
 
+    CLIENT_OTEL_GCP_REGION = _config(
+        "CLIENT_OTEL_GCP_REGION",
+        default="us-west1",
+        doc="The GCP region for metrics submitted by clients.",
+    )
+
     CLIENT_OTEL_LOG_LEVEL = _config(
         "CLIENT_OTEL_LOG_LEVEL",
         default="info",

--- a/tecken/tests/test_upload.py
+++ b/tecken/tests/test_upload.py
@@ -1193,6 +1193,7 @@ def test_upload_auth_info(client, db, uploaderuser):
     config_provider = client_otel.ClientOTelConfigProvider(
         service_account="otel-service-account@my-gcp-project.iam.gserviceaccount.com",
         gcp_project="my-gcp-project",
+        gcp_region="us-west1",
         log_level="info",
         iam_client=MockIAMCredentialsClient("some-access-token"),
     )
@@ -1202,13 +1203,18 @@ def test_upload_auth_info(client, db, uploaderuser):
         assert response.status_code == 200
         assert response.json() == {
             "email": uploaderuser.email,
+            "user_id": uploaderuser.id,
             "try_symbols": True,
             "token_expires_at": int(token.expires_at.timestamp()),
             "upload_api_version": 2,
             "opentelemetry": {
                 "endpoint": "https://telemetry.googleapis.com/",
                 "headers": {"Authorization": "Bearer some-access-token"},
-                "resource_attributes": {"gcp.project_id": "my-gcp-project"},
+                "resource_attributes": {
+                    "gcp.project_id": "my-gcp-project",
+                    "location": "us-west1",
+                    "user.id": uploaderuser.id,
+                },
                 "log_level": "info",
             },
         }
@@ -1223,6 +1229,7 @@ def test_upload_auth_info_no_otel(client, db, uploaderuser):
     assert response.status_code == 200
     assert response.json() == {
         "email": uploaderuser.email,
+        "user_id": uploaderuser.id,
         "try_symbols": False,
         "token_expires_at": int(token.expires_at.timestamp()),
         "upload_api_version": 1,

--- a/tecken/upload/apps.py
+++ b/tecken/upload/apps.py
@@ -49,9 +49,10 @@ class UploadAppConfig(AppConfig):
         post_migrate.connect(create_default_groups, sender=self)
         if settings.CLIENT_OTEL_SERVICE_ACCOUNT:
             client_otel.init(
-                settings.CLIENT_OTEL_SERVICE_ACCOUNT,
-                settings.CLIENT_OTEL_GCP_PROJECT,
-                settings.CLIENT_OTEL_LOG_LEVEL,
+                service_account=settings.CLIENT_OTEL_SERVICE_ACCOUNT,
+                gcp_project=settings.CLIENT_OTEL_GCP_PROJECT,
+                gcp_region=settings.CLIENT_OTEL_GCP_REGION,
+                log_level=settings.CLIENT_OTEL_LOG_LEVEL,
             )
         executor.init(
             settings.SYNCHRONOUS_UPLOAD_FILE_UPLOAD,

--- a/tecken/upload/client_otel.py
+++ b/tecken/upload/client_otel.py
@@ -12,15 +12,17 @@ class ClientOTelConfigProvider:
         self,
         service_account: str,
         gcp_project: str,
+        gcp_region: str,
         log_level: str,
         iam_client=None,
     ):
         self.service_account = service_account
         self.gcp_project = gcp_project
+        self.gcp_region = gcp_region
         self.log_level = log_level
         self.iam_client = iam_client or iam_credentials.IAMCredentialsClient()
 
-    def get(self) -> dict:
+    def get(self, user_id: int) -> dict:
         """Return the OTel config.
 
         Each call to this function generates a new access token for the OTel service
@@ -37,7 +39,11 @@ class ClientOTelConfigProvider:
         return {
             "endpoint": "https://telemetry.googleapis.com/",
             "headers": {"Authorization": f"Bearer {access_token}"},
-            "resource_attributes": {"gcp.project_id": self.gcp_project},
+            "resource_attributes": {
+                "gcp.project_id": self.gcp_project,
+                "location": self.gcp_region,
+                "user.id": user_id,
+            },
             "log_level": self.log_level,
         }
 
@@ -45,7 +51,9 @@ class ClientOTelConfigProvider:
 CONFIG: ClientOTelConfigProvider | None = None
 
 
-def init(service_account: str, gcp_project: str, log_level: str):
+def init(service_account: str, gcp_project: str, gcp_region: str, log_level: str):
     """Initialize the global OTel config provider."""
     global CONFIG
-    CONFIG = ClientOTelConfigProvider(service_account, gcp_project, log_level)
+    CONFIG = ClientOTelConfigProvider(
+        service_account, gcp_project, gcp_region, log_level
+    )

--- a/tecken/upload/views.py
+++ b/tecken/upload/views.py
@@ -359,10 +359,11 @@ def upload_auth_info(request):
     """
     response_data = {
         "email": request.user.email,
+        "user_id": request.user.id,
         "try_symbols": bool(request.user.has_perm("upload.upload_try_symbols")),
         "token_expires_at": int(request.token.expires_at.timestamp()),
         "upload_api_version": request.token.preferred_upload_api_version,
     }
     if client_otel.CONFIG:
-        response_data["opentelemetry"] = client_otel.CONFIG.get()
+        response_data["opentelemetry"] = client_otel.CONFIG.get(request.user.id)
     return http.JsonResponse(response_data)


### PR DESCRIPTION
This adds another resource attribute to the OTel configuration returned by the /upload/auth_info/ endpoint: The `location` attribute is required for Google's OTLP metrics API.

The PR also adds the user id, which can be used as a resource attribute as well, so we can filter traces and metrics for individual users. It's quite unusual to want this for metrics, but we only have about ten active uploader users, so we are not concerned about cardinality, and the uploaders are either employees or partners uploading public symbols files to our server, so we also aren't worried about privacy. I wouldn't want to use the user emails that are already included in the response in the telemetry, but using user ids in the telemetry seems fine.