### PR TITLE
bug-2037388: Make new user id resource attribute a string.

### DIFF
--- a/tecken/tests/test_upload.py
+++ b/tecken/tests/test_upload.py
@@ -1213,7 +1213,7 @@ def test_upload_auth_info(client, db, uploaderuser):
                 "resource_attributes": {
                     "gcp.project_id": "my-gcp-project",
                     "location": "us-west1",
-                    "user.id": uploaderuser.id,
+                    "user.id": str(uploaderuser.id),
                 },
                 "log_level": "info",
             },

--- a/tecken/upload/client_otel.py
+++ b/tecken/upload/client_otel.py
@@ -42,7 +42,7 @@ class ClientOTelConfigProvider:
             "resource_attributes": {
                 "gcp.project_id": self.gcp_project,
                 "location": self.gcp_region,
-                "user.id": user_id,
+                "user.id": str(user_id),
             },
             "log_level": self.log_level,
         }


### PR DESCRIPTION
This fixes an oversight in #3315: Resource attributes must be strings, but the current version returns the user id as an integer. This fix changes it to a string.