### PR TITLE
bug-2037432: Add initiate_upload() method to the StorageBackend interface.

### DIFF
--- a/tecken/ext/gcs/storage.py
+++ b/tecken/ext/gcs/storage.py
@@ -22,6 +22,10 @@ class GCSStorage(StorageBackend):
     An implementation of the StorageBackend interface for Google Cloud Storage.
     """
 
+    # Upload seesions are GCS resumable uploads as documented in
+    # https://docs.cloud.google.com/storage/docs/resumable-uploads.
+    upload_session_protocol = "gcs-resumable"
+
     def __init__(
         self,
         bucket: str,
@@ -130,15 +134,10 @@ class GCSStorage(StorageBackend):
         )
         return metadata
 
-    def upload(self, key: str, body: BufferedReader, metadata: ObjectMetadata):
-        """Upload the object with the given key and body to the storage backend.
+    def _prepare_upload_blob(self, key: str, metadata: ObjectMetadata) -> storage.Blob:
+        """Helper function for upload() and initiate_upload().
 
-        :arg key: the key of the symbol file not including the prefix, i.e. the key in the format
-            ``<debug-file>/<debug-id>/<symbols-file>``.
-        :arg body: A stream yielding the symbols file contents.
-        :arg metadata: An ObjectMetadata instance with the metadata.
-
-        :raises StorageError: an unexpected backend-specific error was raised
+        This function can be inlined once we remove the upload() method.
         """
         bucket = self._get_bucket()
         blob = bucket.blob(f"{self.prefix}/{key}")
@@ -153,9 +152,43 @@ class GCSStorage(StorageBackend):
         blob.content_encoding = metadata.content_encoding
         # Prevent "decompressive transcoding" on download. See bug 1827506.
         blob.cache_control = "no-transform"
+        return blob
+
+    def upload(self, key: str, body: BufferedReader, metadata: ObjectMetadata):
+        """Upload the object with the given key and body to the storage backend.
+
+        :arg key: the key of the symbol file not including the prefix, i.e. the key in the format
+            ``<debug-file>/<debug-id>/<symbols-file>``.
+        :arg body: A stream yielding the symbols file contents.
+        :arg metadata: An ObjectMetadata instance with the metadata.
+
+        :raises StorageError: an unexpected backend-specific error was raised
+        """
+        blob = self._prepare_upload_blob(key, metadata)
         try:
             blob.upload_from_file(
                 body, size=metadata.content_length, timeout=self.timeout
+            )
+        except ClientError as exc:
+            raise StorageError(str(exc), backend=self) from exc
+
+    def initiate_upload(self, key: str, metadata: ObjectMetadata) -> str:
+        """Initiate uploading an object with the given key to the storage backend.
+
+        This function starts an upload session for the given key, and returns a URL that can be
+        used to upload the object data using the protocol named in the upload_session_protocol
+        class variable.
+
+        :arg key: the key of the symbol file not including the prefix, i.e. the key in the format
+            ``<debug-file>/<debug-id>/<symbols-file>``.
+        :arg metadata: An ObjectMetadata instance with the metadata.
+
+        :raises StorageError: an unexpected backend-specific error was raised
+        """
+        blob = self._prepare_upload_blob(key, metadata)
+        try:
+            return blob.create_resumable_upload_session(
+                size=metadata.content_length, timeout=self.timeout
             )
         except ClientError as exc:
             raise StorageError(str(exc), backend=self) from exc

--- a/tecken/ext/gcs/storage.py
+++ b/tecken/ext/gcs/storage.py
@@ -22,7 +22,7 @@ class GCSStorage(StorageBackend):
     An implementation of the StorageBackend interface for Google Cloud Storage.
     """
 
-    # Upload seesions are GCS resumable uploads as documented in
+    # Upload sessions are GCS resumable uploads as documented in
     # https://docs.cloud.google.com/storage/docs/resumable-uploads.
     upload_session_protocol = "gcs-resumable"
 

--- a/tecken/libstorage.py
+++ b/tecken/libstorage.py
@@ -5,7 +5,7 @@
 from dataclasses import dataclass
 import datetime
 from io import BufferedReader
-from typing import Any, Optional
+from typing import Any, ClassVar, Optional
 
 from django.utils.module_loading import import_string
 
@@ -37,6 +37,11 @@ class StorageBackend:
 
     # Whether the backend handles try symboles
     try_symbols: bool
+
+    # The name of the protocol for upload sessions started with initiate_upload. This name is
+    # passed on to clients together with the upload session URL, and each protocol name should
+    # be documented in the service documentation.
+    upload_session_protocol: ClassVar[str]
 
     def exists(self) -> bool:
         """Check that this storage exists.
@@ -72,6 +77,23 @@ class StorageBackend:
         :raises StorageError: an unexpected backend-specific error was raised
         """
         raise NotImplementedError("upload() must be implemented by the concrete class")
+
+    def initiate_upload(self, key: str, metadata: ObjectMetadata) -> str:
+        """Initiate uploading an object with the given key to the storage backend.
+
+        This function starts an upload session for the given key, and returns a URL that can be
+        used to upload the object data using the protocol named in the upload_session_protocol
+        class variable.
+
+        :arg key: the key of the symbol file not including the prefix, i.e. the key in the format
+            ``<debug-file>/<debug-id>/<symbols-file>``.
+        :arg metadata: An ObjectMetadata instance with the metadata.
+
+        :raises StorageError: an unexpected backend-specific error was raised
+        """
+        raise NotImplementedError(
+            "initiate_upload() must be implemented by the concrete class"
+        )
 
 
 class StorageError(Exception):

--- a/tecken/tests/test_storage_backends.py
+++ b/tecken/tests/test_storage_backends.py
@@ -28,7 +28,7 @@ def test_upload_and_download(
     assert backend.exists()
 
     if use_upload_session:
-        upload.upload_session_to_backend(backend)
+        upload.upload_to_backend_with_session(backend)
     else:
         upload.upload_to_backend(backend)
     metadata = backend.get_object_metadata(upload.key)

--- a/tecken/tests/test_storage_backends.py
+++ b/tecken/tests/test_storage_backends.py
@@ -12,17 +12,25 @@ from tecken.libstorage import StorageError
 from tecken.tests.utils import Upload, UPLOADS
 
 
+@pytest.mark.parametrize("use_upload_session", [False, True])
 @pytest.mark.parametrize("try_storage", [False, True])
 @pytest.mark.parametrize("upload", UPLOADS.values(), ids=UPLOADS.keys())
 @pytest.mark.parametrize("storage_kind", ["gcs", "gcs-cdn"])
 def test_upload_and_download(
-    get_storage_backend, storage_kind: str, upload: Upload, try_storage: bool
+    get_storage_backend,
+    storage_kind: str,
+    upload: Upload,
+    try_storage: bool,
+    use_upload_session: bool,
 ):
     backend = get_storage_backend(storage_kind, try_storage)
     backend.clear()
     assert backend.exists()
 
-    upload.upload_to_backend(backend)
+    if use_upload_session:
+        upload.upload_session_to_backend(backend)
+    else:
+        upload.upload_to_backend(backend)
     metadata = backend.get_object_metadata(upload.key)
     response = requests.get(metadata.download_url)
     response.raise_for_status()

--- a/tecken/tests/utils.py
+++ b/tecken/tests/utils.py
@@ -77,15 +77,17 @@ class Upload:
         self.backend = backend
         backend.upload(self.key, BytesIO(self.body), self.metadata)
 
-    def upload_session_to_backend(self, backend: StorageBackend):
+    def upload_to_backend_with_session(self, backend: StorageBackend):
         self.backend = backend
         url = backend.initiate_upload(self.key, self.metadata)
         self.upload_to_session_url(url)
 
     def upload_to_session_url(self, url: str):
-        # NOTE(smarnach): The GCS emulator incorrectly ignores the Content-Type header in the
-        # request initiating the upload session. As a mitigation, we pass it again in the upload
-        # request. This isn't required when using the actual GCS.
+        # NOTE(smarnach): GCS resumable uploads allow setting the Content-Type header either on
+        # the request initiating the upload session or on the request uploading the data. We
+        # include the Content-Type header in the request initiating the upload session, but the
+        # emulator ignores it on that request, so the object ends up with a default content type
+        # once the upload finishes. As a mitigation, we pass it again in the upload request.
         headers = {}
         if self.metadata.content_type:
             headers["Content-Type"] = self.metadata.content_type

--- a/tecken/tests/utils.py
+++ b/tecken/tests/utils.py
@@ -9,6 +9,8 @@ from io import BytesIO
 import os
 from typing import Optional
 
+import requests
+
 from tecken.base.symbolstorage import SymbolStorage
 from tecken.libstorage import ObjectMetadata, StorageBackend
 from tecken.libsym import extract_sym_header_data
@@ -74,6 +76,21 @@ class Upload:
     def upload_to_backend(self, backend: StorageBackend):
         self.backend = backend
         backend.upload(self.key, BytesIO(self.body), self.metadata)
+
+    def upload_session_to_backend(self, backend: StorageBackend):
+        self.backend = backend
+        url = backend.initiate_upload(self.key, self.metadata)
+        self.upload_to_session_url(url)
+
+    def upload_to_session_url(self, url: str):
+        # NOTE(smarnach): The GCS emulator incorrectly ignores the Content-Type header in the
+        # request initiating the upload session. As a mitigation, we pass it again in the upload
+        # request. This isn't required when using the actual GCS.
+        headers = {}
+        if self.metadata.content_type:
+            headers["Content-Type"] = self.metadata.content_type
+        response = requests.put(url, self.body, headers=headers)
+        response.raise_for_status()
 
     def upload(self, storage: SymbolStorage, try_storage: bool = False):
         backend = storage.get_upload_backend(try_storage)


### PR DESCRIPTION
This PR is the first step towards implementing the new upload API in Tecken.

In the new API, the server no longer uploads the files directly to the storage backend. Instead, it initiates upload sessions and returns the session URL to the client, which in turn performs the actual upload. This PR adds the `initiate_upload()` method to the `StorageBackend` interface for this purpose, and it implements it for the `GCSStorage` backend – the only backend currently supported by the codebase.

The `initiate_upload()` implementation for GCS is very similar to the original `upload()` implementation. It does not accept the request body as a parameter, and calls the `create_resumable_upload_session()` instead of `upload_from_file()` on the `Blob`, but otherwise they are the same. I factored out the common code into a helper method, which can be inlined again once we remove the `upload()` method from `StorageBackend` at the end of the migration to the new upload interface.

The tests I added initially failed due to a bug in the GCS emulator. The emulator ignores the Content-Type header that is passed when the upload session is created, so I had to add code to pass it again when actually performing the upload. This won't be required when using the real GCS.