### PR TITLE
bug-2038605: set private: true and use @mozilla namespace for package names

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "tecken",
+  "name": "@mozilla/tecken-frontend",
   "version": "0.1.0",
-  "private": false,
+  "private": true,
   "license": "MPL-2.0",
   "dependencies": {
     "bulma": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tecken",
+  "name": "@mozilla/tecken",
   "description": "The Mozilla Symbol Server",
   "private": true,
   "repository": {


### PR DESCRIPTION
See mozilla-services/socorro#7215

The same motivation and fixes are made here.

Some differences worth noting:
* Unlike for the Socorro PR referenced above, the root `package.json` has no `package-lock.json`, since it has no dependencies, so I didn't update/generate a `package-lock.json`.
* Also, unlike Socorro, Tecken uses `yarn` as its `/frontend` package manager, and unlike `package-lock.json`, `yarn.lock` doesn't contain these `private` and `name` fields, so `yarn.lock` doesn't need to be updated.