### PR TITLE
bug-2046068: Clean up storage key handling.

### DIFF
--- a/tecken/base/symbolstorage.py
+++ b/tecken/base/symbolstorage.py
@@ -59,25 +59,10 @@ class SymbolStorage:
             return self.try_upload_backend
         return self.upload_backend
 
-    @staticmethod
-    def make_key(symbol: str, debugid: str, filename: str) -> str:
-        """Generates a symbol file key for the given identifiers.
-
-        :arg symbol:
-        :arg debugid:
-        :arg filename:
-
-        :returns: A key suitable for use with StorageBackend methods.
-        """
-        # There are some legacy use case where the debug ID might not already be
-        # uppercased. If so, we override it. Every debug ID is always in uppercase.
-        return f"{symbol}/{debugid.upper()}/{filename}"
-
     def get_metadata(
-        self, symbol: str, debugid: str, filename: str, try_storage: bool = False
+        self, key: str, try_storage: bool = False
     ) -> Optional[ObjectMetadata]:
         """Return the metadata of the symbols file if it can be found, and None otherwise."""
-        key = self.make_key(symbol=symbol, debugid=debugid, filename=filename)
         for backend in self.get_download_backends(try_storage):
             with METRICS.timer("symboldownloader_exists"):
                 metadata = backend.get_object_metadata(key)

--- a/tecken/base/utils.py
+++ b/tecken/base/utils.py
@@ -15,78 +15,56 @@ def filesizeformat(bytes):
     return dj_filesizeformat(bytes).replace("\xa0", " ")
 
 
-# See the docstring in invalid_key_name_characters for an explanation
-# of this regex.
-INVALID_CHARS_REGEX = re.compile(
-    # \x00-\x1f is the "ASCII control characters". That's 00 (Null character)
-    # until 31 (Unit separator) (whatever that is).
-    r'[\x00-\x1f\x80-\xff\\\^`><{}\[\]#%"\'\|]'
+# Characters valid in the first and last part of a symbols file key. The allowed
+# characters were originally based on what's valid in AWS S3 object keys:
+#
+# https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
+#
+# While we are no longer using S3, and the requirements for GCS are a bit more relaxed,
+# we currently don't have a use case for relaxing our requirements.
+#
+# https://cloud.google.com/storage/docs/objects#naming
+#
+# This is the list of "characters to avoid" from the S3 docs:
+#
+# * Backslash ("\")
+# * Left curly brace ("{")
+# * Non-printable ASCII characters (128–255 decimal characters)
+# * Caret ("^")
+# * Right curly brace ("}")
+# * Percent character ("%")
+# * Grave accent / back tick ("`")
+# * Right square bracket ("]")
+# * Quotation marks
+# * 'Greater Than' symbol (">")
+# * Left square bracket ("[")
+# * 'Less Than' symbol ("<")
+# * 'Pound' character ("#")
+# * Vertical bar / pipe ("|")
+#
+# We also exlucde the slash character, since it separates the components of the key, so
+# it can't occur within a component.
+VALID_KEY_CHARS = r"[^\x00-\x1f\x80-\xff\\\^`><{}\[\]#%\"'\|/]+"
+
+# The debug id in the key can only consist of hex characters.
+VALID_HEX_CHARS = "[0-9A-Fa-f]+"
+
+# A regular expression to validate a complete symbols file key.
+VALID_KEY_REGEX = re.compile(
+    f"""
+    (?P<debug_name>{VALID_KEY_CHARS})
+    /
+    (?P<debug_id>{VALID_HEX_CHARS})
+    /
+    (?P<symbols_file>{VALID_KEY_CHARS})
+    """,
+    re.X,
 )
 
 
-def invalid_key_name_characters(key):
-    """Return true if there are characters in the key name that is
-    considered invalid.
+def validate_key(key: str) -> bool:
+    """Indicate whether the given key is valid.
 
-    Invalid characters list is based on the official S3 documentation.
-    https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
-
-    In particular, they list a set of "Characters to Avoid". They are
-    as follows:
-
-    * Backslash ("\")
-    * Left curly brace ("{")
-    * Non-printable ASCII characters (128–255 decimal characters)
-    * Caret ("^")
-    * Right curly brace ("}")
-    * Percent character ("%")
-    * Grave accent / back tick ("`")
-    * Right square bracket ("]")
-    * Quotation marks
-    * 'Greater Than' symbol (">")
-    * Left square bracket ("[")
-    * 'Less Than' symbol ("<")
-    * 'Pound' character ("#")
-    * Vertical bar / pipe ("|")
-
-    This function can be used also to avoid or outright refuse to bother
-    looking up if we have a symbol. This is useful in the Download part
-    where we don't want clients to be able to try to break the underlying
-    XML API by attempting lookups on really "strange" control characters.
-    E.g. https://bugzilla.mozilla.org/show_bug.cgi?id=1427730
-
-    Because this function gets used a lot, by the Download view functions,
-    it's important that this function is as fast as it can be. Therefore,
-    consider the following pre-optimization observations:
-
-    * Doing `invalid_key_name_characters('foo.pdb' + hex + 'foo.sym')`
-      is 25% slower than doing
-      `invalid_key_name_characters('foo.pdb' + 'foo.sym')`.
-      I.e. the fewer characters to check, the faster. The debug ID
-      can be checked differently.
-
-    * There is no significant performance difference between using
-      regex.findall() and regex.search(). But surprisingly, looping
-      and exiting as early as possible with regex.finditer() is
-      about 25% slower.
-
-    * Since the key is usually made up of a symbol +/+ debugid +/+ filename
-      you might be tempted to do `(invalid_key_name_characters(symbol)
-      OR invalid_key_name_characters(filename))` but this is
-      empirically slower than making a new string like this:
-      `invalid_s3_key_name_characters(symbol + filename)`.
-
-    Also, doing `''.join([symbol, filename])` is actually 15% slower
-    than just adding two strings with `symbol + filename`.
-
-    Note! It is valid to have Emojis or other Unicode characters (that
-    aren't part of the "Extended ASCCI Characters"). For example,
-    `cookié` is not valid, but `🍪` is valid. This might seem odd but
-    it's entirely based on the above mentioned official S3 documentation.
-
-    NOTE(willkg): In January 2025, we switched to GCS, so the filename requirements
-    are different now. Even so, my cursory glance suggests we don't have to change
-    what we have and add new restrictions:
-    https://cloud.google.com/storage/docs/objects#naming
+    The key is matched against `VALID_KEY_REGEX`.
     """
-    return bool(INVALID_CHARS_REGEX.findall(key))
+    return bool(VALID_KEY_REGEX.fullmatch(key))

--- a/tecken/download/urls.py
+++ b/tecken/download/urls.py
@@ -2,21 +2,35 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from django.urls import path
+from django.urls import path, register_converter
 
+from tecken.base.utils import VALID_KEY_CHARS
 from tecken.download import views
+
+
+class KeyComponentConverter:
+    regex = VALID_KEY_CHARS
+
+    def to_python(self, value):
+        return value
+
+    def to_url(self, value):
+        return value
+
+
+register_converter(KeyComponentConverter, "key")
 
 
 app_name = "download"
 
 urlpatterns = [
     path(
-        "try/<str:debugfilename>/<hex:debugid>/<str:filename>",
+        "try/<key:debug_file>/<hex:debug_id>/<key:symbols_file>",
         views.download_symbol_try,
         name="download_symbol_try",
     ),
     path(
-        "<str:debugfilename>/<hex:debugid>/<str:filename>",
+        "<key:debug_file>/<hex:debug_id>/<key:symbols_file>",
         views.download_symbol,
         name="download_symbol",
     ),

--- a/tecken/download/views.py
+++ b/tecken/download/views.py
@@ -16,7 +16,6 @@ from tecken.base.decorators import (
     set_cors_headers,
 )
 from tecken.base.symbolstorage import symbol_storage
-from tecken.base.utils import invalid_key_name_characters
 from tecken.libtiming import measure_time
 from tecken.upload.models import FileUpload
 from tecken.libmarkus import METRICS
@@ -28,16 +27,16 @@ logger = logging.getLogger("tecken")
 BOGUS_DEBUG_ID = "000000000000000000000000000000000"
 
 
-def _ignore_symbol(debugfilename, debugid, filename):
+def _ignore_symbol(debug_file, debug_id, symbols_file):
     # The MS debugger will always try to look up these files. We
     # never have them in our symbol stores. So it can be safely ignored.
-    if filename == "file.ptr":
+    if symbols_file == "file.ptr":
         return True
 
-    if debugid == BOGUS_DEBUG_ID:
+    if debug_id == BOGUS_DEBUG_ID:
         return True
 
-    if not filename.endswith(tuple(settings.DOWNLOAD_FILE_EXTENSIONS_ALLOWED)):
+    if not symbols_file.endswith(tuple(settings.DOWNLOAD_FILE_EXTENSIONS_ALLOWED)):
         return True
 
     # The default is to NOT ignore it
@@ -103,56 +102,41 @@ def is_maybe_codeinfo(some_file, some_id, filename):
 
     """
     return (
-        bool(filename)
-        and filename.endswith(".sym")
-        and bool(some_file)
-        and bool(some_id)
+        filename.endswith(".sym")
         # NOTE(willkg): debug ids are 33 characters and code ids can vary; further
         # some_id is guaranteed to be hex characters because of the urlpattern
         and len(some_id) < 33
     )
 
 
-def download_symbol_try(request, debugfilename, debugid, filename):
-    return download_symbol(request, debugfilename, debugid, filename, try_symbols=True)
+def download_symbol_try(request, debug_file, debug_id, symbols_file):
+    return download_symbol(
+        request, debug_file, debug_id, symbols_file, try_storage=True
+    )
 
 
 @METRICS.timer_decorator("download_symbol")
 @set_request_debug
 @api_require_http_methods(["GET", "HEAD"])
 @set_cors_headers(origin="*", methods="GET")
-def download_symbol(request, debugfilename, debugid, filename, try_symbols=False):
-    # First there's an opportunity to do some basic pattern matching on the symbol,
-    # debugid, and filename parameters to determine if we can, with confidence, simply
-    # ignore it.
-    #
-    # Not only can we avoid doing a SymbolStorage call, we also don't have to bother
-    # logging that it could not be found.
-    if _ignore_symbol(debugfilename, debugid, filename):
-        logger.debug(f"Ignoring symbol {debugfilename}/{debugid}/{filename}")
+def download_symbol(request, debug_file, debug_id, symbols_file, try_storage=False):
+    # Assemble the key from the components. The individual components have already been
+    # validated by the converters in download/urls.py, and the debug ID is already
+    # converted to uppercase.
+    key = f"{debug_file}/{debug_id}/{symbols_file}"
+
+    if _ignore_symbol(debug_file, debug_id, symbols_file):
+        logger.debug("Ignoring symbol %s", key)
         response = http.HttpResponseNotFound("Symbol Not Found (and ignored)")
         if request._request_debug:
             response["Debug-Time"] = 0
         return response
 
-    if invalid_key_name_characters(debugfilename + filename):
-        logger.debug(f"Invalid character {debugfilename!r}/{debugid}/{filename!r}")
-        response = http.HttpResponseBadRequest(
-            "Symbol name lookup contains invalid characters and will never be found."
-        )
-        if request._request_debug:
-            response["Debug-Time"] = 0
-        return response
-
-    refresh_cache = "_refresh" in request.GET
-
-    try_symbols = "try" in request.GET or try_symbols
+    try_storage |= "try" in request.GET
     metadata, elapsed_time = measure_time(
         symbol_storage().get_metadata,
-        symbol=debugfilename,
-        debugid=debugid,
-        filename=filename,
-        try_storage=try_symbols,
+        key,
+        try_storage=try_storage,
     )
     if metadata:
         url = metadata.download_url
@@ -172,20 +156,21 @@ def download_symbol(request, debugfilename, debugid, filename, try_symbols=False
             response.status_code = 200
         return response
 
-    if is_maybe_codeinfo(debugfilename, debugid, filename):
+    if is_maybe_codeinfo(debug_file, debug_id, symbols_file):
+        refresh_cache = "_refresh" in request.GET
         ret = cached_lookup_by_syminfo(
-            somefile=debugfilename, someid=debugid, refresh_cache=refresh_cache
+            somefile=debug_file, someid=debug_id, refresh_cache=refresh_cache
         )
         if ret:
             # Redirect to the correct debuginfo download url
-            if try_symbols:
+            if try_storage:
                 view_to_use = "download:download_symbol_try"
             else:
                 view_to_use = "download:download_symbol"
 
             new_url = reverse(
                 view_to_use,
-                args=(ret["debug_filename"], ret["debug_id"], filename),
+                args=(ret["debug_filename"], ret["debug_id"], symbols_file),
             )
             if request.GET:
                 new_url = f"{new_url}?{request.GET.urlencode()}"

--- a/tecken/tests/test_base_utils.py
+++ b/tecken/tests/test_base_utils.py
@@ -8,45 +8,26 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "debug_filename, filename",
+    "key",
     [
-        (
-            "xül.pdb",  # <-- note the extended ascii char
-            "xul.sym",
-        ),
-        (
-            "x%l.pdb",  # <-- note the %
-            "xul.sym",
-        ),
-        (
-            "xul.pdb",
-            "xul#.ex_",  # <-- note the #
-        ),
-        (
-            "crypt3\x10.pdb",
-            "crypt3\x10.pd_",
-        ),
+        "xül.pdb/1A2B3C4/xul.sym",  # <-- note the extended ascii char
+        "x%l.pdb/1A2B3C4/xul.sym",  # <-- note the %
+        "xul.pdb/1A2B3C/xul#.ex_",  # <-- note the #
+        "xul.so/1A2B3G4E/xul.sym",  # <-- note the G in the debug id
+        "crypt3\x10.pdb/1A2B3C/crypt3\x10.pd_",
     ],
 )
-def test_invalid_keys(debug_filename, filename):
-    key = debug_filename + filename
-    assert utils.invalid_key_name_characters(key) is True
+def test_invalid_keys(key):
+    assert not utils.validate_key(key)
 
 
 @pytest.mark.parametrize(
-    "debug_filename, filename",
+    "key",
     [
-        (
-            "xul.so",
-            "xul.sym",
-        ),
-        (
-            # bug 1954518: ~ is a valid character
-            "libgallium-24.2.8-1~bpo12+rpt1.so",
-            "libgallium-24.2.8-1~bpo12+rpt1.sym",
-        ),
+        "xul.so/1A2B3C/xul.sym",
+        # bug 1954518: ~ is a valid character
+        "libgallium-24.2.8-1~bpo12+rpt1.so/1a2b3c/libgallium-24.2.8-1~bpo12+rpt1.sym",
     ],
 )
-def test_valid_keys(debug_filename, filename):
-    key = debug_filename + filename
-    assert utils.invalid_key_name_characters(key) is False
+def test_valid_keys(key):
+    assert utils.validate_key(key)

--- a/tecken/tests/test_download.py
+++ b/tecken/tests/test_download.py
@@ -160,43 +160,20 @@ def test_client_404(client, db, symbol_storage):
 
 
 @pytest.mark.parametrize(
-    "debug_filename, debug_id, filename",
+    "url",
     [
-        (
-            "xül.pdb",  # <-- note the extended ascii char
-            "44E4EC8C2F41492B9369D6B9A059577C2",
-            "xul.sym",
-        ),
-        (
-            "x%l.pdb",  # <-- note the %
-            "44E4EC8C2F41492B9369D6B9A059577C2",
-            "xul.sym",
-        ),
-        (
-            "xul.pdb",
-            "44E4EC8C2F41492B9369D6B9A059577C2",
-            "xul#.ex_",  # <-- note the #
-        ),
-        (
-            "crypt3\x10.pdb",
-            "3D0443BF4FF5446B83955512615FD0942",
-            "crypt3\x10.pd_",
-        ),
+        # note the extended ascii char
+        "/xül.pdb/44E4EC8C2F41492B9369D6B9A059577C2/xul.sym",
+        # note the %
+        "/x%l.pdb/44E4EC8C2F41492B9369D6B9A059577C2/xul.sym",
+        # note the #
+        "/xul.pdb/44E4EC8C2F41492B9369D6B9A059577C2xul#.ex_",
+        "/crypt3\x10.pdb/3D0443BF4FF5446B83955512615FD0942/crypt3\x10.pd_",
     ],
 )
-def test_client_with_invalid_keys(
-    client, db, symbol_storage, debug_filename, debug_id, filename
-):
-    url = reverse(
-        "download:download_symbol",
-        args=(
-            debug_filename,
-            debug_id,
-            filename,
-        ),
-    )
+def test_client_with_invalid_keys(client, url):
     response = client.get(url)
-    assert response.status_code == 400
+    assert response.status_code == 404
 
 
 def test_client_with_bad_filenames(client, db, symbol_storage):

--- a/tecken/tests/test_download.py
+++ b/tecken/tests/test_download.py
@@ -366,7 +366,6 @@ def test_head_code_id_lookup(client, db, metricsmock, symbol_storage):
         (("xul.dll", "651C9AF99241000", "xul.sym"), True),
         (("firefox.exe", "650C1B67AE000", "firefox.sym"), True),
         # Not codeinfo
-        (("", "ACF393EAF700487177FB4224149071A756EE51F7", "firefox.sym"), False),
         (("gkcodecs.dll", "650C26A577000", "gkcodecs.dl_"), False),
         (("firefox", "EA93F3AC00F7714877FB4224149071A70", "firefox.sym"), False),
         (("libxul.so", "F02950187F3B1A110763AD1633BBE1B60", "libxul.so.sym"), False),

--- a/tecken/tests/test_symbolstorage.py
+++ b/tecken/tests/test_symbolstorage.py
@@ -2,47 +2,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import pytest
-
-from tecken.base.symbolstorage import SymbolStorage
 from tecken.tests.utils import UPLOADS
 
 
-@pytest.mark.parametrize(
-    "symbol, debugid, filename, expected",
-    [
-        (
-            "xul.pdb",
-            "44E4EC8C2F41492B9369D6B9A059577C2",
-            "xul.sym",
-            "xul.pdb/44E4EC8C2F41492B9369D6B9A059577C2/xul.sym",
-        ),
-        (
-            "libc++abi.dylib",
-            "43940F08B65E38888CD3C52398EB1CA10",
-            "libc++abi.dylib.sym",
-            "libc++abi.dylib/43940F08B65E38888CD3C52398EB1CA10/libc++abi.dylib.sym",
-        ),
-    ],
-)
-def test_make_url_path(symbol, debugid, filename, expected):
-    path = SymbolStorage.make_key(symbol=symbol, debugid=debugid, filename=filename)
-    assert path == expected
-
-
-@pytest.mark.parametrize("lower_case_debug_id", [False, True])
-def test_get_metadata(symbol_storage, lower_case_debug_id):
+def test_get_metadata(symbol_storage):
     upload = UPLOADS["compressed"]
     upload.upload(symbol_storage)
     debug_id = upload.debug_id
-    if lower_case_debug_id:
-        debug_id = debug_id.lower()
     metadata = symbol_storage.get_metadata(
-        "teckentest_js.pdb", debug_id, "teckentest_js.sym"
+        f"teckentest_js.pdb/{debug_id}/teckentest_js.sym"
     )
     assert metadata.download_url
 
     # NOTE(willkg): this requests a symbol file that doesn't exist in storage
     assert not symbol_storage.get_metadata(
-        "xxx.pdb", "44E4EC8C2F41492B9369D6B9A059577C2", "xxx.sym"
+        "xxx.pdb/44E4EC8C2F41492B9369D6B9A059577C2/xxx.sym"
     )

--- a/tecken/tests/test_upload.py
+++ b/tecken/tests/test_upload.py
@@ -450,14 +450,14 @@ def test_upload_archive_with_cache_invalidation(
 
     with open(ZIP_FILE, "rb") as fp:
         # First time -- not there
-        assert not symbol_storage.get_metadata(module, debugid, debugfn)
+        assert not symbol_storage.get_metadata(f"{module}/{debugid}/{debugfn}")
 
         url = reverse("upload:upload_archive")
         response = client.post(url, {"file.zip": fp}, HTTP_AUTH_TOKEN=token.key)
         assert response.status_code == 201
 
         # Second time is there
-        assert symbol_storage.get_metadata(module, debugid, debugfn)
+        assert symbol_storage.get_metadata(f"{module}/{debugid}/{debugfn}")
 
 
 def test_upload_archive_by_url(
@@ -630,7 +630,7 @@ def test_upload_client_bad_request(client, db, uploaderuser, settings):
         error_msg = (
             "Unrecognized file pattern. Should only be "
             "<module>/<hex>/<file> or <name>-symbols.txt and nothing else. "
-            "(First unrecognized pattern was xpcshell.sym)"
+            "(First unrecognized pattern was 'xpcshell.sym')"
         )
         assert response.json()["error"] == error_msg
 
@@ -647,7 +647,9 @@ def test_upload_client_bad_request(client, db, uploaderuser, settings):
         response = client.post(url, {"file.zip": f}, HTTP_AUTH_TOKEN=token.key)
         assert response.status_code == 400
         error_msg = (
-            "Invalid character in filename 'xpcfoo.dbg/A7D6F1BB18CD4CB48/p%eter.sym'"
+            "Unrecognized file pattern. Should only be "
+            "<module>/<hex>/<file> or <name>-symbols.txt and nothing else. "
+            "(First unrecognized pattern was 'xpcfoo.dbg/A7D6F1BB18CD4CB48/p%eter.sym')"
         )
         assert response.json()["error"] == error_msg
 

--- a/tecken/tests/utils.py
+++ b/tecken/tests/utils.py
@@ -38,7 +38,7 @@ class Upload:
 
     @property
     def key(self) -> str:
-        return SymbolStorage.make_key(self.debug_file, self.debug_id, self.sym_file)
+        return f"{self.debug_file}/{self.debug_id}/{self.sym_file}"
 
     @classmethod
     def uncompressed(cls, sym_file: str) -> "Upload":
@@ -47,7 +47,7 @@ class Upload:
         metadata = ObjectMetadata(content_length=len(data["body"]))
         return cls(
             debug_file=data.get("debug_filename", ""),
-            debug_id=data.get("debug_id", ""),
+            debug_id=data.get("debug_id", "").upper(),
             sym_file=sym_file,
             body=data["body"],
             metadata=metadata,
@@ -66,7 +66,7 @@ class Upload:
         )
         return cls(
             debug_file=data.get("debug_filename", ""),
-            debug_id=data.get("debug_id", ""),
+            debug_id=data.get("debug_id", "").upper(),
             sym_file=sym_file,
             body=compressed_body,
             metadata=metadata,

--- a/tecken/upload/utils.py
+++ b/tecken/upload/utils.py
@@ -82,7 +82,7 @@ def dump_and_extract(root_dir, file_buffer, name):
 class FileMember:
     __slots__ = ["path", "name"]
 
-    def __init__(self, path, name):
+    def __init__(self, path: str, name: str):
         self.path = path
         self.name = name
 

--- a/tecken/upload/views.py
+++ b/tecken/upload/views.py
@@ -24,11 +24,12 @@ from tecken.base.decorators import (
     api_require_POST,
 )
 from tecken.base.symbolstorage import symbol_storage
-from tecken.base.utils import filesizeformat, invalid_key_name_characters
+from tecken.base.utils import filesizeformat, validate_key
 from tecken.upload import client_otel, executor
 from tecken.upload.forms import UploadByDownloadForm, UploadByDownloadRemoteError
 from tecken.upload.models import FileUpload, Upload
 from tecken.upload.utils import (
+    FileMember,
     dump_and_extract,
     UnrecognizedArchiveFileExtension,
     DuplicateFileDifferentSize,
@@ -47,46 +48,38 @@ _not_hex_characters = re.compile(r"[^a-f0-9]", re.I)
 # over the extracted zip.
 # The names of files in this list are considered harmless and something that
 # can simply be ignored.
-_ignorable_filenames = (".DS_Store",)
+_ignorable_filenames = [".DS_Store"]
 
 
-def check_symbols_archive_file_listing(file_listings):
+def check_symbols_archive_file_listing(file_listings: list[FileMember]) -> str | None:
     """return a string (the error) if there was something not as expected"""
     for file_listing in file_listings:
+        key = file_listing.name
+        # TODO(smarnach): This looks wrong to me. The documentation of
+        # `DISALLOWED_SYMBOLS_SNIPPETS` appears to imply this should be looked up in
+        # the contents of symbols files rather than in their names. I don't have any
+        # context on this, though.
         for snippet in settings.DISALLOWED_SYMBOLS_SNIPPETS:
-            if snippet in file_listing.name:
+            if snippet in key:
                 return (
                     f"Content of archive file contains the snippet "
                     f"'{snippet}' which is not allowed"
                 )
         # Now check that the filename is matching according to these rules:
-        # 1. Either /<name1>/hex/<name2>,
-        # 2. Or, /<name>-symbols.txt
+        # 1. Either <name1>/hex/<name2>,
+        # 2. Or, <name>-symbols.txt
         # Anything else should be considered and unrecognized file pattern
         # and thus rejected.
-        split = file_listing.name.split("/")
-        if split[-1] in _ignorable_filenames:
+        if "/" not in key and key.lower().endswith("-symbols.txt"):
             continue
-        if len(split) == 3:
-            # Check the symbol and the filename part of it to make sure
-            # it doesn't contain any, considered, invalid S3 characters
-            # when it'd become a key.
-            if invalid_key_name_characters(split[0] + split[2]):
-                return f"Invalid character in filename {file_listing.name!r}"
-            # Check that the middle part is only hex characters.
-            if not _not_hex_characters.findall(split[1]):
-                continue
-        elif len(split) == 1:
-            if file_listing.name.lower().endswith("-symbols.txt"):
-                continue
-
-        # If it didn't get "continued" above, it's an unrecognized file
-        # pattern.
-        return (
-            "Unrecognized file pattern. Should only be <module>/<hex>/<file> "
-            "or <name>-symbols.txt and nothing else. "
-            f"(First unrecognized pattern was {file_listing.name})"
-        )
+        if key.rpartition("/")[2] in _ignorable_filenames:
+            continue
+        if not validate_key(key):
+            return (
+                "Unrecognized file pattern. Should only be <module>/<hex>/<file> "
+                "or <name>-symbols.txt and nothing else. "
+                f"(First unrecognized pattern was {key!r})"
+            )
 
 
 def _ignore_member_file(filename):

--- a/tecken/upload/views.py
+++ b/tecken/upload/views.py
@@ -59,6 +59,7 @@ def check_symbols_archive_file_listing(file_listings: list[FileMember]) -> str |
         # `DISALLOWED_SYMBOLS_SNIPPETS` appears to imply this should be looked up in
         # the contents of symbols files rather than in their names. I don't have any
         # context on this, though.
+        # (See https://bugzilla.mozilla.org/show_bug.cgi?id=2048257)
         for snippet in settings.DISALLOWED_SYMBOLS_SNIPPETS:
             if snippet in key:
                 return (

--- a/tecken/urls.py
+++ b/tecken/urls.py
@@ -6,6 +6,7 @@ from django.urls import register_converter, path, include
 
 from tecken.base import admin_site
 from tecken import views
+from tecken.base.utils import VALID_HEX_CHARS
 
 # These handlers are for dealing with exceptions raised from within
 # Django. Most other 4xx errors happen explicitly in the view functions.
@@ -29,10 +30,10 @@ register_converter(FrontendRoutesPrefixConverter, "frontendroutes")
 
 
 class MixedCaseHexConverter:
-    regex = "[0-9A-Fa-f]+"
+    regex = VALID_HEX_CHARS
 
     def to_python(self, value):
-        return value
+        return value.upper()
 
     def to_url(self, value):
         return value


### PR DESCRIPTION
This cleans up some of the code handling storage keys.

* For downloads, keys are validated directly by Django's router, so we no longer need to validate the key in the view code.
* We use the same regular expression for the Django converters as we do for validating keys in uploaded ZIP archives.
* Keys are represented as a single string as much as possible, rather than storing the three parts separately.
* The variable naming for the three parts is made more consistent (though there are still some weird names left in the test code).

This could probably be cleaned up further, but I think this is already an incremental improvements, and it cleans up the parts I need for implementing the new upload API.